### PR TITLE
Replaced all java common logging with slf4j

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -135,6 +135,11 @@
             <version>${slf4j.version}</version>
         </dependency>
         <dependency>
+            <groupId>org.slf4j</groupId>
+            <artifactId>slf4j-jdk14</artifactId>
+            <version>${slf4j.version}</version>
+        </dependency>
+        <dependency>
             <groupId>org.springframework</groupId>
             <artifactId>spring-context</artifactId>
             <version>5.3.5</version>
@@ -179,7 +184,7 @@
             <artifactId>opencsv</artifactId>
             <version>5.4</version>
         </dependency>
-	<dependency>
+	    <dependency>
             <groupId>com.sendgrid</groupId>
             <artifactId>sendgrid-java</artifactId>
             <version>4.7.2</version>

--- a/src/main/java/edu/suffolk/litlab/efspserver/LegalIssuesTaxonomyCodes.java
+++ b/src/main/java/edu/suffolk/litlab/efspserver/LegalIssuesTaxonomyCodes.java
@@ -13,10 +13,11 @@ import java.util.HashSet;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
-import java.util.logging.Logger;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 public class LegalIssuesTaxonomyCodes {
-  private static Logger log = Logger.getLogger("edu.suffolk.litlab.efspserver.Person"); 
+  private static Logger log = LoggerFactory.getLogger(LegalIssuesTaxonomyCodes.class); 
 
   /** Reads a special version of the csv at originally from https://taxonomy.legal/download. 
    * A column is added before "Taxonomies" that maps top level codes to ECF case types:

--- a/src/main/java/edu/suffolk/litlab/efspserver/XsdDownloader.java
+++ b/src/main/java/edu/suffolk/litlab/efspserver/XsdDownloader.java
@@ -33,7 +33,7 @@ import org.xml.sax.SAXException;
  * URL to it.
  * <a href="https://github.com/pablod/xsd-downloader">Github here</a>
  *
- * @author c 
+ * @author https://github.com/pablod
  */
 public class XsdDownloader {
 

--- a/src/main/java/edu/suffolk/litlab/efspserver/docassemble/DocassembleToFilingEntityConverter.java
+++ b/src/main/java/edu/suffolk/litlab/efspserver/docassemble/DocassembleToFilingEntityConverter.java
@@ -15,11 +15,12 @@ import edu.suffolk.litlab.efspserver.services.InterviewToFilingEntityConverter;
 import edu.suffolk.litlab.efspserver.services.JsonExtractException;
 import java.io.IOException;
 import java.io.InputStream;
-import java.util.logging.Logger;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 public class DocassembleToFilingEntityConverter implements InterviewToFilingEntityConverter {
 
-  private static Logger log = Logger.getLogger("mylogger"); 
+  private static Logger log = LoggerFactory.getLogger(DocassembleToFilingEntityConverter.class); 
   private LegalIssuesTaxonomyCodes codes;
   
   public DocassembleToFilingEntityConverter(InputStream taxonomyCsv) 
@@ -45,10 +46,10 @@ public class DocassembleToFilingEntityConverter implements InterviewToFilingEnti
       }
       return Result.ok(entities);  
     } catch (JsonExtractException ex) {
-      log.warning("Got extract Exception: " + ex);
+      log.warn("Got extract Exception: " + ex);
       return Result.err(ex.getError());
     } catch (JsonProcessingException ex) {
-      log.warning("Parsing Exception: " + ex);
+      log.warn("Parsing Exception: " + ex);
       return Result.err(new ExtractError(ExtractError.Type.MalformedInterview));
     }
   }

--- a/src/main/java/edu/suffolk/litlab/efspserver/docassemble/FilingInformationDocassembleJacksonDeserializer.java
+++ b/src/main/java/edu/suffolk/litlab/efspserver/docassemble/FilingInformationDocassembleJacksonDeserializer.java
@@ -19,12 +19,13 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
 import java.util.Set;
