### PR TITLE
ACME/Lets Encrypt support + arbitrary ports

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -7,7 +7,10 @@ services:
         EFM_SUPPORT: tyler
     # Necessary b/c docassemble is external to the docker network
     ports:
-      - "9000:9000"
+      - target: 9000
+        published: 80
+      - target: 9000
+        published: 443
     env_file: .env
     depends_on:
       - "db"

--- a/docs/https.md
+++ b/docs/https.md
@@ -17,15 +17,11 @@ The first of two steps to using HTTPS is actually getting a signed TLS certifica
 
 You can also do this with Let's Encrypt, but unfortunately since we're running on a custom server
 software (not nginx or Apache), then it would take a bit more effort to integrate it.
-TODO(brycew-later): eventually we should. Look into the below for resources 
-
-* [Lets Encrypt Java Clients](https://letsencrypt.org/docs/client-options/#clients-java)
-* [Porunov Java ACME Client](https://github.com/porunov/acme_client) (ACME is the protocol that Let's Encrypt uses)
-* [Shred acme4j](https://github.com/shred/acme4j)
+TODO(brycew-later): eventually we should. Going to use https://github.com/shred/acme4j
 
 ## Using that Certificate in the CXF Server
 
-First, turning the certificate into something that Java can consume, namely, a Java Key Store (jks). 
+First, turning the certificate into something that Java can consume, namely, a Java Key Store (jks).
 
 * https://stackoverflow.com/questions/41416050/installing-an-intermediate-chain-certificate-using-java-key-tool
 * https://www.tbs-certificates.co.uk/FAQ/en/ajouter-certificat-intermediaire-keystore-java.html
@@ -44,26 +40,28 @@ java utils.ImportPrivateKey keystore storepass storetype keypass alias certfile 
 openssl pkcs12 -export -in efile_suffolklitlab_org.crt -inkey efile.suffolklitlab.org.key  -out efile.suffolklitlab.org.p12
 keytool -importkeystore -srckeystore efile.suffolklitlab.org.p12 -srcstoretype PKCS12 -destkeystore efile.suffolklitlab.org.jks -deststoretype JKS
 
-keytool -printcert -v -file efile.suffolklitlab.org.jks 
-keytool -list -v -file efile.suffolklitlab.org.jks 
-keytool -list -v -keystore efile.suffolklitlab.org.jks 
-keytool -exportcert -rfc -alias mykey -keystore efile.suffolklitlab.org.jks > cert.pem
-openssl verify cert.pem
-keytool -exportcert -rfc -keystore efile.suffolklitlab.org.jks > cert.pem
-keytool -exportcert -rfc -keystore efile.suffolklitlab.org.jks
-keytool -list -v -keystore efile.suffolklitlab.org.jks | grep Alias
+#keytool -printcert -v -file efile.suffolklitlab.org.jks
+#keytool -list -v -file efile.suffolklitlab.org.jks 
+#keytool -list -v -keystore efile.suffolklitlab.org.jks 
+## Wrong?
+##keytool -exportcert -rfc -alias mykey -keystore efile.suffolklitlab.org.jks > cert.pem
+#openssl verify cert.pem
+## Wrong?
+##keytool -exportcert -rfc -keystore efile.suffolklitlab.org.jks > cert.pem
+##keytool -exportcert -rfc -keystore efile.suffolklitlab.org.jks
+#keytool -list -v -keystore efile.suffolklitlab.org.jks | grep Alias
 keytool -exportcert -rfc -Alias 1 -keystore efile.suffolklitlab.org.jks > cert.pem
-openssl verify cert.pem
-openssl verify efile_suffolklitlab_org.ca-bundle 
+#openssl verify cert.pem
+#openssl verify efile_suffolklitlab_org.ca-bundle 
 vim sectigo.intermediate.crt
 cat efile_suffolklitlab_org.ca-bundle efile_suffolklitlab_org.crt > efile_suffolklitlab_org_combined.crt
 openssl pkcs12 -export -in efile_suffolklitlab_org_combined.crt -inkey efile.suffolklitlab.org.key -out efile.suffolklitlab.org.combined.p12
 keytool -importkeystore -srckeystore efile.suffolklitlab.org.combined.p12 -srcstoretype PKCS12 -destkeystore efile.suffolklitlab.org.combined.jks -deststoretype JKS
 keytool -exportcert -rfc -alias 1 -keystore efile.suffolklitlab.org.combined.jks > cert.pem
-openssl verify cert.pem 
-openssl verify -CAfile sectigo.root.crt -untrusted sectigo.intermediate.crt cert.pem 
-keytool -list -v -keystore efile.suffolklitlab.org.combined.jks
-keytool -list -v -keystore efile.suffolklitlab.org.combined.jks | grep Alias
+#openssl verify cert.pem 
+#openssl verify -CAfile sectigo.root.crt -untrusted sectigo.intermediate.crt cert.pem 
+#keytool -list -v -keystore efile.suffolklitlab.org.combined.jks
+#keytool -list -v -keystore efile.suffolklitlab.org.combined.jks | grep Alias
 cp efile.suffolklitlab.org.combined.jks EFileProxyServer/src/main/config/
 ```
 

--- a/docs/setup.md
+++ b/docs/setup.md
@@ -133,8 +133,7 @@ And for [twilio](https://www.twilio.com/docs/libraries/java):
 [This REST/JAX book is extremely helpful](https://dennis-xlc.gitbooks.io/restful-java-with-jax-rs-2-0-2rd-edition/content/en/part1/chapter3/developing_a_jax_rs_restful_service.html).
 
 Note: 
-* Docassemble will run on port 80
-* Maven/proxy efsp will run on port 9000
+* proxy efsp will run on port 80/443
 
 # TODO: we should set up a root endpoint for the proxy server which has a little bit of information about the server
 

--- a/env.example
+++ b/env.example
@@ -1,8 +1,7 @@
 # Password for the HTTPS certificate. NOT the same as Tyler's X509_PASSWORD
 CERT_PASSWORD=
-# The URL that the proxy server looks to for incomming connections
-BASE_LOCAL_URL=https://0.0.0.0:9000
-CURRENT_URL=https://efile.suffolklitlab.org:9000
+# The URL that the external clients see when talking to the proxy server
+EXTERNAL_URL=https://efile.suffolklitlab.org
 TZ=America/New_York
 
 ##### Postgres / database environment variables #####

--- a/pom.xml
+++ b/pom.xml
@@ -190,6 +190,16 @@
             <version>42.3.5</version>
         </dependency>
         <dependency>
+            <groupId>org.shredzone.acme4j</groupId>
+            <artifactId>acme4j-client</artifactId>
+            <version>2.14</version>
+        </dependency>
+        <dependency>
+            <groupId>org.shredzone.acme4j</groupId>
+            <artifactId>acme4j-utils</artifactId>
+            <version>2.14</version>
+        </dependency>
+        <dependency>
             <groupId>com.hubspot</groupId>
             <artifactId>algebra</artifactId>
             <version>1.3</version>
@@ -355,6 +365,15 @@
                             </goals>
                             <configuration>
                                 <mainClass>edu.suffolk.litlab.efspserver.codes.CodeUpdater</mainClass>
+                            </configuration>
+                        </execution>
+                        <execution>
+                            <id>AcmeRenewal</id>
+                            <goals>
+                                <goal>java</goal>
+                            </goals>
+                            <configuration>
+                                <mainClass>edu.suffolk.litlab.efspserver.services.AcmeRenewal</mainClass>
                             </configuration>
                         </execution>
                         <execution>

--- a/src/main/config/ServerConfig.xml
+++ b/src/main/config/ServerConfig.xml
@@ -27,13 +27,16 @@
     xmlns:httpj="http://cxf.apache.org/transports/http-jetty/configuration"
     xsi:schemaLocation="http://cxf.apache.org/configuration/security http://cxf.apache.org/schemas/configuration/security.xsd http://cxf.apache.org/transports/http/configuration http://cxf.apache.org/schemas/configuration/http-conf.xsd http://cxf.apache.org/transports/http-jetty/configuration http://cxf.apache.org/schemas/configuration/http-jetty.xsd http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd">
     <httpj:engine-factory bus="cxf">
-        <httpj:engine port="9000">
+        <httpj:identifiedTLSServerParameters id="secure">
             <httpj:tlsServerParameters>
                 <sec:keyManagers keyPasswordCallbackHandler="edu.suffolk.litlab.efspserver.HttpsCallbackHandler">
                     <sec:keyStore file="src/main/config/efile.suffolklitlab.org.combined.jks" type="JKS"/>
                 </sec:keyManagers>
-	        <sec:certAlias>1</sec:certAlias>
+	              <sec:certAlias>1</sec:certAlias>
             </httpj:tlsServerParameters>
+        </httpj:identifiedTLSServerParameters>
+        <httpj:engine port="9000">
+            <httpj:tlsServerParametersRef id="secure"/>
         </httpj:engine>
     </httpj:engine-factory>
 </beans>

--- a/src/main/java/edu/suffolk/litlab/efspserver/ecf/PolicyCacher.java
+++ b/src/main/java/edu/suffolk/litlab/efspserver/ecf/PolicyCacher.java
@@ -1,8 +1,8 @@
 package edu.suffolk.litlab.efspserver.ecf;
 
 import java.time.LocalDateTime;
-import java.util.HashMap;
 import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
 
 import edu.suffolk.litlab.efspserver.services.ServiceHelpers;
 import oasis.names.tc.legalxml_courtfiling.schema.xsd.courtpolicyquerymessage_4.CourtPolicyQueryMessageType;
@@ -11,7 +11,7 @@ import oasis.names.tc.legalxml_courtfiling.wsdl.webservicesprofile_definitions_4
 
 public class PolicyCacher {
   public PolicyCacher() {
-    this.policyInMemoryCache = new HashMap<String, CourtPolicyResponseMessageType>();
+    this.policyInMemoryCache = new ConcurrentHashMap<String, CourtPolicyResponseMessageType>();
     this.lastFlushed = LocalDateTime.now();
   }
 

--- a/src/main/java/edu/suffolk/litlab/efspserver/ecf/TylerModuleSetup.java
+++ b/src/main/java/edu/suffolk/litlab/efspserver/ecf/TylerModuleSetup.java
@@ -261,7 +261,7 @@ public class TylerModuleSetup implements EfmModuleSetup {
   @Override
   public void setupGlobals() {
     OasisEcfWsCallback implementor = new OasisEcfWsCallback(tylerJurisdiction, tylerEnv, codeDs, userDs, sender);
-    String baseLocalUrl = System.getenv("BASE_LOCAL_URL");
+    String baseLocalUrl = ServiceHelpers.BASE_LOCAL_URL;
     String address = baseLocalUrl + "/" + tylerJurisdiction + ServiceHelpers.ASSEMBLY_PORT;
     log.info("Starting NFRC callback server at " + address);
     EndpointImpl jaxWsEndpoint = (EndpointImpl) javax.xml.ws.Endpoint.publish(address,  implementor);

--- a/src/main/java/edu/suffolk/litlab/efspserver/jeffnet/FilingInformationJeffNetSerializer.java
+++ b/src/main/java/edu/suffolk/litlab/efspserver/jeffnet/FilingInformationJeffNetSerializer.java
@@ -45,7 +45,7 @@ public class FilingInformationJeffNetSerializer extends StdSerializer<FilingInfo
     caseInfo.participants.addAll(info.getNewPlaintiffs());
 
     SendingMde mde = new SendingMde();
-    mde.ourUrl = ServiceHelpers.BASE_URL;
+    mde.ourUrl = ServiceHelpers.EXTERNAL_URL;
 
     Callback callbackObj = new Callback();
     String filingUid = UUID.randomUUID().toString();

--- a/src/main/java/edu/suffolk/litlab/efspserver/services/AcmeChallengePublisher.java
+++ b/src/main/java/edu/suffolk/litlab/efspserver/services/AcmeChallengePublisher.java
@@ -1,0 +1,18 @@
+package edu.suffolk.litlab.efspserver.services;
+
+import org.shredzone.acme4j.challenge.Http01Challenge;
+
+/** A class that handles Letsencrypt challenges by publishing an ACME token and
+ * content for a Http01 challenge.
+ */
+public interface AcmeChallengePublisher {
+
+  public default boolean setTokenContent(Http01Challenge challenge) {
+    return setTokenContent(challenge.getToken(), challenge.getAuthorization());
+  }
+
+  public boolean setTokenContent(String token, String content);
+
+  /** Remove the token content, as it shouldn't stay up for too long. */
+  public boolean removeTokenContent();
+}

--- a/src/main/java/edu/suffolk/litlab/efspserver/services/AcmeChallengeService.java
+++ b/src/main/java/edu/suffolk/litlab/efspserver/services/AcmeChallengeService.java
@@ -1,0 +1,60 @@
+package edu.suffolk.litlab.efspserver.services;
+
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.IOException;
+
+import javax.ws.rs.GET;
+import javax.ws.rs.Path;
+import javax.ws.rs.PathParam;
+import javax.ws.rs.core.Response;
+
+@Path("/.well-known")
+public class AcmeChallengeService implements AcmeChallengePublisher {
+
+  private String token;
+  private String content;
+
+  public boolean setTokenContent(String token, String content) {
+    this.token = token;
+    this.content = content;
+    return true;
+  }
+
+  public boolean removeTokenContent() {
+    this.token = "";
+    this.content = "";
+    return true;
+  }
+
+  @GET
+  @Path("/acme-challenge/{token}")
+  public Response getChallengeResponse(@PathParam("token") String inToken) {
+    if (inToken == null || inToken.isBlank()) {
+      return Response.status(404).build();
+    }
+    if (inToken.equals(token)) {
+      return Response.ok(content).build();
+    }
+    if (AcmeChallengeWriter.TOKEN_FILE.exists()) {
+      try {
+        String fromFileToken = smallFileReading(AcmeChallengeWriter.TOKEN_FILE);
+        String fromFileContent = smallFileReading(AcmeChallengeWriter.CONTENT_FILE);
+        if (inToken.equals(fromFileToken)) {
+          return Response.ok(fromFileContent).build();
+        }
+      } catch (IOException ex) {
+        return Response.status(500).build();
+      }
+    }
+    return Response.status(404).build();
+  }
+
+  private static String smallFileReading(File fileToRead) throws IOException {
+    FileInputStream tokenStream = new FileInputStream(fileToRead);
+    byte[] data = new byte[(int) fileToRead.length()];
+    tokenStream.read(data);
+    tokenStream.close();
+    return new String(data, "UTF-8");
+  }
+}

--- a/src/main/java/edu/suffolk/litlab/efspserver/services/AcmeChallengeWriter.java
+++ b/src/main/java/edu/suffolk/litlab/efspserver/services/AcmeChallengeWriter.java
@@ -1,0 +1,32 @@
+package edu.suffolk.litlab.efspserver.services;
+
+import java.io.File;
+import java.io.FileWriter;
+import java.io.IOException;
+import java.io.Writer;
+
+public class AcmeChallengeWriter implements AcmeChallengePublisher {
+
+  public final static File TOKEN_FILE= new File("acme_token_file.txt");
+  public final static File CONTENT_FILE= new File("acme_content_file.txt");
+
+  @Override
+  public boolean setTokenContent(String token, String content) {
+    try {
+      Writer tokenWriter = new FileWriter(TOKEN_FILE);
+      tokenWriter.write(token);
+      tokenWriter.close();
+      Writer contentWriter = new FileWriter(CONTENT_FILE);
+      contentWriter.write(content);
+      contentWriter.close();
+      return true;
+    } catch (IOException ex) {
+      return false;
+    }
+  }
+
+  @Override
+  public boolean removeTokenContent() {
+    return TOKEN_FILE.delete() && CONTENT_FILE.delete();
+  }
+}

--- a/src/main/java/edu/suffolk/litlab/efspserver/services/AcmeRenewal.java
+++ b/src/main/java/edu/suffolk/litlab/efspserver/services/AcmeRenewal.java
@@ -1,0 +1,234 @@
+package edu.suffolk.litlab.efspserver.services;
+
+import java.io.File;
+import java.io.FileReader;
+import java.io.FileWriter;
+import java.io.IOException;
+import java.io.Writer;
+import java.net.URI;
+import java.security.KeyPair;
+import java.security.Security;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.Scanner;
+
+import org.bouncycastle.jce.provider.BouncyCastleProvider;
+import org.shredzone.acme4j.Account;
+import org.shredzone.acme4j.AccountBuilder;
+import org.shredzone.acme4j.Authorization;
+import org.shredzone.acme4j.Certificate;
+import org.shredzone.acme4j.Order;
+import org.shredzone.acme4j.Session;
+import org.shredzone.acme4j.Status;
+import org.shredzone.acme4j.challenge.Http01Challenge;
+import org.shredzone.acme4j.exception.AcmeException;
+import org.shredzone.acme4j.util.CSRBuilder;
+import org.shredzone.acme4j.util.KeyPairUtils;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class AcmeRenewal {
+
+  private static final File USER_KEY_FILE = new File("acme_user.key");
+  private static final File DOMAIN_KEY_FILE = new File("acme_domain.key");
+  private static final File DOMAIN_CSR_FILE = new File("acme_domain.csr");
+  private static final File DOMAIN_CHAIN_FILE = new File("acme_domain-chain.crt");
+
+  // RSA key size of the generated key pairs
+  private static final int KEY_SIZE = 2048;
+
+  private static Logger log =
+      LoggerFactory.getLogger(AcmeRenewal.class);
+
+  private KeyPair loadOrCreateUserKeyPair() throws IOException {
+    if (USER_KEY_FILE.exists()) {
+      try (FileReader fr = new FileReader(USER_KEY_FILE)) {
+        return KeyPairUtils.readKeyPair(fr);
+      }
+    } else {
+      KeyPair userKeyPair = KeyPairUtils.createKeyPair(KEY_SIZE);
+      try (FileWriter fw = new FileWriter(USER_KEY_FILE)) {
+        KeyPairUtils.writeKeyPair(userKeyPair, fw);
+      }
+      return userKeyPair;
+    }
+  }
+
+  private KeyPair loadOrCreateDomainKeyPair() throws IOException {
+    if (DOMAIN_KEY_FILE.exists()) {
+      try (FileReader fr = new FileReader(DOMAIN_KEY_FILE)) {
+        return KeyPairUtils.readKeyPair(fr);
+      }
+    } else {
+      KeyPair domainKeyPair = KeyPairUtils.createKeyPair(KEY_SIZE);
+      try (FileWriter fw = new FileWriter(DOMAIN_KEY_FILE)) {
+        KeyPairUtils.writeKeyPair(domainKeyPair, fw);
+      }
+      return domainKeyPair;
+    }
+  }
+
+
+  public void fetchCertificate(Collection<String> domains, AcmeChallengePublisher publisher) throws IOException, AcmeException {
+    KeyPair userKeyPair = loadOrCreateUserKeyPair();
+
+    Session session = new Session("acme://letsencrypt.org/staging");
+
+    // If there is no account yet, create a new one
+    Account acct = findOrRegisterAccount(session, userKeyPair);
+
+    // This should not be the userKeyPair!
+    KeyPair domainKeyPair = loadOrCreateDomainKeyPair();
+
+    Order order = acct.newOrder().domains(domains).create();
+
+    for (Authorization auth: order.getAuthorizations()) {
+      authorize(auth, publisher);
+    }
+
+    CSRBuilder csrb = new CSRBuilder();
+    csrb.addDomains(domains);
+    csrb.sign(domainKeyPair);
+
+    try (Writer out = new FileWriter(DOMAIN_CSR_FILE)) {
+      csrb.write(out);
+    }
+
+    order.execute(csrb.getEncoded());
+
+    try {
+      int attempts = 10;
+      while (order.getStatus() != Status.VALID && attempts > 0) {
+        attempts -= 1;
+        if (order.getStatus() == Status.INVALID) {
+          log.error("Order has failed, reason: {}", order.getError());
+          throw new AcmeException("Order failed, giving up");
+        }
+
+        Thread.sleep(3000L);
+        order.update();
+      }
+    } catch (InterruptedException ex) {
+      log.error("interrupted", ex);
+      Thread.currentThread().interrupt();
+    }
+
+    Certificate certificate = order.getCertificate();
+    log.info("Success! The certificate for domains {} has been generated!", domains);
+    log.info("Certificate URL: {}", certificate.getLocation());
+    try (FileWriter fw = new FileWriter(DOMAIN_CHAIN_FILE)) {
+      certificate.writeCertificate(fw);
+    }
+    // Additionally TODO(brycew):
+    // * cat ca-bundle (?) and crt together to make combined crt (?)
+    // * openssl to make the combined crt and key into a p12
+    // * keytool to make the combined p12 into a JKS (the final product)
+    // * (optionally) keytool to export the cert from the jks (alias 1) to a cert.pem to openssl verify
+  }
+
+  public Account findOrRegisterAccount(Session session, KeyPair accountKey) throws AcmeException {
+    URI tos = session.getMetadata().getTermsOfService();
+    if (tos != null) {
+      if (!acceptAgreement(tos)) {
+        throw new AcmeException("Didn't accept terms of service");
+      }
+    }
+    Account account = new AccountBuilder()
+      .agreeToTermsOfService()
+      .useKeyPair(accountKey)
+      .create(session);
+
+    log.info("Registered a new user, URL: {}", account.getLocation());
+    return account;
+  }
+
+  private boolean acceptAgreement(URI agreement) {
+    // TODO(brycew): can we see if we're in an interactive mode?
+    System.out.println("Do you accept the Terms of Service at: " + agreement.toString() + "? (y/n)");
+    Scanner cliScanner = new Scanner(System.in);
+    String userInput = cliScanner.nextLine().toLowerCase();
+    cliScanner.close();
+    if (userInput.equals("y") || userInput.equals("yes")) {
+      return true;
+    } else {
+      System.out.print("Did not accept");
+      return false;
+    }
+  }
+
+  private void authorize(Authorization auth, AcmeChallengePublisher publisher) throws AcmeException {
+    log.info("Authorization for domain: {}", auth.getIdentifier().getDomain());
+
+    if (auth.getStatus() == Status.VALID) {
+      return;
+    }
+
+    Http01Challenge challenge = auth.findChallenge(Http01Challenge.class);
+    if (challenge == null) {
+      throw new AcmeException("Found no " + Http01Challenge.TYPE + " challenge, don't know what to do...");
+    }
+
+    StringBuilder msg = new StringBuilder()
+        .append("Commencing challenge! You must create a file in the server's base directory, at")
+        .append("http://")
+        .append(auth.getIdentifier().getDomain())
+        .append("/.well-known/acme-challenge/")
+        .append(challenge.getToken())
+        .append(", with the content:\n\n")
+        .append(challenge.getAuthorization());
+    log.info(msg.toString());
+    if (publisher != null) {
+      log.info("Adding to server now...");
+      publisher.setTokenContent(challenge);
+    }
+
+    // If the challenge is already verified, there's no need to execute it again.
+    if (challenge.getStatus() == Status.VALID) {
+      return;
+    }
+
+    challenge.trigger();
+
+    try {
+      int attempts = 10;
+      while (challenge.getStatus() != Status.VALID && attempts > 0) {
+        attempts -= 1;
+        if (challenge.getStatus() == Status.INVALID) {
+          log.error("Challenge has failed, reason: {}", challenge.getError());
+          throw new AcmeException("Challenge failed, giving up");
+        }
+
+        Thread.sleep(3000L);
+        challenge.update();
+      }
+    } catch (InterruptedException ex) {
+      log.error("Interrupted", ex);
+      Thread.currentThread().interrupt();
+    }
+
+    if (challenge.getStatus() != Status.VALID) {
+      throw new AcmeException("Failed to pass the challenge for domain " + auth.getIdentifier().getDomain() + ", giving up");
+    }
+
+    log.info("Challenge completed!");
+    publisher.removeTokenContent();
+  }
+
+
+  /** Can be run on it's own: writes the token content to be used in two 
+   * different files that are independently read by the Acme service.
+   * 
+   * Run with `mvn exec:java@AcmeRenewal -Dexec.args="efile.suffolklitlab.edu"`.
+   * @throws AcmeException
+   * @throws IOException */
+  public static void main(String... args) throws IOException, AcmeException {
+    if (args.length == 0) {
+      log.error("Usage: AcmeRenewal <domain>...");
+      System.exit(1);
+    }
+    Security.addProvider(new BouncyCastleProvider());
+    AcmeRenewal renewal = new AcmeRenewal();
+    AcmeChallengePublisher publisher = new AcmeChallengeWriter();
+    renewal.fetchCertificate(Arrays.asList(args), publisher);
+  }
+}

--- a/src/main/java/edu/suffolk/litlab/efspserver/services/EfspServer.java
+++ b/src/main/java/edu/suffolk/litlab/efspserver/services/EfspServer.java
@@ -24,6 +24,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 
+import javax.annotation.Nullable;
 import javax.sql.DataSource;
 import javax.ws.rs.core.MediaType;
 
@@ -186,7 +187,6 @@ public class EfspServer {
     log.info("Starting Server with the following Filers: " + modules);
 
     SecurityHub security = new SecurityHub(userDs, tylerEnv, jurisdictions);
-
     AcmeChallengeService challengeService = null;
     boolean useLetsEncrypt = GetEnv("USE_LETSENCRYPT").map(str -> Boolean.parseBoolean(str)).orElse(false);
     if (useLetsEncrypt) {

--- a/src/main/java/edu/suffolk/litlab/efspserver/services/EfspServer.java
+++ b/src/main/java/edu/suffolk/litlab/efspserver/services/EfspServer.java
@@ -1,5 +1,7 @@
 package edu.suffolk.litlab.efspserver.services;
 
+import static edu.suffolk.litlab.efspserver.services.ServiceHelpers.GetEnv;
+
 import com.fasterxml.jackson.jaxrs.json.JacksonJsonProvider;
 import edu.suffolk.litlab.efspserver.HttpsCallbackHandler;
 import edu.suffolk.litlab.efspserver.SendMessage;
@@ -109,7 +111,7 @@ public class EfspServer {
         new JAXBElementProvider<Object>(),
         new JacksonJsonProvider()));
 
-    String baseLocalUrl = System.getenv("BASE_LOCAL_URL"); //"https://0.0.0.0:9000";
+    String baseLocalUrl = ServiceHelpers.BASE_LOCAL_URL;
     sf.setAddress(baseLocalUrl);
     server = sf.create();
   }
@@ -120,16 +122,6 @@ public class EfspServer {
       server.destroy();
     }
   }
-
-  /** Quick wrapper to get an env var as an optional. */
-  public static Optional<String> GetEnv(String envVarName) {
-    String val = System.getenv(envVarName);
-    if (val == null || val.isBlank()) {
-      return Optional.empty();
-    }
-    return Optional.of(val);
-  }
-
 
   public static void main(String[] args) throws Exception {
     String dbUrl = GetEnv("POSTGRES_URL").orElse("localhost");

--- a/src/main/java/edu/suffolk/litlab/efspserver/services/EndpointReflection.java
+++ b/src/main/java/edu/suffolk/litlab/efspserver/services/EndpointReflection.java
@@ -28,7 +28,7 @@ public class EndpointReflection {
   private final String baseUrl; 
   
   public EndpointReflection(String startUrl) {
-    baseUrl = ServiceHelpers.BASE_URL + startUrl;
+    baseUrl = ServiceHelpers.EXTERNAL_URL + startUrl;
   }
   
   /**

--- a/src/main/java/edu/suffolk/litlab/efspserver/services/PaymentsService.java
+++ b/src/main/java/edu/suffolk/litlab/efspserver/services/PaymentsService.java
@@ -541,7 +541,7 @@ public class PaymentsService {
 
   private final RandomString transactionIdGen;
   private final String togaKey;
-  private final String callbackToUsUrl = ServiceHelpers.BASE_URL + "/payments/toga-account"; 
+  private final String callbackToUsUrl = ServiceHelpers.EXTERNAL_URL + "/payments/toga-account"; 
   private final String togaUrl;
   private final EfmFirmService firmFactory;
   private final DataSource codeDs;

--- a/src/test/java/edu/suffolk/litlab/efspserver/services/CodesServiceTest.java
+++ b/src/test/java/edu/suffolk/litlab/efspserver/services/CodesServiceTest.java
@@ -101,7 +101,7 @@ public class CodesServiceTest {
     client.path(path);
     Response resp = client.get();
     log.info("resp: " + resp);
-    return resp.readEntity(String.class); 
+    return resp.readEntity(String.class);
   }
   
   @Test
@@ -114,47 +114,47 @@ public class CodesServiceTest {
     assertTrue(node.has("getCaseSubtypes"));
     assertTrue(node.has("getPartyTypes"));
   }
-  
+
   @Test
   public void testGetSubCourt() throws JsonMappingException, JsonProcessingException {
     ObjectMapper mapper = new ObjectMapper();
     JsonNode node = mapper.readTree(getServerResponseAt("/courts/adams"));
     assertTrue(node.has("getCourtLocationCodes"), "didn't have court location codes: " + node);
     assertEquals(
-        ServiceHelpers.BASE_URL + "/jurisdictions/illinois/codes/courts/adams/codes",
+        ServiceHelpers.EXTERNAL_URL + "/jurisdictions/illinois/codes/courts/adams/codes",
         node.get("getCourtLocationCodes").get("url").asText());
     assertTrue(node.has("getCaseTypes"));
     assertEquals(
-        ServiceHelpers.BASE_URL + "/jurisdictions/illinois/codes/courts/adams/case_types",
+        ServiceHelpers.EXTERNAL_URL + "/jurisdictions/illinois/codes/courts/adams/case_types",
         node.get("getCaseTypes").get("url").asText());
   }
-  
+
   @Test
   public void testGetCase() throws JsonMappingException, JsonProcessingException {
     ObjectMapper mapper = new ObjectMapper();
     JsonNode node = mapper.readTree(getServerResponseAt("/courts/adams/case_types/1234"));
     assertTrue(node.has("getCaseSubtypes"), "didn't have case sub types: " + node);
     assertEquals(
-        ServiceHelpers.BASE_URL + "/jurisdictions/illinois/codes/courts/adams/case_types/1234/case_subtypes",
+        ServiceHelpers.EXTERNAL_URL + "/jurisdictions/illinois/codes/courts/adams/case_types/1234/case_subtypes",
         node.get("getCaseSubtypes").get("url").asText());
     assertTrue(node.has("getPartyTypes"));
     assertEquals(
-        ServiceHelpers.BASE_URL + "/jurisdictions/illinois/codes/courts/adams/case_types/1234/party_types", 
+        ServiceHelpers.EXTERNAL_URL + "/jurisdictions/illinois/codes/courts/adams/case_types/1234/party_types",
         node.get("getPartyTypes").get("url").asText());
   }
-  
+
   @Test
   public void testGetUnderFilingCode() throws Exception {
     ObjectMapper mapper = new ObjectMapper();
     JsonNode node = mapper.readTree(getServerResponseAt("/courts/adams/filing_types/1234"));
     assertTrue(node.has("getOptionalServices"), "didn't have optionalServices: " + node);
     assertEquals(
-        ServiceHelpers.BASE_URL + "/jurisdictions/illinois/codes/courts/adams/filing_types/1234/optional_services",
-        node.get("getOptionalServices").get("url").asText());
+        ServiceHelpers.EXTERNAL_URL + "/jurisdictions/illinois/codes/courts/adams/filing_types/1234/optional_services",
+          node.get("getOptionalServices").get("url").asText());
     assertTrue(node.has("getFilingComponents"));
     assertEquals(
-        ServiceHelpers.BASE_URL + "/jurisdictions/illinois/codes/courts/adams/filing_types/1234/filing_components",
+        ServiceHelpers.EXTERNAL_URL + "/jurisdictions/illinois/codes/courts/adams/filing_types/1234/filing_components",
         node.get("getFilingComponents").get("url").asText());
   }
-  
+
 }


### PR DESCRIPTION
## ACME support

[ACME (automatic certification management environment)](https://datatracker.ietf.org/doc/html/rfc8555#page-4) is standard that Lets Encrypt uses to automatically generated certificates for your site.  This PR lets you start a cert challenge from a separate program (`AcmeRenewal`), and then detect and publish the token from the main server. Flexible enough that it should be able to run on a timer automatically when you don't have to interactively agree to the terms of service.

Uses acme4j, with most of the `AcmeRenewal` class coming from https://shredzone.org/maven/acme4j/example.html.

Starts progress on #80, though it doesn't finish it; we still need to turn the`.pem` cert into a Java key store file, copy it
to the right place, restart the server so it can use the new cert, and then put the whole thing on a weekly (?, maybe daily?) timer (see the TODOs remaining in `AcmeRenewal`).

## Simplify URL env var passing

No more `BASE_LOCAL_URL` or `CURRENT_URL` env vars: just a single `EXTERNAL_URL` var. The `BASE_LOCAL_URL` java var is determined automatically base on if you are running with HTTPS or not.

Also changes the  docker-compose to use 80 and 443 instead of 9000 externally. I personally am the only person who is routinely running this on the same machine as docassemble, and most of the time you wont want to. If you do, notably, you won't need to separately renew your TLS certs (i.e. the above feature, which is why these separate features are bundled).