### PR TITLE
Ignore tables that don't exist

### DIFF
--- a/src/main/java/edu/suffolk/litlab/efspserver/ecfcodes/CodeUpdater.java
+++ b/src/main/java/edu/suffolk/litlab/efspserver/ecfcodes/CodeUpdater.java
@@ -447,11 +447,11 @@ public class CodeUpdater {
           tables);
       for (String table : tables) {
         Instant deleteFromTable = Instant.now(Clock.systemUTC());
-        if (!cd.deleteFromTable(table, courtLocation)) {
-          log.error("Couldn't delete from {} at {}, aborting", table, courtLocation);
-          cd.rollback(sp);
-          return false;
-        }
+
+        // No longer checking for false here -- see PR.
+        // Will ignore tables that don't exist.
+        cd.deleteFromTable(table, courtLocation)
+
         updates = updates.plus(Duration.between(deleteFromTable, Instant.now(Clock.systemUTC())));
       }
     }

--- a/src/main/java/edu/suffolk/litlab/efspserver/ecfcodes/CodeUpdater.java
+++ b/src/main/java/edu/suffolk/litlab/efspserver/ecfcodes/CodeUpdater.java
@@ -450,7 +450,7 @@ public class CodeUpdater {
 
         // No longer checking for false here -- see PR.
         // Will ignore tables that don't exist.
-        cd.deleteFromTable(table, courtLocation)
+        cd.deleteFromTable(table, courtLocation);
 
         updates = updates.plus(Duration.between(deleteFromTable, Instant.now(Clock.systemUTC())));
       }


### PR DESCRIPTION
Attempts to resolve Tyler Code refresh issue.

We're changing it so when we try to delete data for a table that doesn't exist yet, it just skips it. It seems benign, but maybe we're missing some context. 

@BryceStevenWilley no pressure to review, just so you're aware!

