### PR TITLE
Search jurisdiction codes

### DIFF
--- a/src/main/java/edu/suffolk/litlab/efspserver/ecf4/EcfCourtSpecificSerializer.java
+++ b/src/main/java/edu/suffolk/litlab/efspserver/ecf4/EcfCourtSpecificSerializer.java
@@ -116,7 +116,7 @@ public class EcfCourtSpecificSerializer {
       InfoCollector collector)
       throws FilingError {
     CaseCategory caseCategory =
-        vetCaseCat(cd.getCaseCategoryWithKey(this.court.code, caseCategoryCode), collector);
+        vetCaseCat(cd.getCaseCategoryWithCode(this.court.code, caseCategoryCode), collector);
     List<CaseType> caseTypes = cd.getCaseTypesFor(court.code, caseCategory.code, Optional.empty());
     Optional<CaseType> maybeType = cd.getCaseTypeWith(court.code, caseTypeCode);
     CaseType type = vetCaseType(maybeType, caseTypes, caseCategory, collector, false);
@@ -131,7 +131,7 @@ public class EcfCourtSpecificSerializer {
   public ComboCaseCodes serializeCaseCodes(
       FilingInformation info, InfoCollector collector, boolean isInitialFiling) throws FilingError {
     Optional<CaseCategory> maybeCaseCat =
-        cd.getCaseCategoryWithKey(this.court.code, info.getCaseCategoryCode());
+        cd.getCaseCategoryWithCode(this.court.code, info.getCaseCategoryCode());
     CaseCategory caseCategory = vetCaseCat(maybeCaseCat, collector);
 
     List<CaseType> caseTypes = cd.getCaseTypesFor(court.code, caseCategory.code, Optional.empty());

--- a/src/main/java/edu/suffolk/litlab/efspserver/tyler/codes/CaseCategory.java
+++ b/src/main/java/edu/suffolk/litlab/efspserver/tyler/codes/CaseCategory.java
@@ -91,6 +91,24 @@ public class CaseCategory {
     return st;
   }
 
+  public static String searchCaseCategories() {
+    return """
+        SELECT DISTINCT name
+        FROM casecategory
+        WHERE domain=? AND name ILIKE ?
+        ORDER BY name
+        """;
+  }
+
+  public static String retrieveCaseCategoryForName() {
+    return """
+        SELECT DISTINCT code, location
+        FROM casecategory
+        WHERE domain=? AND name=?
+        ORDER BY location
+        """;
+  }
+
   // TODO(#86): stop filtering out criminal categories
   public static String getCaseCategoriesForLoc() {
     return """

--- a/src/main/java/edu/suffolk/litlab/efspserver/tyler/codes/CaseCategory.java
+++ b/src/main/java/edu/suffolk/litlab/efspserver/tyler/codes/CaseCategory.java
@@ -137,7 +137,7 @@ public class CaseCategory {
         """;
   }
 
-  public static String getCaseCategoryWithKey() {
+  public static String getCaseCategoryWithCode() {
     return """
         SELECT code, name, ecfcasetype, procedureremedyinitial,
           procedureremedysubsequent, damageamountinitial, damageamountsubsequent

--- a/src/main/java/edu/suffolk/litlab/efspserver/tyler/codes/CodeAndLocation.java
+++ b/src/main/java/edu/suffolk/litlab/efspserver/tyler/codes/CodeAndLocation.java
@@ -1,0 +1,18 @@
+package edu.suffolk.litlab.efspserver.tyler.codes;
+
+/**
+ * The code and location for a Tyler code.
+ *
+ * <p>Returned by the various "search" APIs; you search for all codes with "XYZ" in the name, and
+ * then do `/filing_code_names/XYZ` to get the code and location, enough to find all of the
+ * information you need about that code.
+ */
+public class CodeAndLocation {
+  public final String code;
+  public final String location;
+
+  public CodeAndLocation(String code, String location) {
+    this.code = code;
+    this.location = location;
+  }
+}

--- a/src/main/java/edu/suffolk/litlab/efspserver/tyler/codes/CodeDatabase.java
+++ b/src/main/java/edu/suffolk/litlab/efspserver/tyler/codes/CodeDatabase.java
@@ -238,6 +238,67 @@ public class CodeDatabase extends CodeDatabaseAPI {
     return stmt;
   }
 
+  /**
+   * In most cases, we want to find all instances of the search term, not the exact term. It's a
+   * LIKE compare, so add the 0 or more characters on either side.
+   *
+   * @param searchTerm
+   * @return
+   */
+  public static String likeWildcard(String searchTerm) {
+    if (searchTerm == null) {
+      return "%";
+    }
+    return "%" + searchTerm + "%";
+  }
+
+  /**
+   * Gets all distinct case category names that have the search term in them.
+   *
+   * @param searchTerm
+   * @return
+   */
+  public List<String> searchCaseCategory(String searchTerm) {
+    String finalSearchTerm = likeWildcard(searchTerm);
+    return safetyWrap(
+        () -> {
+          String query = CaseCategory.searchCaseCategories();
+          List<String> cats = new ArrayList<>();
+          try (PreparedStatement st = conn.prepareStatement(query)) {
+            st.setString(1, tylerDomain);
+            st.setString(2, finalSearchTerm);
+            ResultSet rs = st.executeQuery();
+            while (rs.next()) {
+              cats.add(rs.getString(1));
+            }
+          }
+          return cats;
+        });
+  }
+
+  /**
+   * Get the code and court locations of the case categories that match the given name exactly.
+   *
+   * @param categoryName
+   * @return
+   */
+  public List<CodeAndLocation> retrieveCaseCategoryByName(String categoryName) {
+    return safetyWrap(
+        () -> {
+          String query = CaseCategory.retrieveCaseCategoryForName();
+          List<CodeAndLocation> cats = new ArrayList<>();
+          try (PreparedStatement st = conn.prepareStatement(query)) {
+            st.setString(1, tylerDomain);
+            st.setString(2, categoryName);
+            ResultSet rs = st.executeQuery();
+            while (rs.next()) {
+              cats.add(new CodeAndLocation(rs.getString(1), rs.getString(2)));
+            }
+          }
+          return cats;
+        });
+  }
+
   public List<CaseCategory> getCaseCategoriesFor(String courtLocationId) {
     return safetyWrap(
         () -> {
@@ -294,6 +355,48 @@ public class CodeDatabase extends CodeDatabaseAPI {
               log.warn("No categories for code " + caseCatCode + " at " + courtLocationId);
               return Optional.empty();
             }
+          }
+        });
+  }
+
+  /**
+   * Gets all distinct case type names that have the search term in them.
+   *
+   * @param searchTerm
+   * @return
+   */
+  public List<String> searchCaseType(String searchTerm) {
+    String finalSearchTerm = likeWildcard(searchTerm);
+    return safetyWrap(
+        () -> {
+          try (PreparedStatement st =
+              CaseType.prepSearchQuery(conn, tylerDomain, finalSearchTerm)) {
+            List<String> types = new ArrayList<>();
+            ResultSet rs = st.executeQuery();
+            while (rs.next()) {
+              types.add(rs.getString(1));
+            }
+            return types;
+          }
+        });
+  }
+
+  /**
+   * Get the code and court locations of the case types that match the given name exactly.
+   *
+   * @param categoryName
+   * @return
+   */
+  public List<CodeAndLocation> retrieveCaseTypeByName(String caseTypeName) {
+    return safetyWrap(
+        () -> {
+          try (PreparedStatement st = CaseType.prepRetrieveQuery(conn, tylerDomain, caseTypeName)) {
+            List<CodeAndLocation> types = new ArrayList<>();
+            ResultSet rs = st.executeQuery();
+            while (rs.next()) {
+              types.add(new CodeAndLocation(rs.getString(1), rs.getString(2)));
+            }
+            return types;
           }
         });
   }
@@ -478,6 +581,49 @@ public class CodeDatabase extends CodeDatabaseAPI {
     }
   }
 
+  /**
+   * Gets all distinct filing type names that have the search term in them.
+   *
+   * @param searchTerm
+   * @return
+   */
+  public List<String> searchFilingType(String searchTerm) {
+    String finalSearchTerm = likeWildcard(searchTerm);
+    return safetyWrap(
+        () -> {
+          try (PreparedStatement st =
+              FilingCode.prepSearchQuery(conn, tylerDomain, finalSearchTerm)) {
+            List<String> types = new ArrayList<>();
+            ResultSet rs = st.executeQuery();
+            while (rs.next()) {
+              types.add(rs.getString(1));
+            }
+            return types;
+          }
+        });
+  }
+
+  /**
+   * Get the code and court locations of the filing types that match the given name exactly.
+   *
+   * @param categoryName
+   * @return
+   */
+  public List<CodeAndLocation> retrieveFilingTypeByName(String caseTypeName) {
+    return safetyWrap(
+        () -> {
+          try (PreparedStatement st =
+              FilingCode.prepRetrieveQuery(conn, tylerDomain, caseTypeName)) {
+            List<CodeAndLocation> types = new ArrayList<>();
+            ResultSet rs = st.executeQuery();
+            while (rs.next()) {
+              types.add(new CodeAndLocation(rs.getString(1), rs.getString(2)));
+            }
+            return types;
+          }
+        });
+  }
+
   public List<FilingCode> getFilingType(
       String courtLocationId, String categoryCode, String typeCode, boolean initial) {
     return safetyWrap(
@@ -553,6 +699,47 @@ public class CodeDatabase extends CodeDatabaseAPI {
   }
 
   /**
+   * Gets all distinct filing type names that have the search term in them.
+   *
+   * @param searchTerm
+   * @return
+   */
+  public List<String> searchPartyType(String searchTerm) {
+    String finalSearchTerm = likeWildcard(searchTerm);
+    return safetyWrap(
+        () -> {
+          String query = PartyType.searchPartyType();
+          List<String> types = new ArrayList<>();
+          try (PreparedStatement st = conn.prepareStatement(query)) {
+            st.setString(1, tylerDomain);
+            st.setString(2, finalSearchTerm);
+            ResultSet rs = st.executeQuery();
+            while (rs.next()) {
+              types.add(rs.getString(1));
+            }
+            return types;
+          }
+        });
+  }
+
+  public List<CodeAndLocation> retrievePartyType(String partyTypeName) {
+    return safetyWrap(
+        () -> {
+          String query = PartyType.retrievePartyTypeFromName();
+          List<CodeAndLocation> types = new ArrayList<>();
+          try (PreparedStatement st = conn.prepareStatement(query)) {
+            st.setString(1, tylerDomain);
+            st.setString(2, partyTypeName);
+            ResultSet rs = st.executeQuery();
+            while (rs.next()) {
+              types.add(new CodeAndLocation(rs.getString(1), rs.getString(2)));
+            }
+            return types;
+          }
+        });
+  }
+
+  /**
    * Gets the party types that are allowed for a given court and case type.
    *
    * @param courtLocationId
@@ -593,6 +780,24 @@ public class CodeDatabase extends CodeDatabaseAPI {
         });
   }
 
+  public List<PartyType> getPartyTypeByCode(String courtLocationId, String partyTypeCode) {
+    return safetyWrap(
+        () -> {
+          String query = PartyType.retrievePartyTypeFromName();
+          List<PartyType> types = new ArrayList<>();
+          try (PreparedStatement st = conn.prepareStatement(query)) {
+            st.setString(1, tylerDomain);
+            st.setString(2, courtLocationId);
+            st.setString(3, partyTypeCode);
+            ResultSet rs = st.executeQuery();
+            while (rs.next()) {
+              types.add(new PartyType(rs));
+            }
+            return types;
+          }
+        });
+  }
+
   public List<CrossReference> getCrossReference(String courtLocationId, String caseTypeId) {
     return safetyWrap(
         () -> {
@@ -625,32 +830,6 @@ public class CodeDatabase extends CodeDatabaseAPI {
           }
           return types;
         });
-  }
-
-  private <T> List<T> safetyWrap(SQLFunction<List<T>> sup) {
-    if (conn == null) {
-      log.error("SQL connection not created yet!");
-      return List.of();
-    }
-    try {
-      return sup.get();
-    } catch (SQLException ex) {
-      log.error("SQL excption: " + ex);
-      return List.of();
-    }
-  }
-
-  private <T> Optional<T> safetyWrapOpt(SQLFunction<Optional<T>> sup) {
-    if (conn == null) {
-      log.error("SQL connection not created yet!");
-      return Optional.empty();
-    }
-    try {
-      return sup.get();
-    } catch (SQLException ex) {
-      log.error("SQL excption: " + ex);
-      return Optional.empty();
-    }
   }
 
   public List<DocumentTypeTableRow> getDocumentTypes(String courtLocationId, String filingCodeId) {
@@ -843,6 +1022,52 @@ public class CodeDatabase extends CodeDatabaseAPI {
       log.error("SQLExecption: " + ex);
       return List.of();
     }
+  }
+
+  public List<String> searchOptionalServices(String searchTerm) {
+    final String finalSearchTerm = likeWildcard(searchTerm);
+    return safetyWrap(
+        () -> {
+          try (PreparedStatement st =
+              OptionalServiceCode.prepSearch(conn, tylerDomain, finalSearchTerm)) {
+            List<String> optServs = new ArrayList<>();
+            ResultSet rs = st.executeQuery();
+            while (rs.next()) {
+              optServs.add(rs.getString(1));
+            }
+            return optServs;
+          }
+        });
+  }
+
+  public List<CodeAndLocation> retrieveOptionalServices(String optServName) {
+    return safetyWrap(
+        () -> {
+          try (PreparedStatement st =
+              OptionalServiceCode.prepRetrieve(conn, tylerDomain, optServName)) {
+            List<CodeAndLocation> optServs = new ArrayList<>();
+            ResultSet rs = st.executeQuery();
+            while (rs.next()) {
+              optServs.add(new CodeAndLocation(rs.getString(1), rs.getString(2)));
+            }
+            return optServs;
+          }
+        });
+  }
+
+  public List<OptionalServiceCode> getOptionalServicesByCode(String courtId, String optServCode) {
+    return safetyWrap(
+        () -> {
+          try (PreparedStatement st =
+              OptionalServiceCode.prepQueryWithCode(conn, tylerDomain, courtId, optServCode)) {
+            List<OptionalServiceCode> optServs = new ArrayList<>();
+            ResultSet rs = st.executeQuery();
+            while (rs.next()) {
+              optServs.add(new OptionalServiceCode(rs));
+            }
+            return optServs;
+          }
+        });
   }
 
   public List<OptionalServiceCode> getOptionalServices(String courtId, String filingCode) {
@@ -1114,5 +1339,31 @@ public class CodeDatabase extends CodeDatabaseAPI {
             return disclaimers;
           }
         });
+  }
+
+  private <T> List<T> safetyWrap(SQLFunction<List<T>> sup) {
+    if (conn == null) {
+      log.error("SQL connection not created yet!");
+      return List.of();
+    }
+    try {
+      return sup.get();
+    } catch (SQLException ex) {
+      log.error("SQL excption: " + ex);
+      return List.of();
+    }
+  }
+
+  private <T> Optional<T> safetyWrapOpt(SQLFunction<Optional<T>> sup) {
+    if (conn == null) {
+      log.error("SQL connection not created yet!");
+      return Optional.empty();
+    }
+    try {
+      return sup.get();
+    } catch (SQLException ex) {
+      log.error("SQL excption: " + ex);
+      return Optional.empty();
+    }
   }
 }

--- a/src/main/java/edu/suffolk/litlab/efspserver/tyler/codes/CodeDatabase.java
+++ b/src/main/java/edu/suffolk/litlab/efspserver/tyler/codes/CodeDatabase.java
@@ -277,10 +277,11 @@ public class CodeDatabase extends CodeDatabaseAPI {
         });
   }
 
-  public Optional<CaseCategory> getCaseCategoryWithKey(String courtLocationId, String caseCatCode) {
+  public Optional<CaseCategory> getCaseCategoryWithCode(
+      String courtLocationId, String caseCatCode) {
     return safetyWrapOpt(
         () -> {
-          String query = CaseCategory.getCaseCategoryWithKey();
+          String query = CaseCategory.getCaseCategoryWithCode();
           try (PreparedStatement st = conn.prepareStatement(query)) {
             st.setString(1, tylerDomain);
             st.setString(2, courtLocationId);
@@ -509,7 +510,7 @@ public class CodeDatabase extends CodeDatabaseAPI {
     return safetyWrapOpt(
         () -> {
           try (PreparedStatement st =
-              FilingCode.prepQueryWithKey(conn, tylerDomain, courtLocationId, filingCode)) {
+              FilingCode.prepQueryWithCode(conn, tylerDomain, courtLocationId, filingCode)) {
             ResultSet rs = st.executeQuery();
             if (rs.next()) {
               return Optional.of(new FilingCode(rs));
@@ -559,7 +560,7 @@ public class CodeDatabase extends CodeDatabaseAPI {
    *     case type.
    * @return a list of party types
    */
-  public List<PartyType> getPartyTypeFor(String courtLocationId, String typeCode) {
+  public List<PartyType> getPartyTypeFor(String courtLocationId, String caseTypeCode) {
     return safetyWrap(
         () -> {
           String query = PartyType.getPartyTypeFromCaseType();
@@ -567,8 +568,8 @@ public class CodeDatabase extends CodeDatabaseAPI {
           try (PreparedStatement caseSt = conn.prepareStatement(query)) {
             caseSt.setString(1, tylerDomain);
             caseSt.setString(2, courtLocationId);
-            if (typeCode != null) {
-              caseSt.setString(3, typeCode);
+            if (caseTypeCode != null) {
+              caseSt.setString(3, caseTypeCode);
               try (ResultSet rs = caseSt.executeQuery()) {
                 while (rs.next()) {
                   partyTypes.add(new PartyType(rs));

--- a/src/main/java/edu/suffolk/litlab/efspserver/tyler/codes/FilingCode.java
+++ b/src/main/java/edu/suffolk/litlab/efspserver/tyler/codes/FilingCode.java
@@ -97,9 +97,6 @@ public class FilingCode {
     return st;
   }
   
-  // TODO(brycew): test this one in particular, it was wrong
-  public static PreparedStatement prepQueryWithKey(Connection conn, String domain, String courtId, String typeCode) throws SQLException {
-    PreparedStatement st = conn.prepareStatement(getFilingWithKey());
     st.setString(1, domain);
     st.setString(2, courtId);
     st.setString(3, typeCode);
@@ -136,7 +133,7 @@ public class FilingCode {
     }
   }
   
-  private static String getFilingWithKey() {
+  private static String getFilingWithCode() {
     return """
         SELECT code, name, fee, casecategory, casetypeid, filingtype, iscourtuseonly,
                civilclaimamount, probateestateamount, amountincontroversy, useduedate,

--- a/src/main/java/edu/suffolk/litlab/efspserver/tyler/codes/FilingCode.java
+++ b/src/main/java/edu/suffolk/litlab/efspserver/tyler/codes/FilingCode.java
@@ -79,6 +79,32 @@ public class FilingCode {
     );
   }
   
+  public static PreparedStatement prepSearchQuery(Connection conn, String domain, String searchTerm) throws SQLException {
+    final String search = """
+        SELECT DISTINCT name
+        FROM filing
+        WHERE domain=? AND name ILIKE ?
+        ORDER BY name
+        """;
+    PreparedStatement st = conn.prepareStatement(search);
+    st.setString(1, domain);
+    st.setString(2, searchTerm);
+    return st;
+  }
+  
+  public static PreparedStatement prepRetrieveQuery(Connection conn, String domain, String filingName) throws SQLException {
+    String retrieve = """
+        SELECT DISTINCT code, location
+        FROM filing
+        WHERE domain=? AND name=?
+        ORDER BY location
+        """;
+    PreparedStatement st = conn.prepareStatement(retrieve);
+    st.setString(1, domain);
+    st.setString(2, filingName);
+    return st;
+  }
+  
   public static PreparedStatement prepQueryWithCaseInfo(Connection conn, 
       boolean initial, String domain, String courtLocationId, String categoryId, String caseTypeId) throws SQLException {
     PreparedStatement st = conn.prepareStatement(getFilingWithCaseInfo(initial));
@@ -89,20 +115,6 @@ public class FilingCode {
     return st;
   }
 
-  public static PreparedStatement prepQueryNoCaseInfo(Connection conn, 
-      boolean initial, String domain, String courtLocationId) throws SQLException {
-    PreparedStatement st = conn.prepareStatement(getFilingNoCaseInfo(initial));
-    st.setString(1, domain);
-    st.setString(2, courtLocationId);
-    return st;
-  }
-  
-    st.setString(1, domain);
-    st.setString(2, courtId);
-    st.setString(3, typeCode);
-    return st;
-  }
-  
   /** @param initial true if its an initial filing, false if it's a subsequent. */
   private static String getFilingWithCaseInfo(boolean initial) {
     String mainQuery = """
@@ -118,6 +130,15 @@ public class FilingCode {
     }
   }
   
+
+  public static PreparedStatement prepQueryNoCaseInfo(Connection conn, 
+      boolean initial, String domain, String courtLocationId) throws SQLException {
+    PreparedStatement st = conn.prepareStatement(getFilingNoCaseInfo(initial));
+    st.setString(1, domain);
+    st.setString(2, courtLocationId);
+    return st;
+  }
+
   private static String getFilingNoCaseInfo(boolean initial) {
     String mainQuery = """
           SELECT code, name, fee, casecategory, casetypeid, filingtype, iscourtuseonly, 
@@ -131,6 +152,15 @@ public class FilingCode {
     } else {
       return mainQuery + "AND (filingtype='Subsequent' OR filingtype='Both')";
     }
+  }
+  
+  // TODO(brycew): test this one in particular, it was wrong
+  public static PreparedStatement prepQueryWithCode(Connection conn, String domain, String courtId, String typeCode) throws SQLException {
+    PreparedStatement st = conn.prepareStatement(getFilingWithCode());
+    st.setString(1, domain);
+    st.setString(2, courtId);
+    st.setString(3, typeCode);
+    return st;
   }
   
   private static String getFilingWithCode() {

--- a/src/main/java/edu/suffolk/litlab/efspserver/tyler/codes/OptionalServiceCode.java
+++ b/src/main/java/edu/suffolk/litlab/efspserver/tyler/codes/OptionalServiceCode.java
@@ -74,20 +74,64 @@ public class OptionalServiceCode {
 
   public static PreparedStatement prepQuery(
       Connection conn, String domain, String courtId, String filingCodeId) throws SQLException {
-    PreparedStatement st = conn.prepareStatement(query());
+    final String query =
+        """
+        SELECT os.code, os.name, os.displayorder, os.fee, os_fl.filingcodeid, os.multiplier, os.altfeedesc, os.hasfeeprompt,
+          os.feeprompttext
+        FROM optionalservices as os JOIN optionalservices_filinglist as os_fl ON os.domain=os_fl.domain AND os.location=os_fl.location AND os.code=os_fl.code
+        WHERE os.domain=? AND os.location=? AND os_fl.filingcodeid=?
+        """;
+    PreparedStatement st = conn.prepareStatement(query);
     st.setString(1, domain);
     st.setString(2, courtId);
     st.setString(3, filingCodeId);
     return st;
   }
 
-  public static String query() {
-    return """
+  public static PreparedStatement prepSearch(Connection conn, String domain, String searchTerm)
+      throws SQLException {
+    final String search =
+        """
+        SELECT DISTINCT os.name
+        FROM optionalservices as os
+        WHERE os.domain=? AND os.name ILIKE ?
+        ORDER BY os.name
+        """;
+    PreparedStatement st = conn.prepareStatement(search);
+    st.setString(1, domain);
+    st.setString(2, searchTerm);
+    return st;
+  }
+
+  public static PreparedStatement prepRetrieve(Connection conn, String domain, String optServName)
+      throws SQLException {
+    final String retrieve =
+        """
+        SELECT DISTINCT os.code, os.location
+        FROM optionalservices as os
+        WHERE os.domain=? AND os.name=?
+        ORDER BY os.location
+        """;
+    PreparedStatement st = conn.prepareStatement(retrieve);
+    st.setString(1, domain);
+    st.setString(2, optServName);
+    return st;
+  }
+
+  public static PreparedStatement prepQueryWithCode(
+      Connection conn, String domain, String courtId, String optServCode) throws SQLException {
+    final String query =
+        """
         SELECT os.code, os.name, os.displayorder, os.fee, os_fl.filingcodeid, os.multiplier, os.altfeedesc, os.hasfeeprompt,
           os.feeprompttext
         FROM optionalservices as os JOIN optionalservices_filinglist as os_fl ON os.domain=os_fl.domain AND os.location=os_fl.location AND os.code=os_fl.code
-        WHERE os.domain=? AND os.location=? AND os_fl.filingcodeid=?
+        WHERE os.domain=? AND os.location=? AND os.code=?
         """;
+    PreparedStatement st = conn.prepareStatement(query);
+    st.setString(1, domain);
+    st.setString(2, courtId);
+    st.setString(3, optServCode);
+    return st;
   }
 
   public static void createFromOptionalServiceTable(Connection conn) throws SQLException {

--- a/src/main/java/edu/suffolk/litlab/efspserver/tyler/codes/PartyType.java
+++ b/src/main/java/edu/suffolk/litlab/efspserver/tyler/codes/PartyType.java
@@ -71,6 +71,24 @@ public class PartyType {
         rs.getString(12));
   }
 
+  public static String searchPartyType() {
+    return """
+        SELECT DISTINCT name
+        FROM partytype
+        WHERE domain=? AND name ILIKE ?
+        ORDER BY name
+        """;
+  }
+
+  public static String retrievePartyTypeFromName() {
+    return """
+        SELECT DISTINCT code, location
+        FROM partytype
+        WHERE domain=? AND name=?
+        ORDER BY location
+        """;
+  }
+
   public static String getPartyTypeFromCaseType() {
     return """
         SELECT code, name, isavailablefornewparties, casetypeid, isrequired, amount,
@@ -89,6 +107,15 @@ public class PartyType {
         FROM partytype
         WHERE domain=? AND location=? AND casetypeid=''
         ORDER BY isrequired DESC, displayorder, casetypeid DESC""";
+  }
+
+  public static String getPartyTypeFromCode() {
+    return """
+        SELECT code, name, isavailablefornewparties, casetypeid, isrequired, amount,
+               numberofpartiestoignore, sendforredaction, dateofdeath, displayorder,
+               efspcode, location
+        FROM partytype
+        WHERE domain=? AND location=? AND code=?""";
   }
 
   @Override


### PR DESCRIPTION
The flow goes like this:

1. To search for all filing types where the name has the words "Jury Demand" in
  it, go to `/jurisdictions/<id>/codes/filing_types?search=Jury Demand`. These methods are called `search` internally.
2. From there, you'll get the full names of the codes. Take one of those full
  names, say, "Jury Demand Filed - 12", and go to
  `jurisdiction/<id>/codes/filing_types/Jury Demand Filed -12`. These methods are called `retrieve` internally.
3. There, you'll get the codes and locations that have that exact name. Go to
  `jurisdictions/<id>/codes/courts/<location_id>/filing_types/12345` to get
  the full filing codes.

Added for:
* Case Categories
* Case Types
* Filing Types
* Party Types
* Optional Services