### PR TITLE
Update to latest google-java-format (1.27.0)

### DIFF
--- a/.github/workflows/formatting.yml
+++ b/.github/workflows/formatting.yml
@@ -14,3 +14,7 @@ jobs:
           wget https://github.com/google/google-java-format/releases/download/v1.27.0/google-java-format_linux-x86-64
           chmod +x google-java-format_linux-x86-64
           ./google-java-format_linux-x86-64 --dry-run --set-exit-if-changed `find src/main/java/edu/suffolk -name *.java ! -name CodeTableConstants.java ! -name FilingCode.java`
+      - name: Help (if necessary)
+        if: failure()
+        run: |
+          echo "The files listed above have formatting issues! See the instructions in CONTRIBUTING.md to format the Java code!"

--- a/.github/workflows/formatting.yml
+++ b/.github/workflows/formatting.yml
@@ -8,12 +8,9 @@ jobs:
 
     steps:
       - uses: actions/checkout@v4
-      - name: Set up JDK 17
-        uses: actions/setup-java@v4
-        with:
-          java-version: '17'
-          distribution: 'adopt'
       - name: Format all of the code
+        # Gets the native graal image: a bit bigger, but don't need to set up Java, faster startup
         run: |
-          wget https://github.com/google/google-java-format/releases/download/v1.16.0/google-java-format-1.16.0-all-deps.jar
-          java -jar google-java-format-1.16.0-all-deps.jar --dry-run --set-exit-if-changed `find src/main/java/edu/suffolk -name *.java ! -name CodeTableConstants.java ! -name FilingCode.java`
+          wget https://github.com/google/google-java-format/releases/download/v1.27.0/google-java-format_linux-x86-64
+          chmod +x google-java-format_linux-x86-64
+          ./google-java-format_linux-x86-64 --dry-run --set-exit-if-changed `find src/main/java/edu/suffolk -name *.java ! -name CodeTableConstants.java ! -name FilingCode.java`

--- a/.gitignore
+++ b/.gitignore
@@ -72,3 +72,6 @@ docassemble-os/
 
 # Test related
 !src/test/resources/tyler_efm_codes*.tar.gz
+
+# formatting
+google-java-format_*

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -6,10 +6,11 @@ See the [README.md] and [docs/setup.md] for more details here.
 
 ## Formatting code
 
-[Download the google-java-format](https://github.com/google/google-java-format/releases/download/v1.16.0/google-java-format-1.16.0-all-deps.jar) tool, and once downloaded, run
+Download [version 1.27.0 of the native graal executable of google-java-format](https://github.com/google/google-java-format/releases/tag/v1.27.0) for your platform, and once downloaded, run
 
 ```bash
-java -jar google-java-format-1.16.0-all-deps.jar -i `find src/main/java/edu/suffolk -name *.java ! -name CodeTableConstants.java ! -name FilingCode.java`
+chmod +x google-java-format_linux-x86-64 # just once, use the name of your platform
+./google-java-format_linux-x86-64 -i `find src/main/java/edu/suffolk -name *.java ! -name CodeTableConstants.java ! -name FilingCode.java`
 ```
 
 To format all of your files.

--- a/src/main/java/edu/suffolk/litlab/efspserver/Address.java
+++ b/src/main/java/edu/suffolk/litlab/efspserver/Address.java
@@ -11,8 +11,7 @@ public class Address {
   @JsonProperty("AddressLine2")
   private String apartmentLine;
 
-  @JsonProperty("City")
-  private String cityName;
+  @JsonProperty("City")        private String      cityName     ;
 
   @JsonProperty("State")
   private String stateName;
@@ -24,13 +23,7 @@ public class Address {
   private String countryName;
 
   /** Constructor, each address element in order as a string. No qualifications. */
-  public Address(
-      String streetLine,
-      String apartmentLine,
-      String cityName,
-      String stateName,
-      String zipCode,
-      CountryCodeSimpleType countryName) {
+  public Address(String streetLine, String apartmentLine, String cityName, String stateName, String zipCode, CountryCodeSimpleType countryName) {
     this.streetLine = streetLine;
     this.apartmentLine = apartmentLine;
     this.cityName = cityName;

--- a/src/main/java/edu/suffolk/litlab/efspserver/Address.java
+++ b/src/main/java/edu/suffolk/litlab/efspserver/Address.java
@@ -11,7 +11,8 @@ public class Address {
   @JsonProperty("AddressLine2")
   private String apartmentLine;
 
-  @JsonProperty("City")        private String      cityName     ;
+  @JsonProperty("City")
+  private String cityName;
 
   @JsonProperty("State")
   private String stateName;
@@ -23,7 +24,13 @@ public class Address {
   private String countryName;
 
   /** Constructor, each address element in order as a string. No qualifications. */
-  public Address(String streetLine, String apartmentLine, String cityName, String stateName, String zipCode, CountryCodeSimpleType countryName) {
+  public Address(
+      String streetLine,
+      String apartmentLine,
+      String cityName,
+      String stateName,
+      String zipCode,
+      CountryCodeSimpleType countryName) {
     this.streetLine = streetLine;
     this.apartmentLine = apartmentLine;
     this.cityName = cityName;

--- a/src/main/java/edu/suffolk/litlab/efspserver/services/PaymentsService.java
+++ b/src/main/java/edu/suffolk/litlab/efspserver/services/PaymentsService.java
@@ -387,7 +387,7 @@ public class PaymentsService {
 
     log.info("Redirecting with transactionId: " + transactionId);
     String fullHtml =
-        """
+"""
 <!DOCTYPE html>
 <html>
     <head>


### PR DESCRIPTION
* only one small formatting change affected the repo (text block start quote moved to beginning of line)
* can use the native graal image to format: faster startup / runtime
    * 8 seconds vs 13 on main, and 31MB download vs 198 on main (for all of Java)
* don't need Java on the GitHub image / can run with java versions newer than 17
* added better help message in GitHub action when it fails (just saying what to do, instead of a file path with no context)