### PR TITLE
Add cache in workflow file

### DIFF
--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -9,9 +9,10 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - name: Set up JDK 11
-        uses: actions/setup-java@v3
+        uses: actions/setup-java@v4
         with:
           java-version: '17'
           distribution: 'adopt'
+          cache: 'maven'
       - name: Build with Maven
         run: mvn --batch-mode -Preproducible package


### PR DESCRIPTION
Not too much faster, but does save ~96MB of bandwidth from maven central on each run. Pretty nice.

~1/2 of the time is spent on compiling everything, ~1/2 is spent on tests (90% of the tests are `CodesServiceTest` and `DatabaseVersionTest`, the DB container tests that spin up a docker container for postgres.