### PR TITLE
Dedupe optionalservice table

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>edu.suffolk.litlab</groupId>
     <artifactId>efspserver</artifactId>
-    <version>1.1.3b1</version>
+    <version>1.2.0</version>
     <name>Suffolk LITLab EFSP Proxy Server</name>
     <url>https://suffolklitlab.org</url>
     <description>an EFSP client for the AssemblyLine Project</description>


### PR DESCRIPTION
Despite the fact that there are two tables for optional services to shrink the disk space usage, there was an error that would duplicate entries in the table that should have been much smaller, but it would only happen on insert/ a version update for the court. No logical errors happened, but would result in a large amount of codes and extra parsing to be done on the docassemble side.