### PR TITLE
Allow for no Attorneys if individual filer

### DIFF
--- a/src/main/java/edu/suffolk/litlab/efspserver/JsonHelpers.java
+++ b/src/main/java/edu/suffolk/litlab/efspserver/JsonHelpers.java
@@ -19,6 +19,14 @@ public class JsonHelpers {
     return Optional.empty();
   }
 
+  public static Optional<String> getNonEmptyStringMember(JsonNode obj, String memberName) {
+    var maybeStr = getStringMember(obj, memberName);
+    if (maybeStr.map(str -> str.isBlank()).orElse(true)) {
+      return Optional.empty();
+    }
+    return maybeStr;
+  }
+
   public static String getStringDefault(JsonNode obj, String memberName, String def) {
     if (!obj.has(memberName)) {
       return def;

--- a/src/main/java/edu/suffolk/litlab/efspserver/docassemble/FilingDocDocassembleJacksonDeserializer.java
+++ b/src/main/java/edu/suffolk/litlab/efspserver/docassemble/FilingDocDocassembleJacksonDeserializer.java
@@ -2,6 +2,7 @@ package edu.suffolk.litlab.efspserver.docassemble;
 
 import static edu.suffolk.litlab.efspserver.JsonHelpers.getIntMember;
 import static edu.suffolk.litlab.efspserver.JsonHelpers.getMemberList;
+import static edu.suffolk.litlab.efspserver.JsonHelpers.getNonEmptyStringMember;
 import static edu.suffolk.litlab.efspserver.JsonHelpers.getNumberMember;
 import static edu.suffolk.litlab.efspserver.JsonHelpers.getStringDefault;
 import static edu.suffolk.litlab.efspserver.JsonHelpers.getStringMember;
@@ -103,7 +104,7 @@ public class FilingDocDocassembleJacksonDeserializer {
     }
     String userDescription = getStringDefault(node, "filing_description", "");
     Optional<String> filingRefNum = getStringMember(node, "reference_number");
-    Optional<String> filingAttorney = getStringMember(node, "filing_attorney");
+    Optional<String> filingAttorney = getNonEmptyStringMember(node, "filing_attorney");
     String filingComment = getStringDefault(node, "filing_comment", "");
 
     String _logName =

--- a/src/main/java/edu/suffolk/litlab/efspserver/ecf/EcfCourtSpecificSerializer.java
+++ b/src/main/java/edu/suffolk/litlab/efspserver/ecf/EcfCourtSpecificSerializer.java
@@ -696,6 +696,7 @@ public class EcfCourtSpecificSerializer {
       CaseCategory caseCategory,
       CaseType motionType,
       FilingCode filing,
+      boolean isIndividual,
       JsonNode miscInfo,
       InfoCollector collector)
       throws IOException, FilingError {
@@ -757,10 +758,10 @@ public class EcfCourtSpecificSerializer {
 
     DataFieldRow attorneyRow = allDataFields.getFieldRow("FilingFilingAttorneyView");
     if (attorneyRow.isvisible) {
-      if (doc.getFilingAttorney().isPresent()) {
+      if (doc.getFilingAttorney().isPresent() && !doc.getFilingAttorney().get().isBlank()) {
         metadata.setFilingAttorneyID(
             XmlHelper.convertId(doc.getFilingAttorney().get(), "REFERENCE"));
-      } else if (!attorneyRow.isrequired) {
+      } else if (!attorneyRow.isrequired || isIndividual) {
         // "This field should contain empty values for Individual filers"
         metadata.setFilingAttorneyID(XmlHelper.convertId("", ""));
       } else {


### PR DESCRIPTION
Individual filers don't have to provide filing attorneys, even if the court marks `FilingFilingAttorneyView` as required (it's only required form firm filers, something I hadn't noticed in the fine print of the documentation).

Adds an extra `getFirm` query when preparing filing, hopefully it doesn't take too long though.