### PR TITLE
Support client_sign.properties as a secure file.

### DIFF
--- a/docs/operations_guide/index.md
+++ b/docs/operations_guide/index.md
@@ -53,7 +53,9 @@ You should have separate .env files for each environment. For example, staging v
 
 ## Secured Files/Certs
 
-For files that you want to keep out of the Docker image, you should set up a private Fly.io Tigris bucket. This is Fly.io's equivalent of AWS's S3 service. When a Fly.io machine starts up, the fly_startup_script.sh will run. The script will pull down the keystore cert from Tigris if the file is not already in the system. While Fly.io will automatically inject the AWS config values into your application the first time you setup Tigris, you should also store the AWS config values in your .env file in case you need to reference them again or re-create a Fly.io app in the future.
+For files that you want to keep out of the Docker image, you should set up a private Fly.io Tigris bucket. This is Fly.io's equivalent of AWS's S3 service. When a Fly.io machine starts up, the fly_startup_script.sh will run. The script will pull down any secure files that are not already present from Tigris. This includes the PFX certificate and client_sign.properties. See the secured files section in the env.example file for the full list of supported files.
+
+While Fly.io will automatically inject the AWS config values into your application the first time you setup Tigris, you should also store the AWS config values in your .env file in case you need to reference them again or re-create a Fly.io app in the future.
 
 For more details, check out:
 https://fly.io/docs/reference/tigris/

--- a/env.example
+++ b/env.example
@@ -64,8 +64,13 @@ JEFFERSON_ENDPOINT=https://example.com
 # NOTE: this ONLY needs to be in the Docassemble server.
 JEFFERSON_KEY=
 
+##### Secured Files #####
+# These are secured files that are stored in encrypted cloud storage. Use this for any secured files that are not
+# baked into your Docker image. This is useful in the case of continuous deployment.
 # For Fly.io, this is the private Tigris (S3-compatible object store) URL to the cert referenced by PATH_TO_KEYSTORE
 #S3_TO_KEYSTORE_CERT=s3://my-tigris-url/MyOrg.pfx
+# Private Tigris URL to the client_sign.properties
+#S3_TO_CLIENT_SIGN_PROPERTIES=s3://my-tigris-url/client_sign.properties
 
 # Fly.io Tigris
 #BUCKET_NAME=

--- a/fly_startup_script.sh
+++ b/fly_startup_script.sh
@@ -8,6 +8,11 @@ if test -n "$FLY_MACHINE_ID"; then
   if ! test -f "$PATH_TO_KEYSTORE"; then
     echo "Installing cert"
     apk add --no-cache aws-cli
-    aws s3 cp $S3_TO_KEYSTORE_CERT .
+    aws s3 cp "$S3_TO_KEYSTORE_CERT" .
+  fi
+  if ! test -f "client_sign.properties"; then
+    echo "Installing client_sign.properties"
+    apk add --no-cache aws-cli
+    aws s3 cp "$S3_TO_CLIENT_SIGN_PROPERTIES" .
   fi
 fi


### PR DESCRIPTION
Should fix the nightly codes update when running from a continuous deployment built image.