### PR TITLE
Start using JUnit's Tags to organize tests

### DIFF
--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -14,4 +14,4 @@ jobs:
           java-version: '17'
           distribution: 'adopt'
       - name: Build with Maven
-        run: mvn --batch-mode package
+        run: mvn --batch-mode -Preproducible package

--- a/README.md
+++ b/README.md
@@ -31,8 +31,17 @@ The API token to add to the docassemble config will be printed out.
 
 ## Testing
 
-You can run tests with `mvn test`. To run integration tests
-with coverage, do the following:
+You can run tests with `mvn test`. By default, all tests will run, but you can also limit the types of tests that you run with different maven profiles.
+
+* `mvn -PnoDockerTests test` will avoid tests that use docker. The Database tests spin up little docker containers to ensure that the queries work with Postgres. However, when this server is packaged up and run in a docker container, the nested docker enginer isn't available for the tests to run. So we need a way to avoid running those tests when packaging within docker.
+* `mvn -Preproducible test` will avoid tests that changes on Tyler's side might break, i.e. anything that makes a connection to a staging server. Useful for running on PRs, as we don't want to block PRs on unrelated issues.
+* `mvn -PtylerBreakable test` will **only** run tests that make a connection to Tyler staging servers. These are important to run routinely to ensure that we are aware of potentially breaking changes from the Tyler side.
+
+These testing groups are maintained with [JUnit's Tag](https://junit.org/junit5/docs/current/user-guide/#writing-tests-tagging-and-filtering) feature; each tag is specified in the profile's `<group>` or `<excludedGroup>` in the [pom.xml](pom.xml).
+
+### Integration Tests
+
+To run integration tests with coverage, do the following:
 
 ```bash
 # download a separate jar for jacoco and extract it

--- a/pom.xml
+++ b/pom.xml
@@ -544,7 +544,7 @@
                         <artifactId>maven-surefire-plugin</artifactId>
                         <version>${maven-surefire.version}</version>
                         <configuration>
-                            <excludedGroups>Tyler-Breakable</excludedGroups>
+                            <excludedGroups>TylerBreakable</excludedGroups>
                         </configuration>
                     </plugin>
                 </plugins>
@@ -560,7 +560,7 @@
                         <artifactId>maven-surefire-plugin</artifactId>
                         <version>${maven-surefire.version}</version>
                         <configuration>
-                            <groups>Tyler-Breakable</groups>
+                            <groups>TylerBreakable</groups>
                         </configuration>
                     </plugin>
                 </plugins>

--- a/pom.xml
+++ b/pom.xml
@@ -516,15 +516,10 @@
         </plugins>
     </reporting>
     
+    <!-- See the "Testing" section of the README for more information on these testing profiles. -->
     <profiles>
         <profile>
-        <!-- This profile is used because the Database tests spin up little
-             docker containers to ensure that the queries work with Postgres.
-             
-             However, when this server is packaged up and run in a docker container,
-             the nested docker enginer isn't available for the tests to run. So just
-             don't run those tests when packaging within docker.
-              -->
+        <!-- This profile excludes tests that use docker, so we can run tests when packaging from within a docker container. -->
             <id>noDockerTests</id>
             <build>
                 <plugins>
@@ -533,18 +528,43 @@
                         <artifactId>maven-surefire-plugin</artifactId>
                         <version>${maven-surefire.version}</version>
                         <configuration>
-                            <excludes>
-                                <exclude>**/UserDatabaseTest.java</exclude>
-                                <exclude>**/LoginDatabaseTest.java</exclude>
-                                <exclude>**/CodeDatabaseTest.java</exclude>
-                                <exclude>**/CodesServiceTest.java</exclude>
-                                <exclude>**/DatabaseVersionTest.java</exclude>
-                            </excludes>
+                            <excludedGroups>Docker</excludedGroups>
                         </configuration>
                     </plugin>
                 </plugins>
             </build>
         </profile>
-
+        <profile>
+            <!-- This profile runs reproducible tests, i.e. non flaky tests. -->
+            <id>reproducible</id>
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-surefire-plugin</artifactId>
+                        <version>${maven-surefire.version}</version>
+                        <configuration>
+                            <excludedGroups>Tyler-Breakable</excludedGroups>
+                        </configuration>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
+        <profile>
+            <!-- This profile runs tests that changes on Tyler's side might break. -->
+            <id>tylerBreakable</id>
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-surefire-plugin</artifactId>
+                        <version>${maven-surefire.version}</version>
+                        <configuration>
+                            <groups>Tyler-Breakable</groups>
+                        </configuration>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
     </profiles>
 </project>

--- a/src/test/java/edu/suffolk/litlab/efspserver/SoapClientChooserTest.java
+++ b/src/test/java/edu/suffolk/litlab/efspserver/SoapClientChooserTest.java
@@ -1,24 +1,26 @@
 package edu.suffolk.litlab.efspserver;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.io.IOException;
 import java.net.HttpURLConnection;
 import java.net.URL;
 
+import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 
 import edu.suffolk.litlab.efspserver.tyler.TylerUrls;
 
+@Tag("Tyler-Breakable")
 public class SoapClientChooserTest {
   
   public void testJurisdictionEnvUrl(String urlExpected, String urlGenerated) throws IOException {
-    assertEquals(urlExpected, urlGenerated);
+    assertThat(urlGenerated).isEqualTo(urlExpected);
     URL url = new URL(urlGenerated);
     HttpURLConnection conn = (HttpURLConnection) url.openConnection();
     int resp = conn.getResponseCode();
-    assertTrue("The generated URL (" + urlGenerated + ") returns an invalid HTTP error code: " + Integer.toString(resp), resp < 400);
+    assertTrue(resp < 400, () -> "The generated URL (" + urlGenerated + ") returns an invalid HTTP error code: " + Integer.toString(resp));
   }
 
   @Test

--- a/src/test/java/edu/suffolk/litlab/efspserver/SoapClientChooserTest.java
+++ b/src/test/java/edu/suffolk/litlab/efspserver/SoapClientChooserTest.java
@@ -12,7 +12,7 @@ import org.junit.jupiter.api.Test;
 
 import edu.suffolk.litlab.efspserver.tyler.TylerUrls;
 
-@Tag("Tyler-Breakable")
+@Tag("TylerBreakable")
 public class SoapClientChooserTest {
   
   public void testJurisdictionEnvUrl(String urlExpected, String urlGenerated) throws IOException {

--- a/src/test/java/edu/suffolk/litlab/efspserver/db/DatabaseVersionTest.java
+++ b/src/test/java/edu/suffolk/litlab/efspserver/db/DatabaseVersionTest.java
@@ -29,6 +29,7 @@ import org.apache.commons.compress.archivers.tar.TarArchiveInputStream;
 import org.apache.commons.compress.utils.IOUtils;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -42,6 +43,7 @@ import edu.suffolk.litlab.efspserver.tyler.codes.FilingComponent;
 import edu.suffolk.litlab.efspserver.tyler.codes.OptionalServiceCode;
 import edu.suffolk.litlab.efspserver.tyler.codes.PartyType;
 
+@Tag("Docker")
 public class DatabaseVersionTest {
 
   public static final String POSTGRES_DOCKER_NAME = "postgres:14";

--- a/src/test/java/edu/suffolk/litlab/efspserver/db/LoginDatabaseTest.java
+++ b/src/test/java/edu/suffolk/litlab/efspserver/db/LoginDatabaseTest.java
@@ -15,12 +15,14 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Tag;
 import org.testcontainers.containers.PostgreSQLContainer;
 import org.testcontainers.junit.jupiter.Container;
 import org.testcontainers.utility.DockerImageName;
 
 import com.fasterxml.jackson.databind.JsonNode;
 
+@Tag("Docker")
 public class LoginDatabaseTest {
   private final static Logger log = 
       LoggerFactory.getLogger(LoginDatabaseTest.class); 

--- a/src/test/java/edu/suffolk/litlab/efspserver/db/UserDatabaseTest.java
+++ b/src/test/java/edu/suffolk/litlab/efspserver/db/UserDatabaseTest.java
@@ -11,11 +11,13 @@ import java.util.UUID;
 
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 import org.testcontainers.containers.PostgreSQLContainer;
 import org.testcontainers.junit.jupiter.Container;
 import org.testcontainers.utility.DockerImageName;
 
+@Tag("Docker")
 public class UserDatabaseTest {
   
   private UserDatabase ud;

--- a/src/test/java/edu/suffolk/litlab/efspserver/services/CodesServiceTest.java
+++ b/src/test/java/edu/suffolk/litlab/efspserver/services/CodesServiceTest.java
@@ -19,6 +19,7 @@ import org.apache.cxf.jaxrs.lifecycle.SingletonResourceProvider;
 import org.apache.cxf.jaxrs.provider.JAXBElementProvider;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -37,6 +38,7 @@ import edu.suffolk.litlab.efspserver.db.DatabaseVersionTest;
 import edu.suffolk.litlab.efspserver.tyler.codes.CodeDatabase;
 import edu.suffolk.litlab.efspserver.tyler.codes.EcfCodesService;
 
+@Tag("Docker")
 public class CodesServiceTest {
   private static Logger log = LoggerFactory.getLogger(CodesServiceTest.class);
   

--- a/src/test/java/edu/suffolk/litlab/efspserver/tyler/codes/CodeDatabaseTest.java
+++ b/src/test/java/edu/suffolk/litlab/efspserver/tyler/codes/CodeDatabaseTest.java
@@ -13,6 +13,7 @@ import java.util.Optional;
 
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -24,6 +25,7 @@ import edu.suffolk.litlab.efspserver.db.DatabaseCreator;
 import edu.suffolk.litlab.efspserver.db.DatabaseVersionTest;
 import edu.suffolk.litlab.efspserver.ecfcodes.CodeUpdater;
 
+@Tag("Docker")
 public class CodeDatabaseTest {
   private static Logger log = 
       LoggerFactory.getLogger(CodeDatabaseTest.class); 


### PR DESCRIPTION
Mainly for us to not run tests that make a connection to Tyler servers in our CICD pipelines, as they will break unexpectedly.

Made because currently, the `SoapClientChooserTest` was failing in both #200 and #197, for reasons completely unrelated to those PRs. This should keep the CICD cleaner and more consistent.