-import java.util.logging.Logger;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import java.util.stream.Collectors;
 
 public class FilingInformationDocassembleJacksonDeserializer 
     extends StdDeserializer<FilingInformation> {
-  private static Logger log = Logger.getLogger("mylogger"); 
+  private static Logger log = LoggerFactory.getLogger("mylogger"); 
 
   private static final long serialVersionUID = 1L;
 
@@ -51,7 +52,7 @@ public class FilingInformationDocassembleJacksonDeserializer
         Person per = PersonDocassembleJacksonDeserializer.fromNode(peopleElements.get(i), p);
         people.add(per);
       } catch (JsonProcessingException ex) {
-        log.warning("Person exception: " + ex);
+        log.warn("Person exception: " + ex);
       }
     }
     return Result.ok(people);
@@ -85,20 +86,20 @@ public class FilingInformationDocassembleJacksonDeserializer
           new ExtractError(ExtractError.Type.MissingRequired, "users[0]", "users[0].email"));
     }
       
-    log.fine("Got users");
+    log.debug("Got users");
     Result<List<Person>, ExtractError> maybeOthers = collectPeople(node, "other_parties", p);
     if (maybeOthers.isErr()) {
       throw new JsonExtractException(p, maybeOthers.unwrapErrOrElseThrow());
     }
     final List<Person> otherParties = maybeOthers.unwrapOrElseThrow(); 
-    log.fine("Got other parties");
+    log.debug("Got other parties");
       
     Optional<Boolean> userStartedCase = Optional.empty(); 
     if (node.has("user_started_case") 
         && node.get("user_started_case").isBoolean()) {
       userStartedCase = Optional.of(node.get("user_started_case").asBoolean());
     }
