### PR TITLE
Build the main Jar with all dependencies

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,7 +5,7 @@ COPY pom.xml LICENSE client_sign.propertie[s] quartz.properties Suffolk.pf[x] ac
 # Install all of the maven packages, so we don't have to every time we change code
 RUN mvn -f /usr/src/app/pom.xml -DskipTests clean dependency:resolve dependency:go-offline package && mvn -f /usr/src/app/pom.xml test
 COPY src /usr/src/app/src
-RUN mvn -f /usr/src/app/pom.xml -DskipTests package dependency:build-classpath -Dmdep.outputFile=cp.txt -PnoDockerTests
+RUN mvn -f /usr/src/app/pom.xml -DskipTests package -PnoDockerTests
 COPY docker_run_script.sh docker_integration_test.sh fly_startup_script.sh /usr/src/app/
 
 EXPOSE 9000

--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ Docker env files can't be directly used in `bash`, so if you are running things 
 Run the following command after starting the services with `docker compose`:
 
 ```bash
-docker exec -i efileproxyserver-efspjava-1 /usr/bin/mvn -f /usr/src/app/pom.xml exec:java@LoginDatabase -Dexec.args="servername true true"
+docker exec -i efileproxyserver-efspjava-1 /usr/bin/java -cp /usr/src/app/target/efspserver-with-deps.jar edu.suffolk.litlab.efspserver.db.LoginDatabase \"servername\" true true
 ```
 
 The API token to add to the docassemble config will be printed out.

--- a/docker_integration_test.sh
+++ b/docker_integration_test.sh
@@ -4,7 +4,7 @@ set -x
 cd /usr/src/app
 java \
     -javaagent:jacocoagent.jar=destfile=/tmp/jacoco/jacoco.exec \
-    -cp $(cat cp.txt):target/efspserver.jar \
+    -cp target/efspserver-with-deps.jar \
     edu.suffolk.litlab.efspserver.db.LoginDatabase integrationTest true true > /tmp/secrets/proxy_stuff.txt
 # Add this before the `-cp` line if needed to get exact SOAP envelopes being sent
 # -javaagent:extract-tls-secrets-4.0.0.jar=/tmp/secrets/secrets.log \
@@ -15,6 +15,5 @@ java \
 exec java \
     -javaagent:extract-tls-secrets-4.0.0.jar=/tmp/secrets/secrets.log \
     -javaagent:jacocoagent.jar=destfile=/tmp/jacoco/jacoco.exec \
-    -cp $(cat cp.txt):target/efspserver.jar \
     -XX:+HeapDumpOnOutOfMemoryError \
-    edu.suffolk.litlab.efspserver.services.EfspServer
+    -jar target/efspserver-with-deps.jar

--- a/docker_run_script.sh
+++ b/docker_run_script.sh
@@ -16,8 +16,7 @@ fi
 # if needed to debug http logs:
 # https://stackoverflow.com/questions/53215038/how-to-log-request-response-using-java-net-http-httpclient
 exec java \
-    -cp $(cat cp.txt):target/efspserver.jar \
     -XX:+HeapDumpOnOutOfMemoryError \
     -XX:InitialRAMPercentage=20.0 \
     -XX:MaxRAMPercentage=75.0 \
-    edu.suffolk.litlab.efspserver.services.EfspServer
+    -jar target/efspserver-with-deps.jar

--- a/docs/developing.md
+++ b/docs/developing.md
@@ -82,7 +82,7 @@ index 3d903c53..57028ced 100755
  # https://stackoverflow.com/questions/53215038/how-to-log-request-response-using-java-net-http-httpclient
  exec java \
 +    -javaagent:extract-tls-secrets-4.0.0.jar=/tmp/secrets/secrets.log \
-     -cp $(cat cp.txt):target/efspserver.jar \
+     -cp target/efspserver-with-deps.jar \
      -XX:+HeapDumpOnOutOfMemoryError \
      -XX:InitialRAMPercentage=20.0 \
 ```

--- a/docs/https.md
+++ b/docs/https.md
@@ -21,7 +21,7 @@ We are still working to improve the steps, but current the process is:
 2. Start up the docker containers (see [setup.md](setup.md)).
 3. Start a bash shell inside the running container: `docker exec -it efileproxyserver-efspjava-1 /bin/bash`
 4. Change directories to the app: `cd /usr/src/app`.
-5. Run the ACME renewal process: `java -cp $(cat cp.txt):target/efspserver.jar edu.suffolk.litlab.efspserver.services.acme.AcmeRenewal renew`.
+5. Run the ACME renewal process: `java -cp target/efspserver-with-deps.jar edu.suffolk.litlab.efspserver.services.acme.AcmeRenewal renew`.
    If the renewal process succeeded, `acme-domain-chain.crt` and `tls_server_cert.jks`
    should both be present in `/tmp/tls_certs` inside the container and in `src/main/config` outside the container.
 6. Exit the bash shell you started, and rebuild and restart the java docker container.

--- a/docs/wsdl2java.md
+++ b/docs/wsdl2java.md
@@ -106,7 +106,7 @@ working in. For us it's mostly `illinois-stage`.
       the pom file's exec-maven-plugin, and just runs the `main` function. The command is below:
 
       ```bash
