### PR TITLE
Spotbug

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -16,3 +16,13 @@ To format all of your files.
 
 (Note: this command might change slightly! If anything unexpected happens, see if the command in the [GitHub Action workflow](.github/workflows/formatting.yml) has changed first.)
 
+## Linting the code
+
+We use [Spotbugs](https://spotbugs.readthedocs.io/en/latest/introduction.html#) as a java linter. To find linter errors, run this:
+
+```bash
+mvn spotbugs:spotbugs
+mvn spotbugs:gui
+```
+
+The later command will open a GUI to see all of the bugs that it's found.

--- a/pom.xml
+++ b/pom.xml
@@ -300,19 +300,18 @@
             <!-- lock down plugins versions to avoid Maven defaults -->
             <plugins>
                 <plugin>
-  <groupId>com.github.spotbugs</groupId>
-  <artifactId>spotbugs-maven-plugin</artifactId>
-  <version>4.7.2.1</version>
-  <dependencies>
-    <!-- overwrite dependency on spotbugs if you want to specify the version of spotbugs -->
-    <dependency>
-      <groupId>com.github.spotbugs</groupId>
-      <artifactId>spotbugs</artifactId>
-      <version>4.7.3</version>
-    </dependency>
-  </dependencies>
-</plugin>
-
+                  <groupId>com.github.spotbugs</groupId>
+                  <artifactId>spotbugs-maven-plugin</artifactId>
+                  <version>4.7.2.1</version>
+                  <dependencies>
+                    <!-- overwrite dependency on spotbugs if you want to specify the version of spotbugs -->
+                    <dependency>
+                      <groupId>com.github.spotbugs</groupId>
+                      <artifactId>spotbugs</artifactId>
+                      <version>4.7.3</version>
+                    </dependency>
+                  </dependencies>
+                </plugin>
                 <plugin>
                     <groupId>biz.lermitage.oga</groupId>
                     <artifactId>oga-maven-plugin</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -300,6 +300,20 @@
             <!-- lock down plugins versions to avoid Maven defaults -->
             <plugins>
                 <plugin>
+  <groupId>com.github.spotbugs</groupId>
+  <artifactId>spotbugs-maven-plugin</artifactId>
+  <version>4.7.2.1</version>
+  <dependencies>
+    <!-- overwrite dependency on spotbugs if you want to specify the version of spotbugs -->
+    <dependency>
+      <groupId>com.github.spotbugs</groupId>
+      <artifactId>spotbugs</artifactId>
+      <version>4.7.3</version>
+    </dependency>
+  </dependencies>
+</plugin>
+
+                <plugin>
                     <groupId>biz.lermitage.oga</groupId>
                     <artifactId>oga-maven-plugin</artifactId>
                     <version>1.7.0</version>

--- a/src/main/java/edu/suffolk/litlab/efspserver/HeaderSigner.java
+++ b/src/main/java/edu/suffolk/litlab/efspserver/HeaderSigner.java
@@ -64,9 +64,10 @@ public class HeaderSigner {
 
   private KeyStore loadKeyStore() throws GeneralSecurityException, IOException {
     KeyStore keystore = KeyStore.getInstance("JKS");
-    InputStream is = new FileInputStream(this.pathToKeystore);
-    keystore.load(is, this.x509Password.toCharArray());
-    return keystore;
+    try (InputStream is = new FileInputStream(this.pathToKeystore)) {
+      keystore.load(is, this.x509Password.toCharArray());
+      return keystore;
+    }
   }
 
   private CMSSignedDataGenerator setUpProvider(final KeyStore keystore)
@@ -78,7 +79,9 @@ public class HeaderSigner {
     final List<Certificate> certlist = new ArrayList<Certificate>();
 
     for (int i = 0, length = certchain == null ? 0 : certchain.length; i < length; i++) {
-      certlist.add(certchain[i]);
+      if (certchain[i] != null) {
+        certlist.add(certchain[i]);
+      }
     }
 
     JcaCertStore certstore = new JcaCertStore(certlist);

--- a/src/main/java/edu/suffolk/litlab/efspserver/LegalIssuesTaxonomyCodes.java
+++ b/src/main/java/edu/suffolk/litlab/efspserver/LegalIssuesTaxonomyCodes.java
@@ -104,7 +104,7 @@ public class LegalIssuesTaxonomyCodes {
    * A very lazy list-based adjacency directed graph implementation. Each node has parents, and
    * children. All nodes are contained in a map in the parent class.
    */
-  class InternalNode {
+  static class InternalNode {
     String code;
     String title;
     String definition;

--- a/src/main/java/edu/suffolk/litlab/efspserver/codes/CodeDatabase.java
+++ b/src/main/java/edu/suffolk/litlab/efspserver/codes/CodeDatabase.java
@@ -907,7 +907,7 @@ public class CodeDatabase implements DatabaseInterface, AutoCloseable {
       return false;
     }
     // TODO(brycew): make variant that deletes everything with a specific jurisdiction
-    String deleteFromTableStr = CodeTableConstants.getDeleteFrom(tableName);
+    final String deleteFromTableStr = CodeTableConstants.getDeleteFrom(tableName);
     boolean tableHasCourt = !deleteFromTableStr.isBlank();
     if (!tableHasCourt) {
       log.warn(

--- a/src/main/java/edu/suffolk/litlab/efspserver/codes/CodeDatabase.java
+++ b/src/main/java/edu/suffolk/litlab/efspserver/codes/CodeDatabase.java
@@ -902,12 +902,12 @@ public class CodeDatabase implements DatabaseInterface, AutoCloseable {
     if (conn == null) {
       throw new SQLException();
     }
-    String deleteFromTableStr = CodeTableConstants.getDeleteFrom(tableName);
     if (courtLocation == null || courtLocation.isBlank()) {
       log.warn("Don't call this without a valid court: just don't use the var");
       return false;
     }
     // TODO(brycew): make variant that deletes everything with a specific jurisdiction
+    String deleteFromTableStr = CodeTableConstants.getDeleteFrom(tableName);
     boolean tableHasCourt = !deleteFromTableStr.isBlank();
     if (!tableHasCourt) {
       log.warn(

--- a/src/main/java/edu/suffolk/litlab/efspserver/codes/CodeUpdater.java
+++ b/src/main/java/edu/suffolk/litlab/efspserver/codes/CodeUpdater.java
@@ -520,7 +520,7 @@ public class CodeUpdater {
       log.error(
           "Need to pass in args: downloadIndiv <jurisdiction> <table> <location or blank for"
               + " system>");
-      System.exit(1);
+      return;
     }
 
     if (!jurisdiction.equalsIgnoreCase(args.get(1))) {

--- a/src/main/java/edu/suffolk/litlab/efspserver/codes/NameAndCode.java
+++ b/src/main/java/edu/suffolk/litlab/efspserver/codes/NameAndCode.java
@@ -18,8 +18,25 @@ public class NameAndCode implements Comparable<NameAndCode> {
   }
 
   @Override
+  public boolean equals(Object obj) {
+    if (obj == null) {
+      return false;
+    }
+    if (obj instanceof NameAndCode otherCode) {
+      return name.equals(otherCode.name) && code.equals(otherCode.code);
+    } else {
+      return false;
+    }
+  }
+
+  @Override
   // < 0 is means this is before arg0, > means after
   public int compareTo(NameAndCode arg0) {
-    return name.compareTo(arg0.name);
+    int val = name.compareTo(arg0.name);
+    if (val != 0) {
+      return val;
+    } else {
+      return code.compareTo(arg0.code);
+    }
   }
 }

--- a/src/main/java/edu/suffolk/litlab/efspserver/codes/NameAndCode.java
+++ b/src/main/java/edu/suffolk/litlab/efspserver/codes/NameAndCode.java
@@ -1,5 +1,7 @@
 package edu.suffolk.litlab.efspserver.codes;
 
+import org.apache.commons.lang3.builder.HashCodeBuilder;
+
 public class NameAndCode implements Comparable<NameAndCode> {
   String name;
   String code;
@@ -27,6 +29,11 @@ public class NameAndCode implements Comparable<NameAndCode> {
     } else {
       return false;
     }
+  }
+
+  @Override
+  public int hashCode() {
+    return (new HashCodeBuilder()).append(name).append(code).build();
   }
 
   @Override

--- a/src/main/java/edu/suffolk/litlab/efspserver/db/DatabaseVersion.java
+++ b/src/main/java/edu/suffolk/litlab/efspserver/db/DatabaseVersion.java
@@ -69,24 +69,27 @@ public class DatabaseVersion {
 
   public boolean setSchemaVersion(int newVersion) throws SQLException {
     String deleteSt = "DELETE FROM schema_version";
-    Statement delete = userConn.createStatement();
-    delete.executeUpdate(deleteSt);
+    try (Statement delete = userConn.createStatement()) {
+      delete.executeUpdate(deleteSt);
+    }
     String insertSt = "INSERT INTO schema_version (version) VALUES (?)";
-    PreparedStatement insert = userConn.prepareStatement(insertSt);
-    insert.setInt(1, newVersion);
-    int retVal = insert.executeUpdate();
-    // Only worked it if inserted 1 row (the new version)
-    return retVal > 0;
+    try (PreparedStatement insert = userConn.prepareStatement(insertSt)) {
+      insert.setInt(1, newVersion);
+      int retVal = insert.executeUpdate();
+      // Only worked it if inserted 1 row (the new version)
+      return retVal > 0;
+    }
   }
 
   public int getSchemaVersion() throws SQLException {
     String select = "SELECT version from schema_version";
-    Statement st = userConn.createStatement();
-    ResultSet rs = st.executeQuery(select);
-    while (rs.next()) {
-      return rs.getInt(1);
+    try (Statement st = userConn.createStatement()) {
+      ResultSet rs = st.executeQuery(select);
+      while (rs.next()) {
+        return rs.getInt(1);
+      }
+      return 0;
     }
-    return 0;
   }
 
   public boolean updateToLatest() throws NoSuchAlgorithmException {

--- a/src/main/java/edu/suffolk/litlab/efspserver/docassemble/FilingDocDocassembleJacksonDeserializer.java
+++ b/src/main/java/edu/suffolk/litlab/efspserver/docassemble/FilingDocDocassembleJacksonDeserializer.java
@@ -10,7 +10,6 @@ import static edu.suffolk.litlab.efspserver.services.FilingError.serverError;
 
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.node.NullNode;
-
 import edu.suffolk.litlab.efspserver.FilingAttachment;
 import edu.suffolk.litlab.efspserver.FilingDoc;
 import edu.suffolk.litlab.efspserver.JsonHelpers;

--- a/src/main/java/edu/suffolk/litlab/efspserver/docassemble/FilingDocDocassembleJacksonDeserializer.java
+++ b/src/main/java/edu/suffolk/litlab/efspserver/docassemble/FilingDocDocassembleJacksonDeserializer.java
@@ -9,6 +9,8 @@ import static edu.suffolk.litlab.efspserver.services.FilingError.malformedInterv
 import static edu.suffolk.litlab.efspserver.services.FilingError.serverError;
 
 import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.node.NullNode;
+
 import edu.suffolk.litlab.efspserver.FilingAttachment;
 import edu.suffolk.litlab.efspserver.FilingDoc;
 import edu.suffolk.litlab.efspserver.JsonHelpers;
@@ -209,6 +211,7 @@ public class FilingDocDocassembleJacksonDeserializer {
       InterviewVariable nameVar =
           collector.requestVar("filename", "The file name of the filing document", "text");
       collector.addRequired(nameVar);
+      filenameNode = NullNode.getInstance();
     }
     String fileName = (filenameNode != null) ? filenameNode.asText("") : "";
     if (!fileName.endsWith(".pdf")) {

--- a/src/main/java/edu/suffolk/litlab/efspserver/docassemble/FilingInformationDocassembleJacksonDeserializer.java
+++ b/src/main/java/edu/suffolk/litlab/efspserver/docassemble/FilingInformationDocassembleJacksonDeserializer.java
@@ -372,12 +372,14 @@ public class FilingInformationDocassembleJacksonDeserializer
           collector.addWrong(
               collector.requestVar(
                   "contact_id", "Service contacts must have a contact id", "text"));
+          contactId = NullNode.getInstance();
         }
         JsonNode serviceType = servObj.get("service_type");
         if (serviceType == null || !serviceType.isTextual()) {
           collector.addWrong(
               collector.requestVar(
                   "service_type", "Service contacts must have a service type code", "text"));
+          serviceType = NullNode.getInstance();
         }
         CaseServiceContact contact =
             new CaseServiceContact(contactId.asText(), serviceType.asText(), realId);

--- a/src/main/java/edu/suffolk/litlab/efspserver/docassemble/NameDocassembleDeserializer.java
+++ b/src/main/java/edu/suffolk/litlab/efspserver/docassemble/NameDocassembleDeserializer.java
@@ -4,7 +4,6 @@ import static edu.suffolk.litlab.efspserver.JsonHelpers.getStringMember;
 
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.node.NullNode;
-
 import edu.suffolk.litlab.efspserver.Name;
 import edu.suffolk.litlab.efspserver.services.FilingError;
 import edu.suffolk.litlab.efspserver.services.InfoCollector;

--- a/src/main/java/edu/suffolk/litlab/efspserver/docassemble/NameDocassembleDeserializer.java
+++ b/src/main/java/edu/suffolk/litlab/efspserver/docassemble/NameDocassembleDeserializer.java
@@ -3,6 +3,8 @@ package edu.suffolk.litlab.efspserver.docassemble;
 import static edu.suffolk.litlab.efspserver.JsonHelpers.getStringMember;
 
 import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.node.NullNode;
+
 import edu.suffolk.litlab.efspserver.Name;
 import edu.suffolk.litlab.efspserver.services.FilingError;
 import edu.suffolk.litlab.efspserver.services.InfoCollector;
@@ -15,6 +17,7 @@ public class NameDocassembleDeserializer {
       InterviewVariable var =
           collector.requestVar("name", "The full name of the person", "IndividualName");
       collector.addRequired(var);
+      node = NullNode.getInstance();
     }
     if (!node.isObject()) {
       FilingError err =

--- a/src/main/java/edu/suffolk/litlab/efspserver/ecf/EcfCaseTypeFactory.java
+++ b/src/main/java/edu/suffolk/litlab/efspserver/ecf/EcfCaseTypeFactory.java
@@ -695,10 +695,10 @@ public class EcfCaseTypeFactory {
     // HACK(brycew): hacky: needed because "fees" querys and "service" put the payment stuff in the
     // tyler Aug, but not the review api.
     if (queryType.equals(QueryType.Fees) || queryType.equals(QueryType.Service)) {
-      //if (info.getPaymentId() == null || info.getPaymentId().isBlank()) {
-        //  collector.addRequired(collector.requestVar("tyler_payment_id", "The ID of the payment
-        // method", "text"));
-      //}
+      // if (info.getPaymentId() == null || info.getPaymentId().isBlank()) {
+      //  collector.addRequired(collector.requestVar("tyler_payment_id", "The ID of the payment
+      // method", "text"));
+      // }
       ecfAug.setProviderCharge(PaymentFactory.makeProviderChargeType(info.getPaymentId()));
     }
 

--- a/src/main/java/edu/suffolk/litlab/efspserver/ecf/EcfCaseTypeFactory.java
+++ b/src/main/java/edu/suffolk/litlab/efspserver/ecf/EcfCaseTypeFactory.java
@@ -695,10 +695,10 @@ public class EcfCaseTypeFactory {
     // HACK(brycew): hacky: needed because "fees" querys and "service" put the payment stuff in the
     // tyler Aug, but not the review api.
     if (queryType.equals(QueryType.Fees) || queryType.equals(QueryType.Service)) {
-      if (info.getPaymentId() == null || info.getPaymentId().isBlank()) {
+      //if (info.getPaymentId() == null || info.getPaymentId().isBlank()) {
         //  collector.addRequired(collector.requestVar("tyler_payment_id", "The ID of the payment
         // method", "text"));
-      }
+      //}
       ecfAug.setProviderCharge(PaymentFactory.makeProviderChargeType(info.getPaymentId()));
     }
 

--- a/src/main/java/edu/suffolk/litlab/efspserver/ecf/OasisEcfFiler.java
+++ b/src/main/java/edu/suffolk/litlab/efspserver/ecf/OasisEcfFiler.java
@@ -490,11 +490,11 @@ public class OasisEcfFiler extends EfmCheckableFilingInterface {
       caseCategoryName = coreAndExisting.caseCategoryName;
       courtName = coreAndExisting.courtName;
       existingCaseTitle = coreAndExisting.existingCaseTitle;
-      if (!queryType.equals(QueryType.Service)
-          && (info.getPaymentId() == null || info.getPaymentId().isBlank())) {
+      //if (!queryType.equals(QueryType.Service)
+      //    && (info.getPaymentId() == null || info.getPaymentId().isBlank())) {
         //  collector.addRequired(collector.requestVar("tyler_payment_id", "The ID of the payment
         // method", "text"));
-      }
+      //}
     } catch (FilingError err) {
       return Result.err(err);
     }

--- a/src/main/java/edu/suffolk/litlab/efspserver/ecf/OasisEcfFiler.java
+++ b/src/main/java/edu/suffolk/litlab/efspserver/ecf/OasisEcfFiler.java
@@ -490,11 +490,11 @@ public class OasisEcfFiler extends EfmCheckableFilingInterface {
       caseCategoryName = coreAndExisting.caseCategoryName;
       courtName = coreAndExisting.courtName;
       existingCaseTitle = coreAndExisting.existingCaseTitle;
-      //if (!queryType.equals(QueryType.Service)
+      // if (!queryType.equals(QueryType.Service)
       //    && (info.getPaymentId() == null || info.getPaymentId().isBlank())) {
-        //  collector.addRequired(collector.requestVar("tyler_payment_id", "The ID of the payment
-        // method", "text"));
-      //}
+      //  collector.addRequired(collector.requestVar("tyler_payment_id", "The ID of the payment
+      // method", "text"));
+      // }
     } catch (FilingError err) {
       return Result.err(err);
     }

--- a/src/main/java/edu/suffolk/litlab/efspserver/ecf/OasisEcfv5WsCallback.java
+++ b/src/main/java/edu/suffolk/litlab/efspserver/ecf/OasisEcfv5WsCallback.java
@@ -325,8 +325,8 @@ public class OasisEcfv5WsCallback implements FilingAssemblyMDE {
     CredentialsAuthenticatedCodeType act = new CredentialsAuthenticatedCodeType();
     act.setValue(CredentialsAuthenticatedCodeSimpleType.AUTHENTICATED);
     st.setCredentialsAuthenticatedCode(act);
-    SystemOperatingModeCodeType mct = new SystemOperatingModeCodeType();
-    mct.setValue(SystemOperatingModeCodeSimpleType.OPS);
+    //SystemOperatingModeCodeType mct = new SystemOperatingModeCodeType();
+    //mct.setValue(SystemOperatingModeCodeSimpleType.OPS);
     var statusFac = new gov.niem.release.niem.domains.cbrn._4.ObjectFactory();
     st.setSystemOperatingModeAbstract(statusFac.createCredentialsAuthenticatedCode(act));
     st.setResendRequestIndicator(Ecfv5XmlHelper.convertBool(false));

--- a/src/main/java/edu/suffolk/litlab/efspserver/ecf/OasisEcfv5WsCallback.java
+++ b/src/main/java/edu/suffolk/litlab/efspserver/ecf/OasisEcfv5WsCallback.java
@@ -12,8 +12,6 @@ import gov.niem.release.niem.codes.cbrncl._4.CredentialsAuthenticatedCodeSimpleT
 import gov.niem.release.niem.codes.cbrncl._4.CredentialsAuthenticatedCodeType;
 import gov.niem.release.niem.codes.cbrncl._4.MessageStatusCodeSimpleType;
 import gov.niem.release.niem.codes.cbrncl._4.MessageStatusCodeType;
-import gov.niem.release.niem.codes.cbrncl._4.SystemOperatingModeCodeSimpleType;
-import gov.niem.release.niem.codes.cbrncl._4.SystemOperatingModeCodeType;
 import gov.niem.release.niem.domains.cbrn._4.MessageContentErrorType;
 import gov.niem.release.niem.domains.cbrn._4.MessageErrorType;
 import gov.niem.release.niem.domains.cbrn._4.MessageStatusType;
@@ -325,8 +323,8 @@ public class OasisEcfv5WsCallback implements FilingAssemblyMDE {
     CredentialsAuthenticatedCodeType act = new CredentialsAuthenticatedCodeType();
     act.setValue(CredentialsAuthenticatedCodeSimpleType.AUTHENTICATED);
     st.setCredentialsAuthenticatedCode(act);
-    //SystemOperatingModeCodeType mct = new SystemOperatingModeCodeType();
-    //mct.setValue(SystemOperatingModeCodeSimpleType.OPS);
+    // SystemOperatingModeCodeType mct = new SystemOperatingModeCodeType();
+    // mct.setValue(SystemOperatingModeCodeSimpleType.OPS);
     var statusFac = new gov.niem.release.niem.domains.cbrn._4.ObjectFactory();
     st.setSystemOperatingModeAbstract(statusFac.createCredentialsAuthenticatedCode(act));
     st.setResendRequestIndicator(Ecfv5XmlHelper.convertBool(false));

--- a/src/main/java/edu/suffolk/litlab/efspserver/services/AcmeRenewal.java
+++ b/src/main/java/edu/suffolk/litlab/efspserver/services/AcmeRenewal.java
@@ -95,7 +95,9 @@ public class AcmeRenewal {
   }
 
   private static KeyPair loadOrCreateUserKeyPair() throws IOException {
-    USER_KEY_FILE.getParentFile().mkdirs();
+    if (!USER_KEY_FILE.getParentFile().mkdirs()) {
+      throw new IOException("Can't make " + USER_KEY_FILE + " directory");
+    }
     if (USER_KEY_FILE.exists()) {
       try (FileReader fr = new FileReader(USER_KEY_FILE)) {
         return KeyPairUtils.readKeyPair(fr);

--- a/src/main/java/edu/suffolk/litlab/efspserver/services/EndpointReflection.java
+++ b/src/main/java/edu/suffolk/litlab/efspserver/services/EndpointReflection.java
@@ -215,7 +215,7 @@ public class EndpointReflection {
     PAYLOAD
   }
 
-  public class Endpoint {
+  public static class Endpoint {
     String uri;
     MethodEnum method;
 
@@ -232,7 +232,7 @@ public class EndpointReflection {
     }
   }
 
-  public class EndpointParameter {
+  public static class EndpointParameter {
     ParameterType parameterType = ParameterType.PAYLOAD;
     String javaType;
     String defaultValue;

--- a/src/main/java/edu/suffolk/litlab/efspserver/services/RootService.java
+++ b/src/main/java/edu/suffolk/litlab/efspserver/services/RootService.java
@@ -32,8 +32,8 @@ public class RootService {
   @Produces(MediaType.APPLICATION_JSON)
   public Response getVersionInfo() {
     final var properties = new Properties();
-    try {
-      properties.load(RootService.class.getResourceAsStream("/version.properties"));
+    try (var is = RootService.class.getResourceAsStream("/version.properties")) {
+      properties.load(is);
       return Response.ok("{\"version\": \"" + properties.getProperty("version") + "\"}").build();
     } catch (IOException e) {
       return Response.status(500).entity("Could not load version info").build();

--- a/src/main/java/https/docs_oasis_open_org/legalxml_courtfiling/ns/v5_0/wsdl/filingassemblymde/FilingAssemblyMDE_FilingAssemblyMDEPort_Client.java
+++ b/src/main/java/https/docs_oasis_open_org/legalxml_courtfiling/ns/v5_0/wsdl/filingassemblymde/FilingAssemblyMDE_FilingAssemblyMDEPort_Client.java
@@ -54,8 +54,8 @@ public final class FilingAssemblyMDE_FilingAssemblyMDEPort_Client {
         {
         System.out.println("Invoking notifyFilingReviewComplete...");
         https.docs_oasis_open_org.legalxml_courtfiling.ns.v5_0.messagewrappers.NotifyFilingReviewCompleteRequestType _notifyFilingReviewComplete_body = null;
-        https.docs_oasis_open_org.legalxml_courtfiling.ns.v5_0.messagewrappers.NotifyFilingReviewCompleteResponseType _notifyFilingReviewComplete__return = port.notifyFilingReviewComplete(_notifyFilingReviewComplete_body);
-        System.out.println("notifyFilingReviewComplete.result=" + _notifyFilingReviewComplete__return);
+        //ecfv5.https.docs_oasis_open_org.legalxml_courtfiling.ns.v5_0.messagewrappers.NotifyFilingReviewCompleteResponseType _notifyFilingReviewComplete__return = port.notifyFilingReviewComplete(_notifyFilingReviewComplete_body);
+        //System.out.println("notifyFilingReviewComplete.result=" + _notifyFilingReviewComplete__return);
 
 
         }


### PR DESCRIPTION
Spotbug is a java linter. IMO, we need a java linter, since:
* as a team, we don't have a ton of java knowledge about best practices
* I know a bit of java best practices, but am not used to handling repos of this size solo
* anything we can do to reduce anxiety about existing bugs in the code and making new releases, I want to do
* I will one day leave

I didn't fix all of the found spotbugs because:
* there are quite a few
* many are in autogenerated code
* some would require pretty substantial changes
* I just don't agree with some. I use capitalized static methods as constructors sometimes (`MyClass.SpecialConstructor`), so I can return `Optional.empty` if need be, and now have throw exceptions. Capitalizing those makes more sense to me, as they are acting as constructors, and not as methods.

This is fine; I'll keep using this as need be, and won't integrate into the CI just yet. It would have to be something more than a "pass/fail" workflow, and would need to be closer to coverage (you're this much better!), which is a bit more complicated than what I've done so far, and would need to research it.

To run spotbug, just use `mvn spotbugs:spotbugs`. After that finishes, you can view the linter errors and warnings in a gui with `mvn spotbugs:gui`. 