### PR TITLE
Verify acme email

### DIFF
--- a/src/main/java/edu/suffolk/litlab/efspserver/services/AcmeRenewal.java
+++ b/src/main/java/edu/suffolk/litlab/efspserver/services/AcmeRenewal.java
@@ -95,8 +95,9 @@ public class AcmeRenewal {
   }
 
   private static KeyPair loadOrCreateUserKeyPair() throws IOException {
-    if (!USER_KEY_FILE.getParentFile().mkdirs()) {
-      throw new IOException("Can't make " + USER_KEY_FILE + " directory");
+    USER_KEY_FILE.getParentFile().mkdirs();
+    if (!USER_KEY_FILE.getParentFile().exists()) {
+      throw new IOException("Could not create the parent file, " + USER_KEY_FILE.getParentFile());
     }
     if (USER_KEY_FILE.exists()) {
       try (FileReader fr = new FileReader(USER_KEY_FILE)) {

--- a/src/main/java/edu/suffolk/litlab/efspserver/services/AcmeRenewal.java
+++ b/src/main/java/edu/suffolk/litlab/efspserver/services/AcmeRenewal.java
@@ -194,11 +194,17 @@ public class AcmeRenewal {
     AccountBuilder ab = new AccountBuilder().agreeToTermsOfService().useKeyPair(accountKey);
     String email = System.getenv("TYLER_USER_EMAIL");
     if (email != null && !email.isBlank()) {
+      log.info("Using " + email + " for account and contact email");
       ab.addEmail(email);
     }
     Account account = ab.create(session);
+    if (email != null && !email.isBlank()) {
+      if (!account.getContacts().stream().anyMatch(con -> con.toString().equals("mailto:" + email))) {
+        account.modify().addEmail(email).commit();
+      }
+    }
 
-    log.info("Registered a new user, URL: {}", account.getLocation());
+    log.info("Registered a new user, URL: {}, contacts: {}", account.getLocation(), account.getContacts().toString());
     return account;
   }
 

--- a/src/main/java/edu/suffolk/litlab/efspserver/services/AcmeRenewal.java
+++ b/src/main/java/edu/suffolk/litlab/efspserver/services/AcmeRenewal.java
@@ -9,6 +9,8 @@ import java.io.FileWriter;
 import java.io.IOException;
 import java.io.Writer;
 import java.net.URI;
+import java.net.URL;
+import java.nio.file.Files;
 import java.security.KeyFactory;
 import java.security.KeyPair;
 import java.security.KeyStore;
@@ -35,6 +37,7 @@ import org.shredzone.acme4j.Account;
 import org.shredzone.acme4j.AccountBuilder;
 import org.shredzone.acme4j.Authorization;
 import org.shredzone.acme4j.Certificate;
+import org.shredzone.acme4j.Login;
 import org.shredzone.acme4j.Order;
 import org.shredzone.acme4j.Session;
 import org.shredzone.acme4j.Status;
@@ -70,6 +73,7 @@ public class AcmeRenewal {
    * certificates. So we save these certs outside the container to the volume, if it's present.
    */
   private static final File USER_KEY_FILE;
+  private static final File ACCOUNT_URL_FILE;
 
   private static final File DOMAIN_KEY_FILE;
   private static final File DOMAIN_CSR_FILE;
@@ -88,6 +92,7 @@ public class AcmeRenewal {
               + "), only saving cert files inside container!");
     }
     USER_KEY_FILE = new File(prefix + "acme_user.key");
+    ACCOUNT_URL_FILE = new File(prefix = "account_url.txt");
     DOMAIN_KEY_FILE = new File(prefix + "acme_domain.key");
     DOMAIN_CSR_FILE = new File(prefix + "acme_domain.csr");
     DOMAIN_CHAIN_FILE = new File(prefix + "acme_domain-chain.crt");
@@ -186,26 +191,41 @@ public class AcmeRenewal {
   }
 
   public Account findOrRegisterAccount(Session session, KeyPair accountKey) throws AcmeException {
-    URI tos = session.getMetadata().getTermsOfService();
-    if (tos != null) {
-      if (!acceptAgreement(tos)) {
-        throw new AcmeException("Didn't accept terms of service");
-      }
-    }
-    AccountBuilder ab = new AccountBuilder().agreeToTermsOfService().useKeyPair(accountKey);
+    Login login = null;
     String email = System.getenv("TYLER_USER_EMAIL");
-    if (email != null && !email.isBlank()) {
-      log.info("Using " + email + " for account and contact email");
-      ab.addEmail(email);
+    try {
+      String accountUrlStr = Files.readString(ACCOUNT_URL_FILE.toPath());
+      login = session.login(new URL(accountUrlStr), accountKey);
+      log.info("Using existing user, URL: {}", login.getAccountLocation());
+    } catch (IOException ex) {
+      URI tos = session.getMetadata().getTermsOfService();
+      if (tos != null) {
+        if (!acceptAgreement(tos)) {
+          throw new AcmeException("Didn't accept terms of service");
+        }
+      }
+      AccountBuilder ab = new AccountBuilder().agreeToTermsOfService().useKeyPair(accountKey);
+      if (email != null && !email.isBlank()) {
+        log.info("Using " + email + " for account and contact email");
+        ab.addEmail(email);
+      }
+      login = ab.createLogin(session);
+
+      log.info("Registering new user, URL: {}", login.getAccountLocation());
     }
-    Account account = ab.create(session);
+    URL accountUrl = login.getAccountLocation();
+    try {
+      Files.writeString(ACCOUNT_URL_FILE.toPath(), accountUrl.toString());
+    } catch (IOException ex) {
+      log.info("Unable to write out account URL! Please save the text '" + accountUrl.toString() + "' in a file named `account_url.txt`, next to `acme_user.key`");
+    }
+    Account account = login.getAccount();
     if (email != null && !email.isBlank()) {
       if (!account.getContacts().stream().anyMatch(con -> con.toString().equals("mailto:" + email))) {
         account.modify().addEmail(email).commit();
       }
     }
-
-    log.info("Registered a new user, URL: {}, contacts: {}", account.getLocation(), account.getContacts().toString());
+    log.info("Got user, URL: {}, contacts: {}", account.getLocation(), account.getContacts().toString());
     return account;
   }
 

--- a/src/main/java/edu/suffolk/litlab/efspserver/services/AcmeRenewal.java
+++ b/src/main/java/edu/suffolk/litlab/efspserver/services/AcmeRenewal.java
@@ -92,7 +92,7 @@ public class AcmeRenewal {
               + "), only saving cert files inside container!");
     }
     USER_KEY_FILE = new File(prefix + "acme_user.key");
-    ACCOUNT_URL_FILE = new File(prefix = "account_url.txt");
+    ACCOUNT_URL_FILE = new File(prefix + "account_url.txt");
     DOMAIN_KEY_FILE = new File(prefix + "acme_domain.key");
     DOMAIN_CSR_FILE = new File(prefix + "acme_domain.csr");
     DOMAIN_CHAIN_FILE = new File(prefix + "acme_domain-chain.crt");

--- a/src/main/java/edu/suffolk/litlab/efspserver/services/AcmeRenewal.java
+++ b/src/main/java/edu/suffolk/litlab/efspserver/services/AcmeRenewal.java
@@ -73,6 +73,7 @@ public class AcmeRenewal {
    * certificates. So we save these certs outside the container to the volume, if it's present.
    */
   private static final File USER_KEY_FILE;
+
   private static final File ACCOUNT_URL_FILE;
 
   private static final File DOMAIN_KEY_FILE;
@@ -217,15 +218,20 @@ public class AcmeRenewal {
     try {
       Files.writeString(ACCOUNT_URL_FILE.toPath(), accountUrl.toString());
     } catch (IOException ex) {
-      log.info("Unable to write out account URL! Please save the text '" + accountUrl.toString() + "' in a file named `account_url.txt`, next to `acme_user.key`");
+      log.info(
+          "Unable to write out account URL! Please save the text '"
+              + accountUrl.toString()
+              + "' in a file named `account_url.txt`, next to `acme_user.key`");
     }
     Account account = login.getAccount();
     if (email != null && !email.isBlank()) {
-      if (!account.getContacts().stream().anyMatch(con -> con.toString().equals("mailto:" + email))) {
+      if (!account.getContacts().stream()
+          .anyMatch(con -> con.toString().equals("mailto:" + email))) {
         account.modify().addEmail(email).commit();
       }
     }
-    log.info("Got user, URL: {}, contacts: {}", account.getLocation(), account.getContacts().toString());
+    log.info(
+        "Got user, URL: {}, contacts: {}", account.getLocation(), account.getContacts().toString());
     return account;
   }
 


### PR DESCRIPTION
I've had some issues with not getting LetEncrypt emails, and I really tried to see if there was any issues with how I was using the `acme4j` client, but I couldn't find anything wrong; we're already giving LetsEncrypt our email, so it should be working. Idk. I did [re-read the acme4j docs](https://shredzone.org/maven/acme4j/usage/login.html) and found some improvements that I could make, so I did. But nothing big got fixed from this. :( 