-      mvn exec:java@XsdDownloader -Dexec.args="https://jurisdiction-env.tylertech.cloud/EFM/Schema/ECF-4.0-FilingReviewMDEService.wsdl ecf"
+      java -cp target/efspserver-with-deps.jar edu.suffolk.litlab.efspserver.XsdDownloader https://jurisdiction-env.tylertech.cloud/EFM/Schema/ECF-4.0-FilingReviewMDEService.wsdl ecf
       ```
 
       This will download all of the ECF files, giving them a single specific prefix. You'll need to move them
@@ -128,7 +128,7 @@ working in. For us it's mostly `illinois-stage`.
       ECF v5, not ECF v4. So just run:
 
       ```bash
-      mvn exec:java@XsdDownloader -Dexec.args="https://jurisdiction-env.tylertech.cloud/EFM/Schema/v5/CourtSchedulingMDE.wsdl ecf-v5"
+      java -cp target/efspserver-with-deps.jar edu.suffolk.litlab.efspserver.XsdDownloader https://jurisdiction-env.tylertech.cloud/EFM/Schema/v5/CourtSchedulingMDE.wsdl ecf-v5
       ```
 
       and move all the files to a different resource directory, this time `src/main/resources/wsdl/{tyler_env}/`.

--- a/fly_create_api_key.sh
+++ b/fly_create_api_key.sh
@@ -1,3 +1,3 @@
 echo "Who will be using this API key? This value will be stored in the server_name field (so no spaces)."
 read server_name
-fly console --debug --verbose --vm-size shared-cpu-2x --vm-memory 4096 --command "mvn -f /usr/src/app/pom.xml exec:java@LoginDatabase -Dexec.args=\"$server_name true true\""
+fly console --debug --verbose --vm-size shared-cpu-2x --vm-memory 4096 --command "java -cp /usr/src/app/target/efspserver-with-deps.jar edu.suffolk.litlab.efspserver.db.LoginDatabase \"$server_name\" true true"

--- a/fly_create_prod_api_key.sh
+++ b/fly_create_prod_api_key.sh
@@ -1,3 +1,3 @@
 echo "Who will be using this API key? This value will be stored in the server_name field (so no spaces)."
 read server_name
-fly console --config fly.production.toml --debug --verbose --vm-size shared-cpu-2x --vm-memory 4096 --command "mvn -f /usr/src/app/pom.xml exec:java@LoginDatabase -Dexec.args=\"$server_name true true\""
+fly console --config fly.production.toml --debug --verbose --vm-size shared-cpu-2x --vm-memory 4096 --command "java -cp /usr/src/app/target/efspserver-with-deps.jar edu.suffolk.litlab.efspserver.db.LoginDatabase \"$server_name\" true true"

--- a/local_create_api_key.sh
+++ b/local_create_api_key.sh
@@ -1,3 +1,3 @@
 echo "Who will be using this API key? This value will be stored in the server_name field (so no spaces)."
 read server_name
-docker exec -t efileproxyserver-efspjava-1 sh -c "mvn -f /usr/src/app/pom.xml exec:java@LoginDatabase -Dexec.args=\"$server_name true true\""
+docker exec -t efileproxyserver-efspjava-1 sh -c "java -cp /usr/src/app/target/efspserver-with-deps.jar edu.suffolk.litlab.efspserver.db.LoginDatabase \"$server_name\" true true"

--- a/pom.xml
+++ b/pom.xml
@@ -181,7 +181,6 @@
             <groupId>jakarta.mail</groupId>
             <artifactId>jakarta.mail-api</artifactId>
             <version>2.1.0</version>
-            <scope>provided</scope>
         </dependency>
         <dependency>
             <groupId>org.springframework</groupId>
@@ -391,60 +390,6 @@
                     <version>3.0.0</version>
                 </plugin>
                 <plugin>
-                    <groupId>org.codehaus.mojo</groupId>
-                    <artifactId>exec-maven-plugin</artifactId>
-                    <version>1.2.1</version>
-                    <executions>
-                        <execution>
-                            <id>XsdDownloader</id>
-                            <goals>
-                                <goal>java</goal>
-                            </goals>
-                            <configuration>
-                                <mainClass>edu.suffolk.litlab.efspserver.XsdDownloader</mainClass>
-                                <!-- mainClass>edu.suffolk.litlab.efspserver.EfmClient</mainClass-->
-                                <!-- mainClass>edu.suffolk.litlab.efspserver.services.EfspServer</mainClass -->
-                            </configuration>
-                        </execution>
-                        <execution>
-                            <id>LoginDatabase</id>
-                            <goals>
-                                <goal>java</goal>
-                            </goals>
-                            <configuration>
-                                <mainClass>edu.suffolk.litlab.efspserver.db.LoginDatabase</mainClass>
-                            </configuration>
-                        </execution>
-                        <execution>
-                            <id>CodeUpdater</id>
-                            <goals>
-                                <goal>java</goal>
-                            </goals>
-                            <configuration>
-                                <mainClass>edu.suffolk.litlab.efspserver.ecfcodes.CodeUpdater</mainClass>
-                            </configuration>
-                        </execution>
-                        <execution>
-                            <id>AcmeRenewal</id>
-                            <goals>
-                                <goal>java</goal>
-                            </goals>
-                            <configuration>
-                                <mainClass>edu.suffolk.litlab.efspserver.services.AcmeRenewal</mainClass>
-                            </configuration>
-                        </execution>
-                        <execution>
-                            <id>filingassemblyclient</id>
-                            <goals>
-                                <goal>java</goal>
-                            </goals>
-                            <configuration>
-                                <mainClass>oasis.names.tc.legalxml_courtfiling.wsdl.webservicesprofile_definitions_4_0.FilingAssemblyMDEPort_FilingAssemblyMDEPort_Client</mainClass>
-                            </configuration>
-                        </execution>
-                    </executions>
-                </plugin>
-                <plugin>
                     <groupId>org.jacoco</groupId>
                     <artifactId>jacoco-maven-plugin</artifactId>
                     <version>0.8.12</version>
@@ -503,6 +448,46 @@
             <plugin>
                 <groupId>org.jacoco</groupId>
                 <artifactId>jacoco-maven-plugin</artifactId>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-shade-plugin</artifactId>
+                <version>3.2.4</version>
+                <executions>
+                    <execution>
+                        <!-- https://stackoverflow.com/a/76639555/11416267 -->
+                        <id>shade-jar-with-dependencies</id>
+                        <phase>package</phase>
+                        <goals>
+                            <goal>shade</goal>
+                        </goals>
+                        <configuration>
+                            <!-- Needed for CXF to work in a fatjar https://stackoverflow.com/a/68743972/11416267 -->
+                            <transformers>
+                                <transformer implementation="org.apache.maven.plugins.shade.resource.ManifestResourceTransformer">
+                                  <manifestEntries>
+                                    <Main-Class>edu.suffolk.litlab.efspserver.services.EfspServer</Main-Class>
+                                  </manifestEntries>
+                                </transformer>
+                                <transformer implementation="org.apache.maven.plugins.shade.resource.AppendingTransformer">
+                                    <resource>META-INF/cxf/bus-extensions.txt</resource>
+                                </transformer>
+                                <transformer implementation="org.apache.maven.plugins.shade.resource.ServicesResourceTransformer"/>
+                            </transformers>
+                            <filters>
+                              <filter>
+                                <artifact>*:*</artifact>
+                                <excludes>
+                                  <exclude>META-INF/*.SF</exclude>
+                                  <exclude>META-INF/*.DSA</exclude>
+                                  <exclude>META-INF/*.RSA</exclude>
+                                </excludes>
+                              </filter>
+                            </filters>
+                            <finalName>${project.build.finalName}-with-deps</finalName>
+                        </configuration>
+                    </execution>
+                </executions>
             </plugin>
         </plugins>
     </build>

--- a/redo_wsdls.py
+++ b/redo_wsdls.py
@@ -16,9 +16,9 @@ from plumbum import local, FG, BG
 
 # Check that wsdl2java and other comands are installed correctly
 wsdl2java = local.cmd.wsdl2java
-wsdl2java['-h'] & FG
-mvn = local['mvn']
-mvn['-h'] & FG
+wsdl2java['-v'] & FG
+java = local['java']
+java['--version'] & FG
 mkdir = local['mkdir']
 # mkdir['-p', 'wsdl_eater'] & FG
 os.chdir('src/main/resources/wsdl')
@@ -43,9 +43,9 @@ for juris in supported_jurisdictions:
   print('downloaded EFMFirmService')
 
   for ecf_wsdl in ['ECF-4.0-FilingReviewMDEService.wsdl', 'ECF-4.0-FilingAssemblyMDEService.wsdl', 'ECF-4.0-CourtRecordMDEService.wsdl', 'ECF-4.0-ServiceMDEService.wsdl']:
-    args = f'-Dexec.args="https://{juris}-{tyler_env}.tylertech.cloud/EFM/Schema/{ecf_wsdl} ecf"'
+    args = f'https://{juris}-{tyler_env}.tylertech.cloud/EFM/Schema/{ecf_wsdl} ecf'
     print(args)
-    mvn['-f', '../../../../../../pom.xml', 'exec:java@XsdDownloader', args] & FG
+    java['-jar', '../../../../../../target/efspserver-with-deps.jar', 'edu.suffolk.litlab.efspserver.XsdDownloader', args] & FG
     local.get('mv')['ecf.xsd', ecf_wsdl] & FG
     print(f'downloaded {ecf_wsdl}')
   os.chdir('../../')

--- a/src/main/java/edu/suffolk/litlab/efspserver/XsdDownloader.java
+++ b/src/main/java/edu/suffolk/litlab/efspserver/XsdDownloader.java
@@ -27,10 +27,10 @@ import org.xml.sax.SAXException;
 
 /**
  * Downloaded the FilingReviewMDE wsdl, necessary for it to run faster. Slightly modified to handle
- * relative paths on the server. Runs like: ``` mvn exec:java@XsdDownloader
- * -Dexec.args="https://example.tylertech.cloud/EFM/Schema/ECF-4.0-FilingReviewMDEService.wsdl ecf"
- * ``` Then move all of the ecf files into src/main/resources/wsdl/, and point the FilingReviewMDE
- * URL to it. <a href="https://github.com/pablod/xsd-downloader">Github here</a>
+ * relative paths on the server. Runs like: <code>
+ * java -cp target/efspserver-with-deps.jar edu.suffolk.litlab.efspserver.XsdDownloader https://example.tylertech.cloud/EFM/Schema/ECF-4.0-FilingReviewMDEService.wsdl ecf"
+ * </code> Then move all of the ecf files into src/main/resources/wsdl/, and point the
+ * FilingReviewMDE URL to it. <a href="https://github.com/pablod/xsd-downloader">Github here</a>
  *
  * @author https://github.com/pablod
  */

--- a/src/main/java/edu/suffolk/litlab/efspserver/db/LoginDatabase.java
+++ b/src/main/java/edu/suffolk/litlab/efspserver/db/LoginDatabase.java
@@ -273,7 +273,8 @@ public class LoginDatabase extends Database {
   }
 
   /**
-   * Example on how to trigger: mvn exec:java@LoginDatabase -Dexec.args="localhostServer true true"
+   * Example on how to trigger: java -cp target/efspserver-with-deps.jar
+   * edu.suffolk.litlab.efspserver.db.LoginDatabase localhostServer true true
    *
    * @throws ClassNotFoundException
    * @throws NumberFormatException

--- a/src/main/java/edu/suffolk/litlab/efspserver/ecfcodes/CodeUpdater.java
+++ b/src/main/java/edu/suffolk/litlab/efspserver/ecfcodes/CodeUpdater.java
@@ -625,7 +625,7 @@ public class CodeUpdater {
    * Run with:
    *
    * <pre>
-   * java -cp $(cat cp.txt):target/efspserver.jar edu.suffolk.litlab.efspserver.ecfcodes.CodeUpdater refresh
+   * java -cp target/efspserver-with-deps.jar edu.suffolk.litlab.efspserver.ecfcodes.CodeUpdater refresh
    * </pre>
    *
    * <p>TODO(#111): use with this System property and class to try to fix parallel unmarshalling

--- a/src/main/java/edu/suffolk/litlab/efspserver/services/acme/AcmeRenewal.java
+++ b/src/main/java/edu/suffolk/litlab/efspserver/services/acme/AcmeRenewal.java
@@ -404,7 +404,7 @@ public class AcmeRenewal {
    * <p>Run with
    *
    * <pre>
-   * java -cp $(cat cp.txt):target/efspserver.jar edu.suffolk.litlab.efspserver.services.acme.AcmeRenewal renew
+   * java -cp target/efspserver-with-deps.jar edu.suffolk.litlab.efspserver.services.acme.AcmeRenewal renew
    * </pre>
    *
    * @throws AcmeException


### PR DESCRIPTION
(aka "shading the main jar")

Needed for a chain of reasons (each with a PR coming):

* currently a PROD issue with some Tyler servers needing a different WSDL Schema (with an optional Paging element) (kinda addressed in #211)
* however, some environments (MA PROD, specifically) don't have that version yet, and updating ours would likely break MA PROD for other unknown / inane reasons.
* to handle that, we need to split up the project into different modules, where we can actually isolate all of the ECF / XML generated Java code from our actual server, and can add support for all versions of Tyler server software (`2022_1`, `2024_4`, etc.)
* to do that, we would move around a lot of maven `pom.xml` files, create a parent pom, etc. This complicates being able to have a single folder with all jars for the classpath, and where specifically we would be running `mvn` commands from in prod (for code updates, API keys, etc.)
* to decouple from `mvn` in PROD and during the packaging workflow, we can just package our server code into a single jar (i.e. this PR).

More description in each commit.