### PR TITLE
Use ExceptionMapper

### DIFF
--- a/src/main/java/edu/suffolk/litlab/efspserver/services/AdminUserService.java
+++ b/src/main/java/edu/suffolk/litlab/efspserver/services/AdminUserService.java
@@ -81,7 +81,6 @@ import tyler.efm.services.schema.userlistresponse.UserListResponseType;
  */
 @Produces(MediaType.APPLICATION_JSON)
 public class AdminUserService {
-
   private static final Logger log = LoggerFactory.getLogger(AdminUserService.class);
 
   private final EfmUserService userFactory;

--- a/src/main/java/edu/suffolk/litlab/efspserver/services/EfspServer.java
+++ b/src/main/java/edu/suffolk/litlab/efspserver/services/EfspServer.java
@@ -140,7 +140,11 @@ public class EfspServer {
         Map.of(
             "xml", MediaType.APPLICATION_XML,
             "json", MediaType.APPLICATION_JSON));
-    sf.setProviders(List.of(new JAXBElementProvider<Object>(), new JacksonJsonProvider()));
+    sf.setProviders(
+        List.of(
+            new JAXBElementProvider<Object>(),
+            new JacksonJsonProvider(),
+            new SoapExceptionMapper()));
 
     sf.setAddress(ServiceHelpers.BASE_LOCAL_URL);
     server = sf.create();

--- a/src/main/java/edu/suffolk/litlab/efspserver/services/SoapExceptionMapper.java
+++ b/src/main/java/edu/suffolk/litlab/efspserver/services/SoapExceptionMapper.java
@@ -1,0 +1,22 @@
+package edu.suffolk.litlab.efspserver.services;
+
+import edu.suffolk.litlab.efspserver.StdLib;
+import jakarta.ws.rs.core.Response;
+import jakarta.ws.rs.ext.ExceptionMapper;
+import jakarta.ws.rs.ext.Provider;
+import org.apache.cxf.interceptor.Fault;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+@Provider
+public class SoapExceptionMapper implements ExceptionMapper<Fault> {
+  private static final Logger log = LoggerFactory.getLogger(AdminUserService.class);
+
+  @Override
+  public Response toResponse(Fault exception) {
+    log.error(StdLib.strFromException(exception));
+    return Response.status(500)
+        .entity("\"Something went wrong when talking to Tyler Technologies servers\"")
+        .build();
+  }
+}


### PR DESCRIPTION
Make sure that we can properly get notifications for SOAP Fault exceptions that are thrown.

https://mincong.io/2018/12/03/exception-handling-in-jax-rs/ came in handy when writing it.

The `@Provider` tag by itself didn't work, but it is worthy of signaling, so I left it there.