-    log.fine("user_started_case: " + userStartedCase.orElse(null));
+    log.debug("user_started_case: " + userStartedCase.orElse(null));
 
     FilingInformation entities = new FilingInformation();
     if (userStartedCase.isEmpty()) {

--- a/src/main/java/edu/suffolk/litlab/efspserver/services/EfmCallback.java
+++ b/src/main/java/edu/suffolk/litlab/efspserver/services/EfmCallback.java
@@ -2,7 +2,8 @@ package edu.suffolk.litlab.efspserver.services;
 
 import edu.suffolk.litlab.efspserver.SendMessage;
 
-import java.util.logging.Logger;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import javax.ws.rs.Path;
 import javax.ws.rs.Produces;
@@ -18,7 +19,7 @@ import javax.ws.rs.core.MediaType;
 @Produces({MediaType.APPLICATION_XML, MediaType.APPLICATION_JSON})
 public class EfmCallback {
   private static Logger log = 
-      Logger.getLogger("edu.suffolk.litlab.efspserver.services.EfmCallback"); 
+      LoggerFactory.getLogger(EfmCallback.class); 
 
   // @POST("/court/{court_id}/{filing_id}/status")
   /*

--- a/src/main/java/edu/suffolk/litlab/efspserver/services/FilingReviewService.java
+++ b/src/main/java/edu/suffolk/litlab/efspserver/services/FilingReviewService.java
@@ -12,7 +12,6 @@ import java.sql.SQLException;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
-import java.util.logging.Logger;
 import javax.ws.rs.DELETE;
 import javax.ws.rs.GET;
 import javax.ws.rs.POST;
@@ -34,6 +33,8 @@ import oasis.names.tc.legalxml_courtfiling.schema.xsd.filingstatusquerymessage_4
 import oasis.names.tc.legalxml_courtfiling.schema.xsd.filingstatusresponsemessage_4.FilingStatusResponseMessageType;
 import oasis.names.tc.legalxml_courtfiling.wsdl.webservicesprofile_definitions_4_0.FilingReviewMDEPort;
 import org.apache.cxf.headers.Header;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import tyler.ecf.extensions.cancelfilingmessage.CancelFilingMessageType;
 import tyler.ecf.extensions.cancelfilingresponsemessage.CancelFilingResponseMessageType;
 import tyler.ecf.extensions.filingdetailquerymessage.FilingDetailQueryMessageType;
@@ -46,7 +47,7 @@ import tyler.efm.wsdl.webservicesprofile_implementation_4_0.FilingReviewMDEServi
 public class FilingReviewService {
 
   private static Logger log = 
-      Logger.getLogger("edu.suffolk.litlab.efspserver.services.FilingReviewService"); 
+      LoggerFactory.getLogger(FilingReviewService.class); 
 
   private FilingReviewMDEService filingFactory;
   private CodeDatabase cd;
@@ -153,7 +154,7 @@ public class FilingReviewService {
       m.getDateRange().add(null);
       FilingListResponseMessageType resp = port.get().getFilingList(m);
       for (MatchingFilingType match : resp.getMatchingFiling()) {
-        log.fine("Matched: " + match.getCaseTrackingID() + ", " + match);
+        log.trace("Matched: " + match.getCaseTrackingID() + ", " + match);
       }
       return ServiceHelpers.mapTylerCodesToHttp(resp.getError(),
           () -> {
@@ -172,9 +173,9 @@ public class FilingReviewService {
   public Response submitFilingForReview(@Context HttpHeaders httpHeaders, 
       @PathParam("court_id") String courtId, String allVars) {
     MediaType mediaType = httpHeaders.getMediaType();
-    log.fine("New FilingDoc: Media type: " + mediaType);
-    log.fine("Court id: " + courtId);
-    log.fine("All vars: " + allVars.substring(0, Integer.min(100, allVars.length() - 1)));
+    log.trace("New FilingDoc: Media type: " + mediaType);
+    log.trace("Court id: " + courtId);
+    log.trace("All vars: " + allVars.substring(0, Integer.min(100, allVars.length() - 1)));
     if (!filingInterfaces.containsKey(courtId)) {
       return Response.status(404).entity("Cannot send filing to " + courtId).build();
     }

--- a/src/main/java/tyler/efm/services/EfmFirmService.java
+++ b/src/main/java/tyler/efm/services/EfmFirmService.java
@@ -26,8 +26,8 @@ public class EfmFirmService extends Service {
     static {
         URL url = EfmFirmService.class.getClassLoader().getResource("wsdl/EFMFirmServiceSingle.svc.wsdl");
         if (url == null) {
-            java.util.logging.Logger.getLogger(EfmFirmService.class.getName())
-                .log(java.util.logging.Level.INFO,
+            org.slf4j.LoggerFactory.getLogger(EfmFirmService.class.getName())
+                .info(
                      "Can not initialize the default wsdl from {0}", "classpath:wsdl/EFMFirmServiceSingle.svc.wsdl");
         }
         WSDL_LOCATION = url;

--- a/src/main/java/tyler/efm/services/EfmUserService.java
+++ b/src/main/java/tyler/efm/services/EfmUserService.java
@@ -26,8 +26,8 @@ public class EfmUserService extends Service {
     static {
         URL url = EfmUserService.class.getClassLoader().getResource("wsdl/EFMUserServiceSingle.svc.wsdl");
         if (url == null) {
-            java.util.logging.Logger.getLogger(EfmUserService.class.getName())
-                .log(java.util.logging.Level.INFO,
+            org.slf4j.LoggerFactory.getLogger(EfmUserService.class.getName())
+                .info(
                      "Can not initialize the default wsdl from {0}", "classpath:wsdl/EFMUserServiceSingle.svc.wsdl");
         }
         WSDL_LOCATION = url;


### PR DESCRIPTION
Finally did some reading on how to do Java logging well*, I changed most of the interfaces to SLF4J (simple logging facade 4 java, names are horrible), which is just a standard interface on top of many different logging backends.

We still use Java common logging (JCL) under the hood, so nothing's changed there yet. But we have the flexibility to when we want to, say, if we need to start running multiple proxys and a load balancer to them, some distributed logging system would work much better in that case. But for now, this is good. 

Sorry @nonprofittechy, this might give you some merge conflicts if you've started doing stuff. It should be simple to fix though.

* I liked https://sematext.com/blog/java-logging/ a lot