### PR TITLE
Patch filer_type

### DIFF
--- a/src/main/java/edu/suffolk/litlab/efspserver/ecf4/EcfCaseTypeFactory.java
+++ b/src/main/java/edu/suffolk/litlab/efspserver/ecf4/EcfCaseTypeFactory.java
@@ -661,11 +661,11 @@ public class EcfCaseTypeFactory {
               filerTypeName,
               "Metadata about the filer of this case",
               "choices",
-              allTypes.stream().map(t -> t.name).collect(Collectors.toList()));
+              allTypes.stream().map(t -> t.code).collect(Collectors.toList()));
       if (filerTypeNode != null && filerTypeNode.isTextual()) {
         String filerType = filerTypeNode.asText();
         Optional<FilerType> typeInfo =
-            allTypes.stream().filter(t -> t.name.equalsIgnoreCase(filerType)).findFirst();
+            allTypes.stream().filter(t -> t.code.equalsIgnoreCase(filerType)).findFirst();
         if (typeInfo.isPresent()) {
           ecfAug.setFilerTypeText(Ecf4Helper.convertText(typeInfo.get().code));
         } else {

--- a/src/main/java/edu/suffolk/litlab/efspserver/tyler/codes/FilerType.java
+++ b/src/main/java/edu/suffolk/litlab/efspserver/tyler/codes/FilerType.java
@@ -28,7 +28,9 @@ public class FilerType {
   }
 
   public static String query() {
-    return "SELECT code, name, default, efspcode, location FROM filertype WHERE domain=? AND"
-        + " location=?";
+    return """
+      SELECT "code", "name", "default", "efspcode", "location"
+      FROM filertype
+      WHERE domain=? AND location=?""";
   }
 }


### PR DESCRIPTION
Follow up to https://github.com/SuffolkLITLab/EfileProxyServer/commit/6ea4e9037bdde875ec9d3d23049eb5020d629480

* We were still expecting the API callers to pass the "name" of the code, not the code itself. This was refactored for all other codes a long time ago, and this makes `filer_type` consistent with everything else (see https://github.com/SuffolkLITLab/EfileProxyServer/pull/82)
* one of the SQL columns is default, which is also a SQL keyword. Need to put the column name in double quotes for PostgreSQL to be happy