### PR TITLE
Smaller codes DB tables

### DIFF
--- a/src/main/java/edu/suffolk/litlab/efspserver/codes/CodeDatabase.java
+++ b/src/main/java/edu/suffolk/litlab/efspserver/codes/CodeDatabase.java
@@ -950,6 +950,7 @@ public class CodeDatabase implements DatabaseInterface, AutoCloseable {
     }
     if (tableName.equals("optionalservices")) {
       OptionalServiceCode.deleteFromOptionalServiceTable(courtLocation, tylerDomain, conn);
+      return true;
     }
     // TODO(brycew): make variant that deletes everything with a specific jurisdiction
     final String deleteFromTableStr = CodeTableConstants.getDeleteFrom(tableName);

--- a/src/main/java/edu/suffolk/litlab/efspserver/codes/CodeDatabase.java
+++ b/src/main/java/edu/suffolk/litlab/efspserver/codes/CodeDatabase.java
@@ -454,15 +454,15 @@ public class CodeDatabase implements DatabaseInterface, AutoCloseable {
             new DataFieldRow(
                 rs.getString(1),
                 rs.getString(2),
-                rs.getString(3),
-                rs.getString(4),
+                rs.getBoolean(3),
+                rs.getBoolean(4),
                 rs.getString(5),
                 rs.getString(6),
                 rs.getString(7),
                 rs.getString(8),
                 rs.getString(9),
                 rs.getString(10),
-                rs.getString(11),
+                rs.getBoolean(11),
                 rs.getString(12));
         dataFieldMap.put(dfr.code, dfr);
       }

