### PR TITLE
Better errors when there's a prepare filing error

### DIFF
--- a/src/main/java/edu/suffolk/litlab/efspserver/ecf4/Ecf4Filer.java
+++ b/src/main/java/edu/suffolk/litlab/efspserver/ecf4/Ecf4Filer.java
@@ -668,6 +668,7 @@ public class Ecf4Filer extends EfmCheckableFilingInterface {
                   info, collector, apiToken, filingPort.get(), recordPort.get(), QueryType.Review)
               .cfm;
     } catch (FilingError err) {
+      log.error("Error when preparing Filing", err);
       return Result.err(err);
     }
 

--- a/src/main/java/edu/suffolk/litlab/efspserver/services/FilingError.java
+++ b/src/main/java/edu/suffolk/litlab/efspserver/services/FilingError.java
@@ -36,6 +36,7 @@ public class FilingError extends Exception {
   }
 
   private FilingError(Type type, String description, Optional<InterviewVariable> missingVariable) {
+    super(type.toString() + " " + description + " " + missingVariable.map(v -> v.toString()).orElse(""));
     this.type = type;
     this.description = description;
     this.missingVariable = missingVariable;

--- a/src/main/java/edu/suffolk/litlab/efspserver/services/FilingError.java
+++ b/src/main/java/edu/suffolk/litlab/efspserver/services/FilingError.java
@@ -36,7 +36,12 @@ public class FilingError extends Exception {
   }
 
   private FilingError(Type type, String description, Optional<InterviewVariable> missingVariable) {
-    super(type.toString() + " " + description + " " + missingVariable.map(v -> v.toString()).orElse(""));
+    super(
+        type.toString()
+            + " "
+            + description
+            + " "
+            + missingVariable.map(v -> v.toString()).orElse(""));
     this.type = type;
     this.description = description;
     this.missingVariable = missingVariable;

--- a/src/main/java/edu/suffolk/litlab/efspserver/tyler/codes/EcfCodesService.java
+++ b/src/main/java/edu/suffolk/litlab/efspserver/tyler/codes/EcfCodesService.java
@@ -319,7 +319,7 @@ public class EcfCodesService extends CodesService {
       if (errResp.isPresent()) {
         return errResp.get();
       }
-      return cors(Response.ok(cd.getCaseCategoryWithCode(courtId, catCode)));
+      return cors(Response.ok(cd.getCaseCategoryWithCode(courtId, catCode).orElse(null)));
     }
   }
 


### PR DESCRIPTION
Actually set the Exception class's message, so exception stack traces don't just say "null", and log as error when an error occurs when getting fees.

Minor fix: getting an individual category directly returned the Optional as JSON,  which is useless (only prints empty and present, from isEmpty and isPresent, lol).