### PR TITLE
Revert change made in #207, and the alpine change in #206.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM maven:3.8-eclipse-temurin-17
+FROM maven:3.8-eclipse-temurin-17-alpine
 # The `[]` is an optional COPY: doesn't copy if those files aren't there (https://stackoverflow.com/a/46801962/11416267)
 # They are needed for Tyler API usage, and serving the REST API as HTTPS
 COPY pom.xml LICENSE client_sign.propertie[s] quartz.properties Suffolk.pf[x] acme_user.ke[y] acme_domain.ke[y] acme_domain-chain.cr[t] extract-tls-secrets-4.0.0.ja[r] jacocoagent.ja[r] /usr/src/app/

--- a/fly_startup_script.sh
+++ b/fly_startup_script.sh
@@ -7,12 +7,12 @@ if test -n "$FLY_MACHINE_ID"; then
   echo "Running Fly.io startup checks..."
   if ! test -f "$PATH_TO_KEYSTORE"; then
     echo "Installing cert"
-    apt-get update && apt-get install -y awscli
+    apk add --no-cache aws-cli
     aws s3 cp "$S3_TO_KEYSTORE_CERT" .
   fi
   if ! test -f "client_sign.properties"; then
     echo "Installing client_sign.properties"
-    apt-get update && apt-get install -y awscli
+    apk add --no-cache aws-cli
     aws s3 cp "$S3_TO_CLIENT_SIGN_PROPERTIES" .
   fi
 fi


### PR DESCRIPTION
Installing and using AWS-cli in Jammy seems to be broken somehow, getting this error:

>  fatal error: An error occurred (403) when calling the HeadObject operation: Forbidden

I assume that it's a permission thing in S3 (not sure how it's acting different in a different image), but it's something I'll have to fix later. Revert to a working state.