--- a/src/main/java/edu/suffolk/litlab/efspserver/codes/CodeDatabase.java
+++ b/src/main/java/edu/suffolk/litlab/efspserver/codes/CodeDatabase.java
@@ -83,7 +83,6 @@ public class CodeDatabase implements DatabaseInterface, AutoCloseable {
   }
 
   public void createTableIfAbsent(String tableName) throws SQLException {
-    log.info("Start of creatTableIfAbsent: {}", tableName);
     if (conn == null) {
       throw new SQLException();
     }

--- a/src/main/java/edu/suffolk/litlab/efspserver/codes/CodeDatabase.java
+++ b/src/main/java/edu/suffolk/litlab/efspserver/codes/CodeDatabase.java
@@ -397,15 +397,15 @@ public class CodeDatabase implements DatabaseInterface, AutoCloseable {
           new DataFieldRow(
               rs.getString(1),
               rs.getString(2),
-              rs.getString(3),
-              rs.getString(4),
+              rs.getBoolean(3),
+              rs.getBoolean(4),
               rs.getString(5),
               rs.getString(6),
               rs.getString(7),
               rs.getString(8),
               rs.getString(9),
               rs.getString(10),
-              rs.getString(11),
+              rs.getBoolean(11),
               rs.getString(12));
       return dfr;
     } catch (SQLException ex) {

--- a/src/main/java/edu/suffolk/litlab/efspserver/codes/CodeTableConstants.java
+++ b/src/main/java/edu/suffolk/litlab/efspserver/codes/CodeTableConstants.java
@@ -17,7 +17,7 @@ public class CodeTableConstants {
   private static final Map<String, String> createQueries = new HashMap<>();
   private static final Map<String, String> insertQueries = new HashMap<>();
   private static final Map<String, String> deleteFromQueries = new HashMap<>();
-  private static final Map<String, String> deleteAllJurisdictionFromQueries = new HashMap<>();
+  private static final Map<String, String> deleteAllCourtsFromQueries = new HashMap<>();
 
   static {
     List<Pair<String, String>> locationColumns = new ArrayList<Pair<String, String>>();
@@ -93,17 +93,17 @@ public class CodeTableConstants {
           new ImmutablePair<String, String>("code", "text"),
           new ImmutablePair<String, String>("name", "text")))),
         Map.entry("datafieldconfig", makeCourtColumnInfo(List.of(
-          new ImmutablePair<String, String>("code", "text"),
+          new ImmutablePair<String, String>("code", "varchar(40)"),
           new ImmutablePair<String, String>("name", "text"), 
-          new ImmutablePair<String, String>("isvisible", "text"),
-          new ImmutablePair<String, String>("isrequired", "text"), 
+          new ImmutablePair<String, String>("isvisible", "boolean"),
+          new ImmutablePair<String, String>("isrequired", "boolean"), 
           new ImmutablePair<String, String>("helptext", "text"),
           new ImmutablePair<String, String>("ghosttext", "text"),
           new ImmutablePair<String, String>("contextualhelpdata", "text"),
           new ImmutablePair<String, String>("validationmessage", "text"),
           new ImmutablePair<String, String>("regularexpression", "text"),
           new ImmutablePair<String, String>("defaultvalueexpression", "text"),
-          new ImmutablePair<String, String>("isreadonly", "text")))),
+          new ImmutablePair<String, String>("isreadonly", "boolean")))),
         ///////// Tables for courts specifically
         Map.entry("answer", makeCourtColumnInfo(List.of(
           new ImmutablePair<String, String>("code", "text"),
@@ -134,7 +134,7 @@ public class CodeTableConstants {
           new ImmutablePair<String, String>("casetypeid", "text"),
           new ImmutablePair<String, String>("efspcode", "text")))),
         Map.entry("casetype", makeCourtColumnInfo(List.of(
-          new ImmutablePair<String, String>("code", "text"),
+          new ImmutablePair<String, String>("code", "varchar(40)"),
           new ImmutablePair<String, String>("name", "text"),
           new ImmutablePair<String, String>("casecategory", "text"),
           new ImmutablePair<String, String>("initial", "text"),
@@ -204,26 +204,26 @@ public class CodeTableConstants {
           new ImmutablePair<String, String>("extension", "text"),
           new ImmutablePair<String, String>("efspcode", "text")))),
         Map.entry("filing", makeCourtColumnInfo(List.of(
-          new ImmutablePair<String, String>("code", "text"), 
+          new ImmutablePair<String, String>("code", "varchar(40)"), 
           new ImmutablePair<String, String>("name", "text"),
-          new ImmutablePair<String, String>("fee", "text"), 
+          new ImmutablePair<String, String>("fee", "text"),
           new ImmutablePair<String, String>("casecategory", "text"),
           new ImmutablePair<String, String>("casetypeid", "text"),
           new ImmutablePair<String, String>("filingtype", "text"),
-          new ImmutablePair<String, String>("iscourtuseonly", "text"),
+          new ImmutablePair<String, String>("iscourtuseonly", "boolean"),
           new ImmutablePair<String, String>("civilclaimamount", "text"),
           new ImmutablePair<String, String>("probateestateamount", "text"),
           new ImmutablePair<String, String>("amountincontroversy", "text"),
-          new ImmutablePair<String, String>("useduedate", "text"),
-          new ImmutablePair<String, String>("isproposedorder", "text"),
+          new ImmutablePair<String, String>("useduedate", "boolean"),
+          new ImmutablePair<String, String>("isproposedorder", "boolean"),
           new ImmutablePair<String, String>("efspcode", "text")))),
         Map.entry("filingcomponent", makeCourtColumnInfo(List.of(
-          new ImmutablePair<>("code", "text"), 
+          new ImmutablePair<>("code", "varchar(40)"), 
           new ImmutablePair<>("name", "text"),
-          new ImmutablePair<>("filingcodeid", "text"),
-          new ImmutablePair<>("required", "text"),
-          new ImmutablePair<>("allowmultiple", "text"),
-          new ImmutablePair<>("displayorder", "text"),
+          new ImmutablePair<>("filingcodeid", "varchar(40)"),
+          new ImmutablePair<>("required", "boolean"),
+          new ImmutablePair<>("allowmultiple", "boolean"),
+          new ImmutablePair<>("displayorder", "integer"),
           new ImmutablePair<>("efspcode", "text")))),
         Map.entry("generaloffense", makeCourtColumnInfo(List.of(
           new ImmutablePair<>("code", "text"), 
@@ -252,22 +252,22 @@ public class CodeTableConstants {
           new ImmutablePair<String, String>("name", "text"), 
           new ImmutablePair<String, String>("efspcode", "text")))),
         Map.entry("optionalservices", makeCourtColumnInfo(List.of(
-          new ImmutablePair<String, String>("code", "text"), 
+          new ImmutablePair<String, String>("code", "varchar(40)"),
           new ImmutablePair<String, String>("name", "text"),
-          new ImmutablePair<String, String>("displayorder", "text"), 
+          new ImmutablePair<String, String>("displayorder", "integer"), 
           new ImmutablePair<String, String>("fee", "text"),
-          new ImmutablePair<String, String>("filingcodeid", "text"),
-          new ImmutablePair<String, String>("multiplier", "text"),
+          //new ImmutablePair<String, String>("filingcodeid", "varchar(40)"),
+          new ImmutablePair<String, String>("multiplier", "boolean"),
           new ImmutablePair<String, String>("altfeedesc", "text"),
-          new ImmutablePair<String, String>("hasfeeprompt", "text"),
+          new ImmutablePair<String, String>("hasfeeprompt", "boolean"),
           new ImmutablePair<String, String>("feeprompttext", "text"),
           new ImmutablePair<String, String>("efspcode", "text")))),
         Map.entry("partytype", makeCourtColumnInfo(List.of(
-          new ImmutablePair<String, String>("code", "text"), 
+          new ImmutablePair<String, String>("code", "varchar(40)"), 
           new ImmutablePair<String, String>("name", "text"),
-          new ImmutablePair<String, String>("isavailablefornewparties", "text"),
+          new ImmutablePair<String, String>("isavailablefornewparties", "boolean"),
           new ImmutablePair<String, String>("casetypeid", "text"),
-          new ImmutablePair<String, String>("isrequired", "text"),
+          new ImmutablePair<String, String>("isrequired", "boolean"),
           new ImmutablePair<String, String>("amount", "text"),
           new ImmutablePair<String, String>("numberofpartiestoignore", "text"),
           new ImmutablePair<String, String>("sendforredaction", "text"),
@@ -330,22 +330,21 @@ public class CodeTableConstants {
     for (Map.Entry<String, TableColumns> table : tableColumns.entrySet()) {
       createQueries.put(table.getKey(), createTableQuery(table.getKey(), table.getValue()));
       insertQueries.put(table.getKey(), createInsertQuery(table.getKey(), table.getValue()));
-      deleteAllJurisdictionFromQueries.put(table.getKey(), "DELETE FROM " + table.getKey() + " WHERE domain=?");
+      deleteAllCourtsFromQueries.put(table.getKey(), "DELETE FROM " + table.getKey() + " WHERE domain=?");
       if (table.getValue().needsExtraLocCol) {
         deleteFromQueries.put(table.getKey(), "DELETE FROM " + table.getKey() + " WHERE domain=? AND location=?");
       }
     }
     
-    tableIndices.put("optionalservices", List.of(
-        "CREATE INDEX ON optionalservices (location)",
-        "CREATE INDEX ON optionalservices (filingcodeid)"));
     tableIndices.put("filing", List.of(
         "CREATE INDEX ON filing (location)",
         "CREATE INDEX ON filing (casecategory)",
-        "CREATE INDEX ON filing (casetypeid)")); 
+        "CREATE INDEX ON filing (casetypeid)",
+        "CREATE INDEX ON filing (domain)"));
     tableIndices.put("filingcomponent", List.of(
         "CREATE INDEX ON filingcomponent (location)", 
-        "CREATE INDEX ON filingcomponent (filingcodeid)")); 
+        "CREATE INDEX ON filingcomponent (filingcodeid)",
+        "CREATE INDEX ON filingcomponent (domain)")); 
   }
 
   public static String getZipNameFromTable(String tableName) {
@@ -388,6 +387,10 @@ public class CodeTableConstants {
     // Drops the type in the column name + type pairs.
     return tableColumns.getOrDefault(tableName, new TableColumns())
         .mainList.stream().map((e) -> e.getLeft()).collect(Collectors.toList());
+  }
+
+  public static List<Pair<String, String>> getTableColumnsWithType(String tableName) {
+    return tableColumns.getOrDefault(tableName, new TableColumns()).mainList;
   }
   
   public static boolean isCourtTable(String tableName) {
@@ -491,11 +494,11 @@ public class CodeTableConstants {
     return deleteFromQueries.get(tableName);
   }
 
-  public static String getDeleteAllJurisdictionFrom(String tableName) {
-    if (!deleteAllJurisdictionFromQueries.containsKey(tableName)) {
+  public static String getDeleteAllCourtsFrom(String tableName) {
+    if (!deleteAllCourtsFromQueries.containsKey(tableName)) {
       return "";
     }
-    return deleteAllJurisdictionFromQueries.get(tableName);
+    return deleteAllCourtsFromQueries.get(tableName);
   }
 
   /**
@@ -551,9 +554,9 @@ public class CodeTableConstants {
       createLocation.append("\"" + col.getLeft() + "\" " + col.getRight());
     }
     if (tc.needsExtraLocCol) {
-      createLocation.append(", \"location\" text");
+      createLocation.append(", \"location\" varchar(80)");
     }
-    createLocation.append(", \"domain\" text");
+    createLocation.append(", \"domain\" varchar(80)");
 
     if (!tc.primaryKeys.isEmpty()) {
       createLocation.append(

--- a/src/main/java/edu/suffolk/litlab/efspserver/codes/CodeTableConstants.java
+++ b/src/main/java/edu/suffolk/litlab/efspserver/codes/CodeTableConstants.java
@@ -251,17 +251,6 @@ public class CodeTableConstants {
           new ImmutablePair<String, String>("code", "text"),
           new ImmutablePair<String, String>("name", "text"), 
           new ImmutablePair<String, String>("efspcode", "text")))),
-        Map.entry("optionalservices", makeCourtColumnInfo(List.of(
-          new ImmutablePair<String, String>("code", "varchar(40)"),
-          new ImmutablePair<String, String>("name", "text"),
-          new ImmutablePair<String, String>("displayorder", "integer"), 
-          new ImmutablePair<String, String>("fee", "text"),
-          //new ImmutablePair<String, String>("filingcodeid", "varchar(40)"),
-          new ImmutablePair<String, String>("multiplier", "boolean"),
-          new ImmutablePair<String, String>("altfeedesc", "text"),
-          new ImmutablePair<String, String>("hasfeeprompt", "boolean"),
-          new ImmutablePair<String, String>("feeprompttext", "text"),
-          new ImmutablePair<String, String>("efspcode", "text")))),
         Map.entry("partytype", makeCourtColumnInfo(List.of(
           new ImmutablePair<String, String>("code", "varchar(40)"), 
           new ImmutablePair<String, String>("name", "text"),

--- a/src/main/java/edu/suffolk/litlab/efspserver/codes/DataFieldRow.java
+++ b/src/main/java/edu/suffolk/litlab/efspserver/codes/DataFieldRow.java
@@ -14,27 +14,27 @@ public class DataFieldRow {
   public String validationmessage;
   public Pattern regularexpression;
   public String defaultvalueexpression;
-  public String isreadonly;
+  public boolean isreadonly;
   public String location;
 
   /** Constructor directly from Database. */
   public DataFieldRow(
       String code,
       String name,
-      String isvisible,
-      String isrequired,
+      boolean isvisible,
+      boolean isrequired,
       String helptext,
       String ghosttext,
       String contextualhelpdata,
       String validationmessage,
       String regularexpression,
       String defaultvalueexpression,
-      String isreadonly,
+      boolean isreadonly,
       String location) {
     this.code = code;
     this.name = name;
-    this.isvisible = Boolean.parseBoolean(isvisible);
-    this.isrequired = Boolean.parseBoolean(isrequired);
+    this.isvisible = isvisible;
+    this.isrequired = isrequired;
     this.helptext = helptext;
     this.ghosttext = ghosttext;
     this.contextualhelpdata = contextualhelpdata;
@@ -56,7 +56,7 @@ public class DataFieldRow {
    * @return
    */
   public static DataFieldRow MissingDataField(String name) {
-    return new DataFieldRow("", name, "false", "false", "", "", "", "", "", "", "", "");
+    return new DataFieldRow("", name, false, false, "", "", "", "", "", "", false, "");
   }
 
   public boolean matchRegex(String value) {

--- a/src/main/java/edu/suffolk/litlab/efspserver/codes/FilingCode.java
+++ b/src/main/java/edu/suffolk/litlab/efspserver/codes/FilingCode.java
@@ -24,21 +24,21 @@ public class FilingCode {
   public final String location;
   
   public FilingCode(String code, String name, String fee, String casecategory,
-          String casetypeid, String filingtype, String iscourtuseonly, String civilclaimamount,
-          String probabeestateamount, String amountincontroversy, String useduedate,
-          String isproposedorder, String efspcode, String location) {
+          String casetypeid, String filingtype, boolean iscourtuseonly, String civilclaimamount,
+          String probabeestateamount, String amountincontroversy, boolean useduedate,
+          boolean isproposedorder, String efspcode, String location) {
     this.code = code;
     this.name = name;
     this.fee = fee;
     this.casecategory = casecategory;
     this.casetypeid = casetypeid;
     this.filingtype = filingtype;
-    this.iscourtuseonly = Boolean.parseBoolean(iscourtuseonly);
+    this.iscourtuseonly = iscourtuseonly;
     this.civilclaimamount = civilclaimamount;
     this.probateestateamount = probabeestateamount;
     this.amountincontroversy = amountincontroversy;
-    this.useduedate = Boolean.parseBoolean(useduedate);
-    this.isproposedorder = Boolean.parseBoolean(isproposedorder);
+    this.useduedate = useduedate;
+    this.isproposedorder = isproposedorder;
     this.efspcode = efspcode;
     this.location = location;
   }
@@ -51,12 +51,12 @@ public class FilingCode {
           rs.getString(4), 
           rs.getString(5), 
           rs.getString(6), 
-          rs.getString(7), 
+          rs.getBoolean(7), 
           rs.getString(8), 
           rs.getString(9), 
           rs.getString(10), 
-          rs.getString(11), 
-          rs.getString(12), 
+          rs.getBoolean(11), 
+          rs.getBoolean(12), 
           rs.getString(13),
           rs.getString(14));
   }

--- a/src/main/java/edu/suffolk/litlab/efspserver/codes/FilingComponent.java
+++ b/src/main/java/edu/suffolk/litlab/efspserver/codes/FilingComponent.java
@@ -19,9 +19,9 @@ public class FilingComponent {
         rs.getString(1),
         rs.getString(2),
         rs.getString(3),
-        Boolean.parseBoolean(rs.getString(4)),
-        Boolean.parseBoolean(rs.getString(5)),
-        Integer.parseInt(rs.getString(6)),
+        rs.getBoolean(4),
+        rs.getBoolean(5),
+        rs.getInt(6),
         rs.getString(7),
         rs.getString(8));
   }
@@ -55,6 +55,14 @@ public class FilingComponent {
 
   @Override
   public String toString() {
-    return "FilingComponent[code=" + code + ",name=" + name + ",location=" + location + "]";
+    StringBuilder sb = new StringBuilder();
+    sb.append("FilingComponent[code=");
+    sb.append(code);
+    sb.append(",name=");
+    sb.append(name);
+    sb.append(",location=");
+    sb.append(location);
+    sb.append("]");
+    return sb.toString();
   }
 }

--- a/src/main/java/edu/suffolk/litlab/efspserver/codes/OptionalServiceCode.java
+++ b/src/main/java/edu/suffolk/litlab/efspserver/codes/OptionalServiceCode.java
@@ -1,9 +1,16 @@
 package edu.suffolk.litlab.efspserver.codes;
 
+import jakarta.xml.bind.JAXBException;
 import java.sql.Connection;
 import java.sql.PreparedStatement;
 import java.sql.ResultSet;
 import java.sql.SQLException;
+import java.sql.Statement;
+import java.util.List;
+import javax.xml.stream.XMLStreamException;
+import org.oasis_open.docs.codelist.ns.genericode._1.CodeListDocument;
+import org.oasis_open.docs.codelist.ns.genericode._1.Column;
+import org.oasis_open.docs.codelist.ns.genericode._1.Value;
 
 public class OptionalServiceCode {
   public final String code;
@@ -13,13 +20,16 @@ public class OptionalServiceCode {
    * present, but might skip numbers or two rows might have the same value: ordering doesn't matter
    * then.
    */
-  public final String displayorder;
+  public final int displayorder;
   /** The Fee associated with this optional service. */
   public final String fee;
   /** This service is only allowed for this given filing code id. */
   public final String filingcodeid;
-  /** Fee multiplire: for instance, a request for 3 certified copies would have a value of 3. */
-  public final String multiplier;
+  /**
+   * Uses a fee multiplier: for instance, if true, a request for 3 certified copies would have a
+   * value of 3.
+   */
+  public final boolean multiplier;
   /** A textual description for a fee that has a calculated value. */
   public final String altfeedesc;
   /** True if the filer must provide a fee amount (?). */
@@ -30,12 +40,12 @@ public class OptionalServiceCode {
   public OptionalServiceCode(
       String code,
       String name,
-      String displayorder,
+      int displayorder,
       String fee,
       String filingcodeid,
-      String multiplier,
+      boolean multiplier,
       String altfeedesc,
-      String hasfeeprompt,
+      boolean hasfeeprompt,
       String feeprompttext) {
     this.code = code;
     this.name = name;
@@ -44,7 +54,7 @@ public class OptionalServiceCode {
     this.filingcodeid = filingcodeid;
     this.multiplier = multiplier;
     this.altfeedesc = altfeedesc;
-    this.hasfeeprompt = Boolean.parseBoolean(hasfeeprompt);
+    this.hasfeeprompt = hasfeeprompt;
     this.feeprompttext = feeprompttext;
   }
 
@@ -52,12 +62,12 @@ public class OptionalServiceCode {
     this(
         rs.getString(1),
         rs.getString(2),
-        rs.getString(3),
+        rs.getInt(3),
         rs.getString(4),
         rs.getString(5),
-        rs.getString(6),
+        rs.getBoolean(6),
         rs.getString(7),
-        rs.getString(8),
+        rs.getBoolean(8),
         rs.getString(9));
   }
 
@@ -72,10 +82,139 @@ public class OptionalServiceCode {
 
   public static String query() {
     return """
-        SELECT code, name, displayorder, fee, filingcodeid, multiplier, altfeedesc, hasfeeprompt,
-          feeprompttext
-        FROM optionalservices
-        WHERE domain=? AND location=? AND filingcodeid=?
+        SELECT os.code, os.name, os.displayorder, os.fee, os_fl.filingcodeid, os.multiplier, os.altfeedesc, os.hasfeeprompt,
+          os.feeprompttext
+        FROM optionalservices as os JOIN optionalservices_filinglist as os_fl ON os.domain=os_fl.domain AND os.location=os_fl.location AND os.code=os_fl.code
+        WHERE os.domain=? AND os.location=? AND os_fl.filingcodeid=?
         """;
+  }
+
+  public static void createFromOptionalServiceTable(Connection conn) throws SQLException {
+    final String CREATE_MAIN =
+        """
+      CREATE TABLE optionalservices (
+          "code" varchar(40),
+          "name" text,
+          "displayorder" integer,
+          "fee" text,
+          "multiplier" boolean,
+          "altfeedesc" text,
+          "hasfeeprompt" boolean,
+          "feeprompttext" text,
+          "efspcode" text,
+          "domain" varchar(80),
+          "location" varchar(80)
+      )
+          """;
+    final String CREATE_FL =
+        """
+      CREATE TABLE optionalservices_filinglist (
+          "code" varchar(40),
+          "filingcodeid" varchar(40),
+          "domain" varchar(80),
+          "location" varchar(80)
+      )
+        """;
+    try (Statement createSt = conn.createStatement()) {
+      createSt.executeUpdate(CREATE_MAIN);
+      createSt.executeUpdate(CREATE_FL);
+    }
+  }
+
+  public static void createIndices(Connection conn) throws SQLException {
+    var indices =
+        List.of(
+            "CREATE INDEX ON optionalservices (location)",
+            "CREATE INDEX ON optionalservices (domain)",
+            "CREATE INDEX ON optionalservices_filinglist (location)",
+            "CREATE INDEX ON optionalservices_filinglist (domain)");
+    try (Statement statement = conn.createStatement()) {
+      for (var myStr : indices) {
+        statement.executeUpdate(myStr);
+      }
+    }
+  }
+
+  public static void deleteFromOptionalServiceTable(
+      String courtLocation, String tylerDomain, Connection conn) throws SQLException {
+    final String DELETE_FROM =
+        (courtLocation == null)
+            ? "DELETE FROM optionalservices WHERE domain=?"
+            : "DELETE FROM optionalservices WHERE domain=? AND location=?";
+    final String DELETE_FROM_FL =
+        (courtLocation == null)
+            ? "DELETE FROM optionalservices_filinglist WHERE domain=?"
+            : "DELETE FROM optionalservices_filinglist WHERE domain=? AND location=?";
+    try (PreparedStatement stmt = conn.prepareStatement(DELETE_FROM);
+        PreparedStatement stmtFL = conn.prepareStatement(DELETE_FROM_FL)) {
+      stmt.setString(1, tylerDomain);
+      stmtFL.setString(1, tylerDomain);
+      if (courtLocation != null) {
+        stmt.setString(2, courtLocation);
+        stmt.setString(2, courtLocation);
+      }
+      stmt.executeUpdate();
+      stmtFL.executeUpdate();
+    }
+  }
+
+  public static void updateOptionalServiceTable(
+      String courtName, String tylerDomain, CodeListDocument doc, Connection conn)
+      throws JAXBException, SQLException, XMLStreamException {
+    String insertMainQuery =
+        """
+      INSERT INTO "optionalservices" ("code", "name", "displayorder", "fee", "multiplier", "altfeedesc", "hasfeeprompt",
+        "feeprompttext", "efspcode", "domain", "location"
+      ) VALUES (
+        ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?
+      )
+        """;
+    String insertFLQuery =
+        """
+      INSERT INTO "optionalservices_filinglist" ("code", "filingcodeid", "domain", "location"
+      ) VALUES (
+        ?, ?, ?, ?
+      )
+        """;
+    try (PreparedStatement stmt = conn.prepareStatement(insertMainQuery);
+        PreparedStatement stmtFilingList = conn.prepareStatement(insertFLQuery)) {
+      for (var r : doc.getSimpleCodeList().getRow()) {
+        // HACK(brycew): jeez, this is horrible. Figure a better option
+        for (Value v : r.getValue()) {
+          Column c = (Column) v.getColumnRef();
+          String colName = c.getId();
+          if (colName.equals("code")) {
+            stmt.setString(1, v.getSimpleValue().getValue());
+            stmtFilingList.setString(1, v.getSimpleValue().getValue());
+          } else if (colName.equals("filingcodeid")) {
+            stmtFilingList.setString(2, v.getSimpleValue().getValue());
+          } else if (colName.equals("name")) {
+            stmt.setString(2, v.getSimpleValue().getValue());
+          } else if (colName.equals("displayorder")) {
+            stmt.setInt(3, Integer.parseInt(v.getSimpleValue().getValue()));
+          } else if (colName.equals("fee")) {
+            stmt.setString(4, v.getSimpleValue().getValue());
+          } else if (colName.equals("multiplier")) {
+            stmt.setBoolean(5, Boolean.parseBoolean(v.getSimpleValue().getValue()));
+          } else if (colName.equals("altfeedesc")) {
+            stmt.setString(6, v.getSimpleValue().getValue());
+          } else if (colName.equals("hasfeeprompt")) {
+            stmt.setBoolean(7, Boolean.parseBoolean(v.getSimpleValue().getValue()));
+          } else if (colName.equals("feeprompttext")) {
+            stmt.setString(8, v.getSimpleValue().getValue());
+          } else if (colName.equals("efspcode")) {
+            stmt.setString(9, v.getSimpleValue().getValue());
+          }
+        }
+        stmt.setString(10, tylerDomain);
+        stmtFilingList.setString(3, tylerDomain);
+        stmt.setString(11, courtName);
+        stmtFilingList.setString(4, courtName);
+        stmt.addBatch();
+        stmtFilingList.addBatch();
+      }
+      stmt.executeBatch();
+      stmtFilingList.executeBatch();
+    }
   }
 }

--- a/src/main/java/edu/suffolk/litlab/efspserver/codes/OptionalServiceCode.java
+++ b/src/main/java/edu/suffolk/litlab/efspserver/codes/OptionalServiceCode.java
@@ -1,13 +1,11 @@
 package edu.suffolk.litlab.efspserver.codes;
 
-import jakarta.xml.bind.JAXBException;
 import java.sql.Connection;
 import java.sql.PreparedStatement;
 import java.sql.ResultSet;
 import java.sql.SQLException;
 import java.sql.Statement;
 import java.util.List;
-import javax.xml.stream.XMLStreamException;
 import org.oasis_open.docs.codelist.ns.genericode._1.CodeListDocument;
 import org.oasis_open.docs.codelist.ns.genericode._1.Column;
 import org.oasis_open.docs.codelist.ns.genericode._1.Value;
@@ -151,7 +149,7 @@ public class OptionalServiceCode {
       stmtFL.setString(1, tylerDomain);
       if (courtLocation != null) {
         stmt.setString(2, courtLocation);
-        stmt.setString(2, courtLocation);
+        stmtFL.setString(2, courtLocation);
       }
       stmt.executeUpdate();
       stmtFL.executeUpdate();
@@ -160,7 +158,7 @@ public class OptionalServiceCode {
 
   public static void updateOptionalServiceTable(
       String courtName, String tylerDomain, CodeListDocument doc, Connection conn)
-      throws JAXBException, SQLException, XMLStreamException {
+      throws SQLException {
     String insertMainQuery =
         """
       INSERT INTO "optionalservices" ("code", "name", "displayorder", "fee", "multiplier", "altfeedesc", "hasfeeprompt",

--- a/src/main/java/edu/suffolk/litlab/efspserver/codes/PartyType.java
+++ b/src/main/java/edu/suffolk/litlab/efspserver/codes/PartyType.java
@@ -21,16 +21,15 @@ public class PartyType {
   public final String location;
 
   public static PartyType TestObj(String code, String name, String location) {
-    return new PartyType(
-        code, name, "True", "123", "True", "386.53", "0", "", "", "", "", location);
+    return new PartyType(code, name, true, "123", true, "386.53", "0", "", "", "", "", location);
   }
 
   public PartyType(
       String code,
       String name,
-      String isAvailable,
+      boolean isAvailable,
       String casetypeid,
-      String isrequired,
+      boolean isrequired,
       String fee,
       String numberofpartiestoignore,
       String sendforredaction,
@@ -40,9 +39,9 @@ public class PartyType {
       String location) {
     this.code = code;
     this.name = name;
-    this.isAvailableForNewParties = Boolean.parseBoolean(isAvailable);
+    this.isAvailableForNewParties = isAvailable;
     this.casetypeid = casetypeid;
-    this.isrequired = Boolean.parseBoolean(isrequired);
+    this.isrequired = isrequired;
     this.amount = new BigDecimal(Double.parseDouble(fee));
     this.numberofpartiestoignore = numberofpartiestoignore;
     this.sendforredaction = sendforredaction;
@@ -60,9 +59,9 @@ public class PartyType {
     this(
         rs.getString(1),
         rs.getString(2),
-        rs.getString(3),
+        rs.getBoolean(3),
         rs.getString(4),
-        rs.getString(5),
+        rs.getBoolean(5),
         rs.getString(6),
         rs.getString(7),
         rs.getString(8),

--- a/src/main/java/edu/suffolk/litlab/efspserver/ecf/EcfCourtSpecificSerializer.java
+++ b/src/main/java/edu/suffolk/litlab/efspserver/ecf/EcfCourtSpecificSerializer.java
@@ -882,7 +882,7 @@ public class EcfCourtSpecificSerializer {
         if (!codeSettings.hasfeeprompt && serv.feeAmount.isPresent()) {
           collector.addWrong(servVar.appendDesc(": doesn't need fee prompt"));
         }
-        if (codeSettings.multiplier.equalsIgnoreCase("true")) {
+        if (codeSettings.multiplier == true) {
           if (serv.multiplier.isEmpty()) {
             collector.addWrong(servVar.appendDesc(": needs multiplier"));
           } else {

--- a/src/test/java/edu/suffolk/litlab/efspserver/db/DatabaseVersionTest.java
+++ b/src/test/java/edu/suffolk/litlab/efspserver/db/DatabaseVersionTest.java
@@ -37,6 +37,11 @@ import org.testcontainers.containers.PostgreSQLContainer;
 import org.testcontainers.junit.jupiter.Container;
 import org.testcontainers.utility.DockerImageName;
 
+import edu.suffolk.litlab.efspserver.codes.CodeDatabase;
+import edu.suffolk.litlab.efspserver.codes.FilingComponent;
+import edu.suffolk.litlab.efspserver.codes.OptionalServiceCode;
+import edu.suffolk.litlab.efspserver.codes.PartyType;
+
 public class DatabaseVersionTest {
   private final static Logger log = 
       LoggerFactory.getLogger(DatabaseVersionTest.class); 
@@ -115,6 +120,15 @@ public class DatabaseVersionTest {
 
     while (rs.next()) {
       assertEquals(rs.getString(1), "illinois-stage");
+    }
+
+    try (var codesDatabase = new CodeDatabase("illinois", "stage", codeConn)) {
+      List<OptionalServiceCode> opts = codesDatabase.getOptionalServices("adams", "27959");
+      assertEquals(23, opts.size());
+      List<PartyType> partyTypes = codesDatabase.getPartyTypeFor("adams", "27898");
+      assertEquals(2, partyTypes.size());
+      List<FilingComponent> components = codesDatabase.getFilingComponents("adams", "27959");
+      assertEquals(2, components.size());
     }
   }
   

--- a/src/test/java/edu/suffolk/litlab/efspserver/ecf/EcfCaseTypeFactoryTest.java
+++ b/src/test/java/edu/suffolk/litlab/efspserver/ecf/EcfCaseTypeFactoryTest.java
@@ -62,7 +62,7 @@ public class EcfCaseTypeFactoryTest {
     when(cd.getLanguages("not_real")).thenReturn(List.of("English", "Polish", "Spanish"));
     when(cd.getDataField(eq("not_real"), anyString())).thenReturn(DataFieldRow.MissingDataField(""));
     when(cd.getDataField(eq("not_real"), eq("PartyGender"))).thenReturn(
-        new DataFieldRow("PartyGender", "Party Gender", "True", "False", "", "", "", "", "", "", "", ""));
+        new DataFieldRow("PartyGender", "Party Gender", true, false, "", "", "", "", "", "", false, ""));
     collector = new FailFastCollector();
   }
 

--- a/src/test/java/edu/suffolk/litlab/efspserver/ecf/EcfCourtSpecificSerializerTest.java
+++ b/src/test/java/edu/suffolk/litlab/efspserver/ecf/EcfCourtSpecificSerializerTest.java
@@ -61,7 +61,7 @@ public class EcfCourtSpecificSerializerTest {
     when(cd.getLanguages("not_real")).thenReturn(List.of("English", "Polish", "Spanish"));
     when(cd.getDataFields(eq("not_real"))).thenReturn(new DataFields(
         Map.of("PartyGender", 
-               new DataFieldRow("PartyGender", "Party Gender", "True", "False", "", "", "", "", "", "", "", ""))
+               new DataFieldRow("PartyGender", "Party Gender", true, false, "", "", "", "", "", "", false, ""))
         ));
     collector = new FailFastCollector();
   }


### PR DESCRIPTION
Shrinks the code tables, particularly the optional services one, which required some refactoring to not assume that most operations take only a single transaction.

It shrinks the disk usage by a few GB, can't find my notes that I have for how much. It wasn't a ton though, and would need to go to enums if we wanted to actually decrease usage.

For now though, addresses #99.

Waiting for a run of `replaceAll` to finish for Illinois, then I'll merge, and will make the PR for integration tests as well.