### PR TITLE
Some last moving things for ACME

### DIFF
--- a/docs/https.md
+++ b/docs/https.md
@@ -17,10 +17,11 @@ We are still working to improve the steps, but current the process is:
 
 1. In your `.env` file, set `USE_LETSENCRYPT=True`, and `CERT_PASSWORD` to a securely generated password, at least 16 characters.
    Something like `openssl rand -base64 12` will generate 16 characters securely.
+   * You can also set a `MONITORING_EMAIL` which will be used for email renewal reminders from Lets Encrypt.
 2. Start up the docker containers (see [setup.md](setup.md)).
 3. Start a bash shell inside the running container: `docker exec -it efileproxyserver-efspjava-1 /bin/bash`
 4. Change directories to the app: `cd /usr/src/app`.
-5. Run the ACME renewal process: `mvn exec:java@AcmeRenewal -Dexec.args="renew"`.
+5. Run the ACME renewal process: `java -cp $(cat cp.txt):target/efspserver.java edu.suffolk.litlab.efspserver.services.acme.AcmeRenewal renew`.
    If the renewal process succeeded, `acme-domain-chain.crt` and `tls_server_cert.jks`
    should both be present in `/tmp/tls_certs` inside the container and in `src/main/config` outside the container.
 6. Exit the bash shell you started, and rebuild and restart the java docker container.

--- a/src/main/java/edu/suffolk/litlab/efspserver/services/EfspServer.java
+++ b/src/main/java/edu/suffolk/litlab/efspserver/services/EfspServer.java
@@ -14,6 +14,7 @@ import edu.suffolk.litlab.efspserver.db.UserDatabase;
 import edu.suffolk.litlab.efspserver.docassemble.DocassembleToFilingInformationConverter;
 import edu.suffolk.litlab.efspserver.ecf4.TylerModuleSetup;
 import edu.suffolk.litlab.efspserver.jeffnet.JeffNetModuleSetup;
+import edu.suffolk.litlab.efspserver.services.acme.AcmeChallengeService;
 import jakarta.ws.rs.core.MediaType;
 import java.io.File;
 import java.security.NoSuchAlgorithmException;

--- a/src/main/java/edu/suffolk/litlab/efspserver/services/acme/AcmeChallengePublisher.java
+++ b/src/main/java/edu/suffolk/litlab/efspserver/services/acme/AcmeChallengePublisher.java
@@ -1,4 +1,4 @@
-package edu.suffolk.litlab.efspserver.services;
+package edu.suffolk.litlab.efspserver.services.acme;
 
 import org.shredzone.acme4j.challenge.Http01Challenge;
 

--- a/src/main/java/edu/suffolk/litlab/efspserver/services/acme/AcmeChallengeService.java
+++ b/src/main/java/edu/suffolk/litlab/efspserver/services/acme/AcmeChallengeService.java
@@ -1,4 +1,4 @@
-package edu.suffolk.litlab.efspserver.services;
+package edu.suffolk.litlab.efspserver.services.acme;
 
 import jakarta.ws.rs.GET;
 import jakarta.ws.rs.Path;

--- a/src/main/java/edu/suffolk/litlab/efspserver/services/acme/AcmeChallengeWriter.java
+++ b/src/main/java/edu/suffolk/litlab/efspserver/services/acme/AcmeChallengeWriter.java
@@ -1,4 +1,4 @@
-package edu.suffolk.litlab.efspserver.services;
+package edu.suffolk.litlab.efspserver.services.acme;
 
 import java.io.File;
 import java.io.FileWriter;


### PR DESCRIPTION
About to renew certs on test and prod, going through and documenting the process, and decided to use the `MONITORING_EMAIL` over the `TYLER_USER_EMAIL`, given the tyler user email is my old email that might be going away.

Additionally moves the ACME files to a separate package in Services, and cleans up their javadocs a bit.