### PR TITLE
HTTPS Implementation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,11 @@ target/
 # HTTPS key-cert related stuff
 *.key
 *.jks
+*.crt
+*.pem
+*.csr
+*.p12
+*.ca-bundle
 
 # Log file
 *.log

--- a/docs/https.md
+++ b/docs/https.md
@@ -1,0 +1,83 @@
+# HTTPS / TLS
+
+You probably want your server to use HTTPS, so not everyone one the same wifi 
+can read your passwords in plaintext on the network.
+
+For a simple explainer, see [Julia Evan's Twitter comic about it](https://twitter.com/b0rk/status/809594614147645440/photo/1).
+
+## Getting a Certificate
+
+The first of two steps to using HTTPS is actually getting a signed TLS certificate from a certificate signer.
+
+### From a Certificate Authority
+
+(TODO(brycew): document this for the future).
+
+### Using Let's Encrypt and ACME
+
+You can also do this with Let's Encrypt, but unfortunately since we're running on a custom server
+software (not nginx or Apache), then it would take a bit more effort to integrate it.
+TODO(brycew): eventually we should. Look into the below for resources 
+
+* [Lets Encrypt Java Clients](https://letsencrypt.org/docs/client-options/#clients-java)
+* [Porunov Java ACME Client](https://github.com/porunov/acme_client) (ACME is the protocol that Let's Encrypt uses)
+* [Shred acme4j](https://github.com/shred/acme4j)
+
+## Using that Certificate in the CXF Server
+
+First, turning the certificate into something that Java can consume, namely, a Java Key Store (jks). 
+
+The commands below are how we did it
+```bash
+# You already have a
+# * efile_suffolklitlab_org.ca-bundle
+# * efile_suffolklitlab_org.crt 
+# * efile.suffolklitlab.org.key
+# * efile.suffolklitlab.org.p12
+   
+java utils.ImportPrivateKey keystore storepass storetype keypass alias certfile keyfile keyfilepass 
+openssl pkcs12 -export -in efile_suffolklitlab_org.crt -inkey efile.suffolklitlab.org.key  -out efile.suffolklitlab.org.p12
+keytool -importkeystore -srckeystore efile.suffolklitlab.org.p12 -srcstoretype PKCS12 -destkeystore efile.suffolklitlab.org.jks -deststoretype JKS
+
+keytool -printcert -v -file efile.suffolklitlab.org.jks 
+keytool -list -v -file efile.suffolklitlab.org.jks 
+keytool -list -v -keystore efile.suffolklitlab.org.jks 
+keytool -exportcert -rfc -alias mykey -keystore efile.suffolklitlab.org.jks > cert.pem
+openssl verify cert.pem
+keytool -exportcert -rfc -keystore efile.suffolklitlab.org.jks > cert.pem
+keytool -exportcert -rfc -keystore efile.suffolklitlab.org.jks
+keytool -list -v -keystore efile.suffolklitlab.org.jks | grep Alias
+keytool -exportcert -rfc -Alias 1 -keystore efile.suffolklitlab.org.jks > cert.pem
+openssl verify cert.pem
+openssl verify efile_suffolklitlab_org.ca-bundle 
+vim sectigo.intermediate.crt
+cat efile_suffolklitlab_org.ca-bundle efile_suffolklitlab_org.crt > efile_suffolklitlab_org_combined.crt
+openssl pkcs12 -export -in efile_suffolklitlab_org_combined.crt -inkey efile.suffolklitlab.org.key -out efile.suffolklitlab.org.combined.p12
+keytool -importkeystore -srckeystore efile.suffolklitlab.org.combined.p12 -srcstoretype PKCS12 -destkeystore efile.suffolklitlab.org.combined.jks -deststoretype JKS
+keytool -exportcert -rfc -alias 1 -keystore efile.suffolklitlab.org.combined.jks > cert.pem
+openssl verify cert.pem 
+openssl verify -CAfile sectigo.root.crt -untrusted sectigo.intermediate.crt cert.pem 
+keytool -list -v -keystore efile.suffolklitlab.org.combined.jks
+keytool -list -v -keystore efile.suffolklitlab.org.combined.jks | grep Alias
+cp efile.suffolklitlab.org.combined.jks EFileProxyServer/src/main/config/
+```
+
+Next you have to set up the CXF server properly to use it.
+
+The following pages have useful information, but are kinda sparse:
+
+* https://cxf.apache.org/docs/secure-jax-rs-services.html
+* http://cxf.apache.org/docs/client-http-transport-including-ssl-support.html
+* https://cwiki.apache.org/confluence/display/CXF20DOC/TLS+Configuration
+* https://cxf.apache.org/docs/standalone-http-transport.html
+* http://svn.apache.org/repos/asf/cxf/trunk/distribution/src/main/release/samples/jax_rs/basic_https/
+
+Some important info:
+
+The SpringBusFactory and Bus from the ServerConfig.xml need to be created in a static block in the Server class,
+and you need to set the CertPassword to the CallbackHandler before you create the factory.
+
+You also need to set the address to be `https://`, not `http://`.
+
+The ServerConfig.xml shouldn't use the `clientAuthentication` elem, as it expects clients connecting to also have a
+TLS cert.

--- a/docs/https.md
+++ b/docs/https.md
@@ -27,6 +27,10 @@ TODO(brycew): eventually we should. Look into the below for resources
 
 First, turning the certificate into something that Java can consume, namely, a Java Key Store (jks). 
 
+* https://stackoverflow.com/questions/41416050/installing-an-intermediate-chain-certificate-using-java-key-tool
+* https://www.tbs-certificates.co.uk/FAQ/en/ajouter-certificat-intermediaire-keystore-java.html
+* https://community.datarobot.com/t5/data-prep/how-to-convert-crt-and-key-to-jks-file/td-p/6342
+
 The commands below are how we did it
 ```bash
 # You already have a

--- a/src/main/config/ServerConfig.xml
+++ b/src/main/config/ServerConfig.xml
@@ -1,0 +1,39 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  Licensed to the Apache Software Foundation (ASF) under one
+  or more contributor license agreements. See the NOTICE file
+  distributed with this work for additional information
+  regarding copyright ownership. The ASF licenses this file
+  to you under the Apache License, Version 2.0 (the
+  "License"); you may not use this file except in compliance
+  with the License. You may obtain a copy of the License at
+  
+  http://www.apache.org/licenses/LICENSE-2.0
+  
+  Unless required by applicable law or agreed to in writing,
+  software distributed under the License is distributed on an
+  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+  KIND, either express or implied. See the License for the
+  specific language governing permissions and limitations
+  under the License.
+-->
+<!-- 
+  ** This file configures the Server which exposes the REST endpoint.
+-->
+<beans xmlns="http://www.springframework.org/schema/beans"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xmlns:sec="http://cxf.apache.org/configuration/security"
+    xmlns:http="http://cxf.apache.org/transports/http/configuration"
+    xmlns:httpj="http://cxf.apache.org/transports/http-jetty/configuration"
+    xsi:schemaLocation="http://cxf.apache.org/configuration/security http://cxf.apache.org/schemas/configuration/security.xsd http://cxf.apache.org/transports/http/configuration http://cxf.apache.org/schemas/configuration/http-conf.xsd http://cxf.apache.org/transports/http-jetty/configuration http://cxf.apache.org/schemas/configuration/http-jetty.xsd http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd">
+    <httpj:engine-factory bus="cxf">
+        <httpj:engine port="9000">
+            <httpj:tlsServerParameters>
+                <sec:keyManagers keyPasswordCallbackHandler="edu.suffolk.litlab.efspserver.HttpsCallbackHandler">
+			<sec:keyStore file="src/main/config/efile.suffolklitlab.org.combined.jks" type="JKS"/>
+                </sec:keyManagers>
+	        <sec:certAlias>1</sec:certAlias>
+            </httpj:tlsServerParameters>
+        </httpj:engine>
+    </httpj:engine-factory>
+</beans>

--- a/src/main/java/edu/suffolk/litlab/efspserver/HttpsCallbackHandler.java
+++ b/src/main/java/edu/suffolk/litlab/efspserver/HttpsCallbackHandler.java
@@ -10,18 +10,18 @@ import javax.security.auth.callback.UnsupportedCallbackException;
 public class HttpsCallbackHandler implements CallbackHandler {
   
   private static String certPassword;
-
+  
   public static void setCertPassword(String newPassword) {
-	 System.out.println("Setting cert password to " + newPassword);
     certPassword = newPassword;
-  }
+  }  
 
   @Override
   public void handle(Callback[] callbacks) throws IOException, UnsupportedCallbackException {
-	  System.out.println("Passing the cert password through to the handler");
     for (int i = 0; i < callbacks.length; i++) {
-      PasswordCallback pc = (PasswordCallback)callbacks[i];
-      pc.setPassword(certPassword.toCharArray()); 
+      if (callbacks[i] instanceof PasswordCallback) {
+        PasswordCallback pc = (PasswordCallback)callbacks[i];
+        pc.setPassword(certPassword.toCharArray()); 
+      }
     }
   }
 

--- a/src/main/java/edu/suffolk/litlab/efspserver/HttpsCallbackHandler.java
+++ b/src/main/java/edu/suffolk/litlab/efspserver/HttpsCallbackHandler.java
@@ -12,11 +12,13 @@ public class HttpsCallbackHandler implements CallbackHandler {
   private static String certPassword;
 
   public static void setCertPassword(String newPassword) {
+	 System.out.println("Setting cert password to " + newPassword);
     certPassword = newPassword;
   }
 
   @Override
   public void handle(Callback[] callbacks) throws IOException, UnsupportedCallbackException {
+	  System.out.println("Passing the cert password through to the handler");
     for (int i = 0; i < callbacks.length; i++) {
       PasswordCallback pc = (PasswordCallback)callbacks[i];
       pc.setPassword(certPassword.toCharArray()); 

--- a/src/main/java/edu/suffolk/litlab/efspserver/services/EfspServer.java
+++ b/src/main/java/edu/suffolk/litlab/efspserver/services/EfspServer.java
@@ -39,13 +39,15 @@ public class EfspServer {
   private Server server;
 
   static {
-    HttpsCallbackHandler.setCertPassword(System.getenv("CERT_PASSWORD"));
-         log.info("Working dir: " + System.getProperty("user.dir"));
-	  SpringBusFactory factory = new SpringBusFactory();
-	  Bus bus = factory.createBus("src/main/config/ServerConfig.xml");
-	  SpringBusFactory.setDefaultBus(bus);
+    Optional<String> certPassword = GetEnv("CERT_PASSWORD");
+    certPassword.ifPresentOrElse(
+        pass -> HttpsCallbackHandler.setCertPassword(pass),
+        () -> log.error("Didn't enter a CERT_PASSWORD: Did you pass an .env file?"));
+    SpringBusFactory factory = new SpringBusFactory();
+    Bus bus = factory.createBus("src/main/config/ServerConfig.xml");
+    SpringBusFactory.setDefaultBus(bus);
   }
-  
+
   protected EfspServer(String x509Password, 
       String dbUrl, int dbPort,
       String dbUser, String dbPassword,

--- a/src/main/java/edu/suffolk/litlab/efspserver/services/EfspServer.java
+++ b/src/main/java/edu/suffolk/litlab/efspserver/services/EfspServer.java
@@ -2,6 +2,7 @@ package edu.suffolk.litlab.efspserver.services;
 
 import com.fasterxml.jackson.jaxrs.json.JacksonJsonProvider;
 import edu.suffolk.litlab.efspserver.SoapX509CallbackHandler;
+import edu.suffolk.litlab.efspserver.HttpsCallbackHandler; 
 import edu.suffolk.litlab.efspserver.CodeUpdater;
 import edu.suffolk.litlab.efspserver.LoginDatabase;
 import edu.suffolk.litlab.efspserver.SecurityHub;
@@ -36,6 +37,14 @@ public class EfspServer {
   
   private JAXRSServerFactoryBean sf;
   private Server server;
+
+  static {
+    HttpsCallbackHandler.setCertPassword(System.getenv("CERT_PASSWORD"));
+         log.info("Working dir: " + System.getProperty("user.dir"));
+	  SpringBusFactory factory = new SpringBusFactory();
+	  Bus bus = factory.createBus("src/main/config/ServerConfig.xml");
+	  SpringBusFactory.setDefaultBus(bus);
+  }
   
   protected EfspServer(String x509Password, 
       String dbUrl, int dbPort,
@@ -69,19 +78,12 @@ public class EfspServer {
       CodeUpdater.executeCommand("downloadAll", "https://illinois-stage.tylerhost.net", cd);
     }
     
-    String baseLocalUrl = "http://0.0.0.0:9000";
+    String baseLocalUrl = "https://0.0.0.0:9000";
     cd.setAutocommit(true);
     ud.setAutocommit(true);
     ld.setAutocommit(true);
     SecurityHub security = new SecurityHub(ld);
     sf = new JAXRSServerFactoryBean();
-    // TODO(brycew): can't get it working, password seems wrong: pausing for now
-    /*
-    log.info("Working dir: " + System.getProperty("user.dir"));
-    SpringBusFactory busFac = new SpringBusFactory();
-    Bus bus = busFac.createBus("src/main/config/ServerConfig.xml");
-    sf.setBus(bus);
-    */
     sf.setResourceClasses(AdminUserService.class,
         FilingReviewService.class,
         FirmAttorneyAndServiceService.class);
@@ -175,7 +177,7 @@ public class EfspServer {
 
     Object implementor = new OasisEcfWsCallback(ud, sender);
     // TODO(brycew): cleaner way to handle baseLocalUrl?
-    String baseLocalUrl = "http://0.0.0.0:9000";
+    String baseLocalUrl = "https://0.0.0.0:9000";
     String address = baseLocalUrl + ServiceHelpers.ASSEMBLY_PORT; 
     Endpoint.publish(address, implementor);
     


### PR DESCRIPTION
Server is now running in HTTPS!

I was debating trying to support both HTTP and HTTPS, but that might be a bit difficult, so I'm probably going to follow https://letsencrypt.org/docs/certificates-for-localhost/ and use that cert for localhost development (or modifying it to work with docker... not sure).

@nonprofittechy, the only resource I couldn't find to document was how you got the cert for the CA that signed ours. Would you mind just dropping that somewhere?