### PR TITLE
Explicitly re-enabled docker tests on GH

### DIFF
--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -14,4 +14,4 @@ jobs:
           java-version: '17'
           distribution: 'adopt'
       - name: Build with Maven
-        run: mvn --batch-mode package -PnoDockerTests
+        run: mvn --batch-mode package


### PR DESCRIPTION
It looks like they were always running (no change in run time from https://github.com/SuffolkLITLab/EfileProxyServer/actions/runs/4993977574/jobs/8943863879). But idk, they should be on anyway. 