### PR TITLE
DataField codes, and Throwing more exceptions instead of returning Results

### DIFF
--- a/src/main/java/edu/suffolk/litlab/efspserver/codes/DataFieldRow.java
+++ b/src/main/java/edu/suffolk/litlab/efspserver/codes/DataFieldRow.java
@@ -1,5 +1,8 @@
 package edu.suffolk.litlab.efspserver.codes;
 
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
 public class DataFieldRow {
   public String code;
   public String name;
@@ -9,7 +12,7 @@ public class DataFieldRow {
   public String ghosttext;
   public String contextualhelpdata;
   public String validationmessage;
-  public String regularexpression;
+  public Pattern regularexpression;
   public String defaultvalueexpression;
   public String isreadonly;
   public String location;
@@ -27,7 +30,11 @@ public class DataFieldRow {
     this.ghosttext = ghosttext;
     this.contextualhelpdata = contextualhelpdata;
     this.validationmessage = validationmessage;
-    this.regularexpression = regularexpression;
+    if (regularexpression == null || regularexpression.isEmpty()) {
+      this.regularexpression = null; 
+    } else {
+      this.regularexpression = Pattern.compile(regularexpression);
+    }
     this.defaultvalueexpression = defaultvalueexpression;
     this.isreadonly = isreadonly;
     this.location = location;
@@ -40,6 +47,14 @@ public class DataFieldRow {
    */
   public static DataFieldRow MissingDataField(String name) {
     return new DataFieldRow("", name, "false", "false", "", "", "", "", "", "", "", "");
+  }
+  
+  public boolean matchRegex(String value) {
+    if (this.regularexpression == null) {
+      return true;
+    }
+    Matcher matcher = this.regularexpression.matcher(value);
+    return matcher.find();
   }
 
 }

--- a/src/main/java/edu/suffolk/litlab/efspserver/docassemble/DocassembleToFilingEntityConverter.java
+++ b/src/main/java/edu/suffolk/litlab/efspserver/docassemble/DocassembleToFilingEntityConverter.java
@@ -5,10 +5,8 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.module.SimpleModule;
 import com.hubspot.algebra.Result;
 import com.opencsv.exceptions.CsvValidationException;
-import edu.suffolk.litlab.efspserver.Address;
 import edu.suffolk.litlab.efspserver.FilingInformation;
 import edu.suffolk.litlab.efspserver.LegalIssuesTaxonomyCodes;
-import edu.suffolk.litlab.efspserver.Person;
 import edu.suffolk.litlab.efspserver.services.FilingError;
 import edu.suffolk.litlab.efspserver.services.InfoCollector;
 import edu.suffolk.litlab.efspserver.services.InterviewToFilingEntityConverter;
@@ -32,10 +30,6 @@ public class DocassembleToFilingEntityConverter extends InterviewToFilingEntityC
   public Result<FilingInformation, FilingError> traverseInterview(String interviewContents,
       InfoCollector collector) {
     SimpleModule module = new SimpleModule();
-    //module.addDeserializer(FilingDoc.class, 
-    //    new FilingDocDocassembleJacksonDeserializer()); 
-    module.addDeserializer(Address.class, new AddressDocassembleJacksonDeserializer(Address.class));
-    module.addDeserializer(Person.class, new PersonDocassembleJacksonDeserializer(Person.class));
     module.addDeserializer(FilingInformation.class, 
         new FilingInformationDocassembleJacksonDeserializer(FilingInformation.class, codes, collector));
     ObjectMapper mapper = new ObjectMapper();

--- a/src/main/java/edu/suffolk/litlab/efspserver/docassemble/NameDocassembleDeserializer.java
+++ b/src/main/java/edu/suffolk/litlab/efspserver/docassemble/NameDocassembleDeserializer.java
@@ -3,7 +3,6 @@ package edu.suffolk.litlab.efspserver.docassemble;
 import java.util.Optional;
 
 import com.fasterxml.jackson.databind.JsonNode;
-import com.hubspot.algebra.Result;
 
 import edu.suffolk.litlab.efspserver.Name;
 import edu.suffolk.litlab.efspserver.services.FilingError;
@@ -21,29 +20,21 @@ public class NameDocassembleDeserializer {
   }
 
 
-  public static Result<Name, FilingError> fromNode(JsonNode node, InfoCollector collector) {
+  public static Name fromNode(JsonNode node, InfoCollector collector) throws FilingError {
     if (node == null) {
       InterviewVariable var = collector.requestVar(
           "name", "The full name of the person", "IndividualName");
       collector.addRequired(var);
-      if (collector.finished()) {
-        FilingError err = FilingError.missingRequired(var);
-        return Result.err(err);
-      }
     }
     if (!node.isObject()) {
       FilingError err = FilingError.malformedInterview(
           "Can't parse person with name that's not a JSON object: " + node.get("name").toPrettyString());
-      return Result.err(err);
+      throw err;
     }
     if (!node.has("first")) {
       InterviewVariable var = collector.requestVar("name.first", 
           "The first name of a person / name of a business", "text");
       collector.addRequired(var);
-      if (collector.finished()) {
-        FilingError err = FilingError.missingRequired(var);
-        return Result.err(err);
-      }
     }
 
     Name name = new Name(
@@ -55,6 +46,6 @@ public class NameDocassembleDeserializer {
           "" // TODO(brycew): where would Maiden name go, if asked for?
     );
     
-    return Result.ok(name);
+    return name;
   }
 }

--- a/src/main/java/edu/suffolk/litlab/efspserver/ecf/EcfCaseTypeFactory.java
+++ b/src/main/java/edu/suffolk/litlab/efspserver/ecf/EcfCaseTypeFactory.java
@@ -59,6 +59,7 @@ public class EcfCaseTypeFactory {
    * @param filingIds The UIDs of all of the filings
    * @param paymentId The UID of the tyler payment account, from GetPaymentAccountList
    * @return
+   * @throws FilingError 
    */
   public Result<JAXBElement<? extends gov.niem.niem.niem_core._2.CaseType>, FilingError> 
       makeCaseTypeFromTylerCategory(
@@ -78,32 +79,29 @@ public class EcfCaseTypeFactory {
       JsonNode miscInfo, // TODO(brycew): if we get XML Answer files, this isn't generic
       EcfCourtSpecificSerializer serializer,
       InfoCollector collector
-  ) throws SQLException {
+  ) throws SQLException, FilingError {
     CaseCategory caseCategory = initialCaseCategory; 
     String caseCategoryCode = caseCategory.code.get();
     JAXBElement<gov.niem.niem.domains.jxdm._4.CaseAugmentationType> caseAug = 
         makeNiemCaseAug(courtLocationId);
-    Result<JAXBElement<tyler.ecf.extensions.common.CaseAugmentationType>, FilingError> tylerAug = 
+    JAXBElement<tyler.ecf.extensions.common.CaseAugmentationType> tylerAug = 
               makeTylerCaseAug(courtLocationId, caseCategory, 
                   caseType, caseSubType, plaintiffs, plaintiffPartyType, defendants, 
                   defendantPartyType, 
                   filingIds,
                   paymentId, queryType, miscInfo, serializer, collector);
-    if (tylerAug.isErr()) {
-      return tylerAug.mapOk(o -> null);
-    }
     // TODO(brycew): handle ensuring the passed in values work with the court codes
     if (caseCategory.ecfcasetype.equals("CivilCase")) {
       JAXBElement<? extends gov.niem.niem.niem_core._2.CaseType> myCase = 
           makeCivilCaseType(
-              caseAug, tylerAug.unwrapOrElseThrow(), filing,
+              caseAug, tylerAug, filing,
               // TODO(brycew) from the gson
               new BigDecimal(500.0));
       myCase.getValue().setCaseCategoryText(XmlHelper.convertText(caseCategoryCode)); 
       return Result.ok(myCase);
     } else if (caseCategory.ecfcasetype.equals("DomesticCase")) {
       JAXBElement<? extends gov.niem.niem.niem_core._2.CaseType> myCase = 
-          makeDomesticCaseType(caseAug, tylerAug.unwrapOrElseThrow(), miscInfo);
+          makeDomesticCaseType(caseAug, tylerAug, miscInfo);
       myCase.getValue().setCaseCategoryText(XmlHelper.convertText(caseCategoryCode)); 
       return Result.ok(myCase);
     } else {
@@ -121,7 +119,7 @@ public class EcfCaseTypeFactory {
     return jof.createCaseAugmentation(caseAug);
   }
   
-  private Result<JAXBElement<tyler.ecf.extensions.common.CaseAugmentationType>, FilingError> 
+  private JAXBElement<tyler.ecf.extensions.common.CaseAugmentationType> 
       makeTylerCaseAug(
           String courtLocationId,
           CaseCategory caseCategory,
@@ -136,7 +134,7 @@ public class EcfCaseTypeFactory {
           JsonNode miscInfo,
           EcfCourtSpecificSerializer serializer,
           InfoCollector collector
-  ) throws SQLException {
+  ) throws SQLException, FilingError {
     // NOTE: in the code tables, only a handful of outliers have more than 1 code for the same category per location
     // SELECT x.code_count, x.name, x.location from 
     //    (select COUNT(code) as code_count, name, location from casecategory group by name, location) 
@@ -174,9 +172,6 @@ public class EcfCaseTypeFactory {
         InterviewVariable subTypeVar = collector.requestVar("tyler_case_subtype", "Sub type of the case", "choices", 
             subTypes.stream().map(nac -> nac.getName()).collect(Collectors.toList()));
         collector.addWrong(subTypeVar);
-        if (collector.finished()) {
-          return Result.err(FilingError.wrongValue(subTypeVar));
-        }
       }
     }
     
@@ -186,31 +181,21 @@ public class EcfCaseTypeFactory {
       FilingError err = FilingError.serverError("DEV ERROR: there are more than 2 required parties ("
           + requiredTypes + "), but only 2 are supported");
       collector.error(err);
-      return Result.err(err);
+      throw err;
     }
     List<String> partyTypeNames = requiredTypes.stream().map(p -> p.name).collect(Collectors.toList());
     if (!partyTypeNames.contains(plantiffPartyType)) {
       InterviewVariable plantiffVar = collector.requestVar("plantiff_party_type", "Legal role of the plantiff", "choices", partyTypeNames);
       collector.addWrong(plantiffVar);
-      if (collector.finished()) {
-        return Result.err(FilingError.wrongValue(plantiffVar));
-      }
     }
 
     if (!partyTypeNames.contains(defendantPartyType)) {
       InterviewVariable defendantVar = collector.requestVar("defendant_party_type", "Legal role of the defendant", "choices", partyTypeNames);
       collector.addWrong(defendantVar);
-      if (collector.finished()) {
-        return Result.err(FilingError.wrongValue(defendantVar));
-      }
     }
     
     for (Person plantiff : plantiffs) {
-      Result<CaseParticipantType, FilingError> partip = serializer.serializeEcfCaseParticipant(plantiff, collector); 
-      if (partip.isErr()) {
-        return partip.mapOk(o -> null);
-      }
-      CaseParticipantType cp = partip.unwrapOrElseThrow();
+      CaseParticipantType cp = serializer.serializeEcfCaseParticipant(plantiff, collector); 
       TextType tt = of.createTextType();
       partyTypes.stream()
           .filter(pt -> pt.name.equalsIgnoreCase(plantiffPartyType))
@@ -221,11 +206,7 @@ public class EcfCaseTypeFactory {
     }
 
     for (Person defendant : defendants) {
-      Result<CaseParticipantType, FilingError> partip = serializer.serializeEcfCaseParticipant(defendant, collector);
-      if (partip.isErr()) {
-        return partip.mapOk(o -> null);
-      }
-      CaseParticipantType cp = partip.unwrapOrElseThrow();
+      CaseParticipantType cp = serializer.serializeEcfCaseParticipant(defendant, collector);
       TextType tt = of.createTextType();
       partyTypes.stream()
           .filter((pt) -> pt.name.equalsIgnoreCase(defendantPartyType))
@@ -239,22 +220,14 @@ public class EcfCaseTypeFactory {
     ecfAug.setAttachServiceContactIndicator(falseVal);
     
     boolean initial = caseType.initial;
-    Result<Optional<ProcedureRemedyType>, FilingError> res = makeProcedureRemedyType(initial, 
+    Optional<ProcedureRemedyType> res = makeProcedureRemedyType(initial, 
         caseCategory, courtLocationId, miscInfo, collector);
-    if (res.isErr()) {
-      return res.mapOk(ignoredOk-> null);
-    }
 
-    Result<Optional<ProcedureRemedyType>, FilingError> resPlus = addDamageAmountType(
-        res.unwrapOrElseThrow(), initial, caseCategory, courtLocationId, miscInfo, collector);
-    if (resPlus.isErr()) {
-      return res.mapOk(ignoredOk-> null);
+    Optional<ProcedureRemedyType> resPlus = addDamageAmountType(
+        res, initial, caseCategory, courtLocationId, miscInfo, collector);
+    if (resPlus.isPresent()) {
+      ecfAug.setProcedureRemedy(resPlus.get());
     }
-    resPlus.ifOk(procRem -> {
-      if (procRem.isPresent()) {
-        ecfAug.setProcedureRemedy(procRem.get());
-      }
-    });
 
     // Filing
     DataFieldRow filertype = cd.getDataField(courtLocationId, "FilingFilerType");
@@ -288,13 +261,13 @@ public class EcfCaseTypeFactory {
     
     log.info("Full ecfAug: " + ecfAug);
 
-    return Result.ok(tylerObjFac.createCaseAugmentation(ecfAug));
+    return tylerObjFac.createCaseAugmentation(ecfAug);
   }
   
-  private Result<Optional<ProcedureRemedyType>, FilingError> makeProcedureRemedyType(
+  private Optional<ProcedureRemedyType> makeProcedureRemedyType(
       boolean initial, 
       CaseCategory cat,
-      String courtLocationId, JsonNode miscInfo, InfoCollector collector) throws SQLException {
+      String courtLocationId, JsonNode miscInfo, InfoCollector collector) throws SQLException, FilingError {
     List<NameAndCode> procedureRemedies = cd.getProcedureOrRemedy(courtLocationId, cat.getCode());
     DataFieldRow procedureView = DataFieldRow.MissingDataField(cat.name);
     String procBehavior = (initial) ? cat.procedureremedyinitial : cat.procedureremedysubsequent;
@@ -320,32 +293,26 @@ public class EcfCaseTypeFactory {
           for (NameAndCode nac : maybeProcedures) { 
             type.getRemedyCode().add(XmlHelper.convertText(nac.getCode())); 
           }
-          return Result.ok(Optional.of(type));
+          return Optional.of(type);
         }
         collector.addWrong(var);
-        if (collector.finished()) {
-          return Result.err(FilingError.wrongValue(var));
-        } 
       } else {
         log.info("Dropping procedure_remedy " + proRem.asText() + ", since isvisible is false for " + courtLocationId);
       }
     } else {
       if (procedureView.isrequired) {
         collector.addRequired(var);
-        if (collector.finished()) {
-          return Result.err(FilingError.wrongValue(var));
-        } 
       } else {
         collector.addOptional(var);
       }
     }
-    return Result.ok(Optional.empty());
+    return Optional.empty();
   }
   
-  private Result<Optional<ProcedureRemedyType>, FilingError> addDamageAmountType(
+  private Optional<ProcedureRemedyType> addDamageAmountType(
       Optional<ProcedureRemedyType> existingType,
       boolean initial, CaseCategory cat,
-      String courtLocationId, JsonNode miscInfo, InfoCollector collector) throws SQLException {
+      String courtLocationId, JsonNode miscInfo, InfoCollector collector) throws SQLException, FilingError {
     List<NameAndCode> damageAmounts = cd.getDamageAmount(courtLocationId, cat.getCode());
     // TODO(brycew): what the heck to do with the DataFieldConfig code = "DamageAmount"? No examples
     DataFieldRow damageConfig = DataFieldRow.MissingDataField(cat.name);
@@ -370,12 +337,9 @@ public class EcfCaseTypeFactory {
         if (maybeDmg.isPresent()) {
           ProcedureRemedyType type = existingType.orElse(new ProcedureRemedyType()); 
           type.setDamageAmountCode(XmlHelper.convertText(maybeDmg.get().getCode()));
-          return Result.ok(Optional.of(type));
+          return Optional.of(type);
         } else {
           collector.addWrong(var);
-           if (collector.finished()) {
-            return Result.err(FilingError.wrongValue(var));
-          } 
         }
       } else {
         log.info("Dropping damage_amount " + jsonDmg.asText() + ", since isvisible is false for " + courtLocationId);
@@ -383,14 +347,11 @@ public class EcfCaseTypeFactory {
     } else {
       if (damageConfig.isrequired) {
         collector.addRequired(var);
-        if (collector.finished()) {
-          return Result.err(FilingError.wrongValue(var));
-        } 
       } else {
         collector.addOptional(var);
       }
     }
-    return Result.ok(existingType); 
+    return existingType; 
   }
   
   /**

--- a/src/main/java/edu/suffolk/litlab/efspserver/ecf/EcfCourtSpecificSerializer.java
+++ b/src/main/java/edu/suffolk/litlab/efspserver/ecf/EcfCourtSpecificSerializer.java
@@ -11,7 +11,6 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import com.fasterxml.jackson.databind.JsonNode;
-import com.hubspot.algebra.Result;
 
 import edu.suffolk.litlab.efspserver.Address;
 import edu.suffolk.litlab.efspserver.ContactInformation;
@@ -77,31 +76,29 @@ public class EcfCourtSpecificSerializer {
     this.courtId = courtId;
   }
   
-  /** Needs to have participant role set. */
-  public Result<CaseParticipantType, FilingError> serializeEcfCaseParticipant(Person per, InfoCollector collector) {
+  /** Needs to have participant role set. 
+   * @throws FilingError */
+  public CaseParticipantType serializeEcfCaseParticipant(Person per, InfoCollector collector) throws FilingError {
     AugmentationType aug;
     if (per.isOrg()) {
       aug = ecfOf.createOrganizationAugmentationType();
     } else {
       aug = ecfOf.createPersonAugmentationType();
     }
-    Result<ContactInformationType, FilingError> cit = serializeEcfContactInformation(per.getContactInfo(), collector);
-    if (cit.isErr()) {
-      return cit.mapOk((o) -> null);
-    }
+    ContactInformationType cit = serializeEcfContactInformation(per.getContactInfo(), collector);
     if (per.isOrg()) {
-      ((OrganizationAugmentationType) aug).getContactInformation().add(cit.unwrapOrElseThrow());
+      ((OrganizationAugmentationType) aug).getContactInformation().add(cit);
       OrganizationType ot = ecfOf.createOrganizationType();
       ot.setOrganizationName(XmlHelper.convertText(per.getName().getFullName()));
       ot.setId(per.getIdString());
       ot.getRest().add(ecfOf.createOrganizationAugmentation((OrganizationAugmentationType) aug));
       CaseParticipantType cpt = ecfOf.createCaseParticipantType();
       cpt.setEntityRepresentation(ecfOf.createEntityOrganization(ot));
-      return Result.ok(cpt);
+      return cpt;
     }
 
     // Else, it's a person: add other optional person stuff
-    ((PersonAugmentationType) aug).getContactInformation().add(cit.unwrapOrElseThrow());
+    ((PersonAugmentationType) aug).getContactInformation().add(cit);
 
     PersonType pt = ecfOf.createPersonType();
     pt.setId(per.getIdString()); 
@@ -120,12 +117,12 @@ public class EcfCourtSpecificSerializer {
       pt.setPersonSex(niemObjFac.createPersonSexCode(sct));
     });
 
-    per.getLanguage().ifPresent((lang) -> {
+    if (per.getLanguage().isPresent()) {
+      String lang = per.getLanguage().get();
       List<String> langs = cd.getLanguages(this.courtId);
       if (!langs.isEmpty() && !langs.contains(lang)) {
         log.info("Can't have language: " + lang);
         collector.addWrong(collector.requestVar("language", "The primary language of this person", "choice", langs));
-        return;
       }
       final gov.niem.niem.iso_639_3._2.ObjectFactory lctOf =
           new gov.niem.niem.iso_639_3._2.ObjectFactory();
@@ -134,10 +131,7 @@ public class EcfCourtSpecificSerializer {
       PersonLanguageType plt = niemObjFac.createPersonLanguageType();
       plt.getLanguage().add(niemObjFac.createLanguageCode(lct));
       pt.setPersonPrimaryLanguage(plt);
-    });
-    if (collector.finished()) {
-      return Result.err(FilingError.wrongValue(collector.getWrong().get(collector.getWrong().size() - 1)));
-    }
+    };
 
     per.getBirthdate().ifPresent((bd) -> {
       pt.setPersonBirthDate(XmlHelper.convertDate(bd));
@@ -145,19 +139,16 @@ public class EcfCourtSpecificSerializer {
 
     CaseParticipantType cpt = ecfOf.createCaseParticipantType();
     cpt.setEntityRepresentation(ecfOf.createEntityPerson(pt));
-    return Result.ok(cpt);
+    return cpt;
   }
   
-  public Result<ContactInformationType, FilingError> serializeEcfContactInformation(
-      ContactInformation contactInfo, InfoCollector collector) {
+  public ContactInformationType serializeEcfContactInformation(
+      ContactInformation contactInfo, InfoCollector collector) throws FilingError {
     ContactInformationType cit = niemObjFac.createContactInformationType();
     if (contactInfo.getAddress().isPresent()) {
       Address addr = contactInfo.getAddress().get();
-      Result<JAXBElement<AddressType>, FilingError> contactMeans = serializeNiemContactMeans(addr, collector);
-      if (contactMeans.isErr()) {
-        return contactMeans.mapOk((o) -> null);
-      }
-      cit.getContactMeans().add(contactMeans.unwrapOrElseThrow()); 
+      JAXBElement<AddressType> contactMeans = serializeNiemContactMeans(addr, collector);
+      cit.getContactMeans().add(contactMeans); 
     }
       
     DataFieldRow phoneRow = cd.getDataField(this.courtId, "PartyPhone");
@@ -166,16 +157,10 @@ public class EcfCourtSpecificSerializer {
       InterviewVariable var = collector.requestVar("phone_number", "Phone number", "text");
       if (phoneRow.isrequired && numbers.isEmpty()) {
         collector.addRequired(var);
-        if (collector.finished()) {
-          return Result.err(FilingError.missingRequired(var));
-        }
       }
       for (String phoneNumber : contactInfo.getPhoneNumbers()) {
         if (!phoneRow.matchRegex(phoneNumber)) {
           collector.addWrong(var);
-          if (collector.finished()) {
-            return Result.err(FilingError.wrongValue(var));
-          }
         }
 
         TelephoneNumberType tnt = niemObjFac.createTelephoneNumberType();
@@ -188,10 +173,10 @@ public class EcfCourtSpecificSerializer {
     contactInfo.getEmail().ifPresent((em) -> {
       cit.getContactMeans().add(niemObjFac.createContactEmailID(XmlHelper.convertString(em))); 
     });
-    return Result.ok(cit);
+    return cit;
   }
 
-  public Result<tyler.efm.services.schema.common.AddressType, FilingError> serializeTylerAddress(Address myAddr) {
+  public tyler.efm.services.schema.common.AddressType serializeTylerAddress(Address myAddr) throws FilingError {
     tyler.efm.services.schema.common.ObjectFactory efmObjFac = 
         new tyler.efm.services.schema.common.ObjectFactory();
     tyler.efm.services.schema.common.AddressType addr = efmObjFac.createAddressType();
@@ -201,19 +186,19 @@ public class EcfCourtSpecificSerializer {
     FailFastCollector collector = new FailFastCollector();
     Optional<CountryCodeType> cct = strToCountryCode(myAddr.getCountry(), collector);
     if (cct.isEmpty()) {
-      return Result.err(FilingError.serverError("Country Code is wrong"));
+      throw FilingError.serverError("Country Code is wrong");
     }
     addr.setState(myAddr.getState()); 
     addr.setZipCode(myAddr.getZip()); 
     addr.setCountry(myAddr.getCountry()); 
-    return Result.ok(addr);
+    return addr;
   }
   
   /** Returns the "ContactMeans" XML object from this address. Can be used in the 
    * ContactInformation element.
    */
-  public Result<JAXBElement<AddressType>, FilingError> serializeNiemContactMeans(Address address,
-      InfoCollector collector) {
+  public JAXBElement<AddressType> serializeNiemContactMeans(Address address,
+      InfoCollector collector) throws FilingError {
     StreetType st = niemObjFac.createStreetType();
     st.setStreetFullText(XmlHelper.convertText(address.getStreet() + " " + address.getApartment())); 
     StructuredAddressType sat = niemObjFac.createStructuredAddressType();
@@ -229,35 +214,29 @@ public class EcfCourtSpecificSerializer {
       InterviewVariable var = collector.requestVar("country", "County of the World, in an address", 
           "choices", countries);
       collector.addWrong(var);
-      if (collector.finished()) {
-        return Result.err(FilingError.wrongValue(var));
-      }
     }
     sat.setLocationCountry(niemObjFac.createLocationCountryFIPS104Code(cct.get()));
     if (!fillStateCode(address.getState(), cct.get(), sat)) {
       String countryString = cct.get().getValue().value();
       List<String> stateCodes = cd.getStateCodes(countryString); 
       InterviewVariable var = collector.requestVar("state", "State in a country", "choices", stateCodes);
-      collector.addWrong(var);
       if (stateCodes.isEmpty()) {
         FilingError err = FilingError.malformedInterview("There are no allowed states for " + countryString);
         collector.error(err);
-        return Result.err(err);
+        throw err;
       }
-      if (collector.finished()) {
-        return Result.err(FilingError.wrongValue(var));
-      }
+      collector.addWrong(var);
     }
     sat.setLocationPostalCode(XmlHelper.convertString(address.getZip())); 
     gov.niem.niem.niem_core._2.AddressType at = niemObjFac.createAddressType();
     at.setAddressRepresentation(niemObjFac.createStructuredAddress(sat));
-    return Result.ok(niemObjFac.createContactMailingAddress(at));
+    return niemObjFac.createContactMailingAddress(at);
   }
 
-  public Result<JAXBElement<DocumentType>, FilingError> filingDocToXml(FilingDoc doc, 
+  public JAXBElement<DocumentType> filingDocToXml(FilingDoc doc, 
           int sequenceNum, CaseCategory caseCategory, CaseType motionType, FilingCode filing, 
           List<FilingComponent> components,
-          JsonNode miscInfo, InfoCollector collector) throws IOException {
+          JsonNode miscInfo, InfoCollector collector) throws IOException, FilingError {
     tyler.ecf.extensions.common.ObjectFactory tylerObjFac = 
         new tyler.ecf.extensions.common.ObjectFactory();
     gov.niem.niem.niem_core._2.ObjectFactory niemObjFac = 
@@ -317,18 +296,12 @@ public class EcfCourtSpecificSerializer {
     if (components.isEmpty()) {
       log.error("Filing Components List is empty! There are no other documents that can be added! Stopping at " + doc.getFileName());
       collector.addRequired(var);
-      if (collector.finished()) {
-        return Result.err(FilingError.missingRequired(var));
-      }
     }
     
     Optional<FilingComponent> filtered = components.stream().filter(c -> c.name.equalsIgnoreCase(doc.getFilingComponentName())).findFirst();
     if (filtered.isEmpty()) {
       log.error("Filing Components (" + components + ") don't match " + doc.getFilingComponentName()); 
       collector.addRequired(var);
-      if (collector.finished()) {
-        return Result.err(FilingError.missingRequired(var));
-      }
     }
     
     attachment.setBinaryCategoryText(XmlHelper.convertText(filtered.get().code)); 
@@ -346,14 +319,14 @@ public class EcfCourtSpecificSerializer {
       String docTypeStr = doc.getDocumentTypeFormatStandardName();
       if (documentType.isrequired) {
         if (docTypeStr.isBlank()) {
-          return Result.err(FilingError.missingRequired(docTypeVar));
+          collector.addRequired(docTypeVar);
         }
         
         Optional<DocumentTypeTableRow> code = docTypes.stream()
                 .filter(d -> d.name.equals(docTypeStr))
                 .findFirst();
         if (code.isEmpty()) {
-          return Result.err(FilingError.wrongValue(docTypeVar));
+          collector.addWrong(docTypeVar);
         }
         
         attachment.setBinaryFormatStandardName(XmlHelper.convertText(code.get().code));
@@ -380,9 +353,9 @@ public class EcfCourtSpecificSerializer {
     docType.getDocumentRendition().add(rendition);
     
     if (doc.isLead()) {
-      return Result.ok(tylerObjFac.createFilingLeadDocument(docType));
+      return tylerObjFac.createFilingLeadDocument(docType);
     } else {
-      return Result.ok(tylerObjFac.createFilingConnectedDocument(docType));
+      return tylerObjFac.createFilingConnectedDocument(docType);
     }
     
   }

--- a/src/main/java/edu/suffolk/litlab/efspserver/services/AdminUserService.java
+++ b/src/main/java/edu/suffolk/litlab/efspserver/services/AdminUserService.java
@@ -6,8 +6,6 @@ import java.net.URL;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
-import java.util.regex.Pattern;
-import java.util.regex.Matcher;
 import javax.ws.rs.DELETE;
 import javax.ws.rs.GET;
 import javax.ws.rs.PATCH;
@@ -560,11 +558,7 @@ public class AdminUserService {
   private boolean passwordOk(DataFieldRow row, String password) {
     if (row.isvisible && row.isrequired 
         && password != null && !password.isEmpty()) {
-      Pattern pattern = Pattern.compile(row.regularexpression);
-      Matcher matcher = pattern.matcher(password); 
-      if (!matcher.find()) {
-        return false;
-      }
+      return row.matchRegex(password);
     }
     return true;
   }

--- a/src/main/java/edu/suffolk/litlab/efspserver/services/CasesService.java
+++ b/src/main/java/edu/suffolk/litlab/efspserver/services/CasesService.java
@@ -119,13 +119,14 @@ public class CasesService {
     }
     if (node.has("person_name") && node.get("person_name").isObject()) {
       FailFastCollector collector = new FailFastCollector();
-      Result<Name, FilingError> maybeName = 
-          NameDocassembleDeserializer.fromNode(node.get("person_name"), collector);
-      if (maybeName.isErr()) {
+      Name maybeName;
+      try {
+        maybeName = NameDocassembleDeserializer.fromNode(node.get("person_name"), collector);
+      } catch (FilingError err) {
         return Response.status(400).entity("Name needs to be a JSON object with first, middle, last, etc.").build();
       }
       PersonType pt = ecfOf.createPersonType();
-      pt.setPersonName(maybeName.unwrapOrElseThrow().getNameType());
+      pt.setPersonName(maybeName.getNameType());
       
       
       commonCpt.setEntityRepresentation(ecfOf.createEntityPerson(pt));

--- a/src/main/java/edu/suffolk/litlab/efspserver/services/EfspServer.java
+++ b/src/main/java/edu/suffolk/litlab/efspserver/services/EfspServer.java
@@ -113,7 +113,7 @@ public class EfspServer {
     sf.setResourceProvider(PaymentsService.class,
         new SingletonResourceProvider(new PaymentsService(security)));
     sf.setResourceProvider(CasesService.class,
-        new SingletonResourceProvider(new CasesService(security)));
+        new SingletonResourceProvider(new CasesService(security, cd)));
     sf.setResourceProvider(MessageSettingsService.class,
         new SingletonResourceProvider(new MessageSettingsService(security, md)));
 

--- a/src/main/java/edu/suffolk/litlab/efspserver/services/FilingError.java
+++ b/src/main/java/edu/suffolk/litlab/efspserver/services/FilingError.java
@@ -3,7 +3,9 @@ package edu.suffolk.litlab.efspserver.services;
 import java.util.Optional;
 import org.apache.commons.lang3.builder.HashCodeBuilder;
 
-public class FilingError {
+public class FilingError extends Exception {
+  private static final long serialVersionUID = 1L;
+
   public enum Type {
     MalformedInterview, /// For when the json is somehow not well formed, or just plain wrong
     MissingRequired, /// For when the json doesn't have a member that is needed, like "users"

--- a/src/main/java/edu/suffolk/litlab/efspserver/services/InfoCollector.java
+++ b/src/main/java/edu/suffolk/litlab/efspserver/services/InfoCollector.java
@@ -51,16 +51,22 @@ public abstract class InfoCollector {
     return true;
   }
   
-  public void addRequired(InterviewVariable var) {
+  public void addRequired(InterviewVariable var) throws FilingError {
     requiredVars.add(var);
+    if (finished()) {
+      throw FilingError.missingRequired(var);
+    }
   }
 
   public void addOptional(InterviewVariable var) {
     optionalVars.add(var);
   }
   
-  public void addWrong(InterviewVariable var) {
+  public void addWrong(InterviewVariable var) throws FilingError{
     wrongVars.add(var);
+    if (finished()) {
+      throw FilingError.wrongValue(var);
+    }
   }
 
   public void pushAttributeStack(String variableName) {

--- a/src/test/java/edu/suffolk/litlab/efspserver/AddressTest.java
+++ b/src/test/java/edu/suffolk/litlab/efspserver/AddressTest.java
@@ -10,7 +10,6 @@ import static org.mockito.Mockito.when;
 import java.util.List;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
-import com.hubspot.algebra.Result;
 
 import edu.suffolk.litlab.efspserver.codes.CodeDatabase;
 import edu.suffolk.litlab.efspserver.ecf.EcfCourtSpecificSerializer;
@@ -39,11 +38,9 @@ public class AddressTest {
   }
   
   @Test
-  public void addressShouldMakeXml() throws JAXBException {
+  public void addressShouldMakeXml() throws JAXBException, FilingError {
     FailFastCollector collector = new FailFastCollector();
-    Result<JAXBElement<AddressType>, FilingError> res = serializer.serializeNiemContactMeans(addr, collector); 
-    assertTrue(res.isOk());
-    JAXBElement<AddressType> addrElem = res.unwrapOrElseThrow();
+    JAXBElement<AddressType> addrElem = serializer.serializeNiemContactMeans(addr, collector); 
 
     // Should be able to grab the xml str without an exception
     XmlHelper.objectToXmlStr(addrElem.getValue(), AddressType.class);
@@ -58,7 +55,7 @@ public class AddressTest {
     JAXBElement<?> state = sat.getLocationState();
     assertTrue(state.getValue() instanceof ProperNameTextType);
     
-    tyler.efm.services.schema.common.AddressType tylerAddr = serializer.serializeTylerAddress(addr).unwrapOrElseThrow(); 
+    tyler.efm.services.schema.common.AddressType tylerAddr = serializer.serializeTylerAddress(addr); 
     assertEquals(tylerAddr.getAddressLine1(), "100 Circle Road");
     assertEquals(tylerAddr.getAddressLine2(), "Apt 2");
     assertEquals(tylerAddr.getCity(), "Plano");

--- a/src/test/java/edu/suffolk/litlab/efspserver/InfoCollectorTest.java
+++ b/src/test/java/edu/suffolk/litlab/efspserver/InfoCollectorTest.java
@@ -3,6 +3,7 @@ package edu.suffolk.litlab.efspserver;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
 
 import edu.suffolk.litlab.efspserver.services.AllWrongCollector;
 import edu.suffolk.litlab.efspserver.services.FilingError;
@@ -26,7 +27,12 @@ public class InfoCollectorTest {
     collector.addOptional(var);
     assertFalse(collector.finished());
     InterviewVariable var2 = new InterviewVariable("fake_var2", "", "text", List.of());
-    collector.addRequired(var2);
+    try {
+      collector.addRequired(var2);
+      fail("Should have thrown error");
+    } catch (FilingError err) {
+      // All good
+    }
     assertTrue(collector.finished());
 
     assertFalse(collector.okToSubmit());
@@ -44,7 +50,12 @@ public class InfoCollectorTest {
   @Test
   public void testFailFastShouldTrackStack() {
     FailFastCollector collector = new FailFastCollector();
-    collector.addRequired(collector.requestVar("hi", "", "text"));
+    try {
+      collector.addRequired(collector.requestVar("hi", "", "text"));
+      fail("Should have thrown filing error");
+    } catch (FilingError err) {
+      // N/A
+    }
     collector.pushAttributeStack("one");
     collector.pushAttributeStack("two");
     collector.addOptional(collector.requestVar("bye", "", "text"));
@@ -58,11 +69,15 @@ public class InfoCollectorTest {
   }
   
   @Test
-  public void testAllWrongShouldGetAll() throws JsonMappingException, JsonProcessingException {
+  public void testAllWrongShouldGetAll() throws JsonMappingException, JsonProcessingException { 
     AllWrongCollector collector = new AllWrongCollector();
     assertFalse(collector.finished());
     assertTrue(collector.okToSubmit());
-    collector.addRequired(collector.requestVar("hi", "", "text"));
+    try {
+      collector.addRequired(collector.requestVar("hi", "", "text"));
+    } catch (FilingError e) {
+      fail("Should NOT have thrown a filing error");
+    }
     assertFalse(collector.finished());
     assertFalse(collector.okToSubmit());
     String json = collector.jsonSummary();


### PR DESCRIPTION
The results might be faster, but it does end up with much more clutter in the lower level functions. Result<..., FilingError> should still be present at the higher level Service functions, but everything else in the lower level should throw, since much of what we were doing before was to equivalent to catch and throw. 

Saves ~100 lines, so I guess that's not bad. 