### PR TITLE
Assume that Tyler gives us nothing on Callback

### DIFF
--- a/src/main/java/edu/suffolk/litlab/efspserver/ecf/OasisEcfWsCallback.java
+++ b/src/main/java/edu/suffolk/litlab/efspserver/ecf/OasisEcfWsCallback.java
@@ -113,8 +113,6 @@ public class OasisEcfWsCallback implements FilingAssemblyMDEPort {
             .append("The document (")
             .append(tylerDoc.getDocumentDescriptionText().getValue())
             .append(") ");
-      } else {
-        docText.append("The document ");
       }
       if (tylerDoc.getDocumentBinary() != null
           && tylerDoc.getDocumentBinary().getBinaryDescriptionText() != null) {
@@ -163,6 +161,9 @@ public class OasisEcfWsCallback implements FilingAssemblyMDEPort {
     }
     if (docText.length() > 0) {
       docText.append('.');
+      if (!docText.substring(0, 12).equals("The document")) {
+        docText.insert(0, "The document ");
+      }
     }
     return docText.toString();
   }


### PR DESCRIPTION
Before, if they gave us nothing, the message would be "the document."

Now, we don't add "The document" unless there isn't anything already (in the cases where there aren't file names, but are comments).