### PR TITLE
Re-enable coverage data on `mvn verify`

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -294,7 +294,7 @@
         <dependency>
             <groupId>org.mockito</groupId>
             <artifactId>mockito-core</artifactId>
-            <version>3.11.2</version>
+            <version>3.12.4</version>
             <scope>test</scope>
         </dependency>
     </dependencies>
@@ -350,7 +350,7 @@
                     <configuration>
                         <redirectTestOutputToFile>true</redirectTestOutputToFile>
                         <trimStackTrace>false</trimStackTrace>
-                        <argLine>${argLine}</argLine>
+                        <argLine>@{argLine}</argLine>
                     </configuration>
                 </plugin>
                 <plugin>
@@ -444,7 +444,7 @@
                 <plugin>
                     <groupId>org.jacoco</groupId>
                     <artifactId>jacoco-maven-plugin</artifactId>
-                    <version>0.8.10</version>
+                    <version>0.8.12</version>
                     <configuration>
                         <excludes>
                             <exclude>ecfv5/**/*.class</exclude>
@@ -459,13 +459,13 @@
                     </configuration>
                     <executions>
                         <execution>
-                            <id>default-prepare-agent</id>
                             <goals>
                                 <goal>prepare-agent</goal>
                             </goals>
                         </execution>
                         <execution>
                             <id>default-report</id>
+                            <phase>verify</phase>
                             <goals>
                                 <goal>report</goal>
                             </goals>
@@ -494,6 +494,14 @@
                 </plugin>
             </plugins>
         </pluginManagement>
+
+
+        <plugins>
+            <plugin>
+                <groupId>org.jacoco</groupId>
+                <artifactId>jacoco-maven-plugin</artifactId>
+            </plugin>
+        </plugins>
     </build>
     
     <reporting>

--- a/pom.xml
+++ b/pom.xml
@@ -481,9 +481,10 @@
                                         <element>BUNDLE</element>
                                         <limits>
                                             <limit>
-                                                <counter>COMPLEXITY</counter>
+                                                <counter>INSTRUCTION</counter>
                                                 <value>COVEREDRATIO</value>
-                                                <minimum>0.60</minimum>
+                                                <!-- TODO(brycew): ratchet this up to at least 75% -->
+                                                <minimum>0.25</minimum>
                                             </limit>
                                         </limits>
                                     </rule>
@@ -494,7 +495,6 @@
                 </plugin>
             </plugins>
         </pluginManagement>
-
 
         <plugins>
             <plugin>


### PR DESCRIPTION
In order to be more knowledgeable about any testing gaps we have, we want coverage metrics to be generated using [JaCoCo](https://www.eclemma.org/jacoco/) on each run of the unit (and any eventual Java-run integration) tests. This will help the ECF5 effort by finding gaps in unit tests and helping us do any necessary refactors for ECF5 more confidentially.

When revisiting the repo, I noticed that JaCoCo was not running as it should have been. When I initially wrote the project back in my Java-ignorant days, I had incorrectly setup the JaCoCo plugin in the `pom.xml`: it was configured in `<pluginManagement>`, but not in `<plugins>`. So, the config would be used in any child projects, but not in the project itself. Additionally, it adds the report to the `verify` phase, which occurs after integration tests and before the `install` phase.

Additionally did some related cleanups to get JaCoCo to succeed, which include:

* Changed JaCoCo's `check` goal to only fail if the line coverage is below 25% (currently at 27%). We can ratchet it higher and higher as the test coverage improves (which I plan on focusing on for future PRs). 
* Using maven's 'late property evaluation' in surefire for JaCoCo to work (`@argLine` instead of `$argLine`).
* Bumped JaCoCo version to latest, which is only a patch update.
* Bumped mockito's version, which was failing locally for me due to a registry error.]