### PR TITLE
Change apk to apt

### DIFF
--- a/fly_startup_script.sh
+++ b/fly_startup_script.sh
@@ -7,12 +7,12 @@ if test -n "$FLY_MACHINE_ID"; then
   echo "Running Fly.io startup checks..."
   if ! test -f "$PATH_TO_KEYSTORE"; then
     echo "Installing cert"
-    apk add --no-cache aws-cli
+    apt update && apt install awscli
     aws s3 cp "$S3_TO_KEYSTORE_CERT" .
   fi
   if ! test -f "client_sign.properties"; then
     echo "Installing client_sign.properties"
-    apk add --no-cache aws-cli
+    apt update && apt install awscli
     aws s3 cp "$S3_TO_CLIENT_SIGN_PROPERTIES" .
   fi
 fi


### PR DESCRIPTION
Since we switched from alpine images in #204 (completed in #206), we can no longer use apk, and must use ubuntu's `apt` instead.

Only place `apk` is used in this repo, so should be good. Will have to merge to main to test though.