### PR TITLE
Use Enunciate to generate REST endpoint docs

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,7 +5,7 @@ COPY pom.xml /usr/app/
 COPY TylerEcf4 /usr/app/TylerEcf4/
 COPY TylerEcf5 /usr/app/TylerEcf5/
 COPY TylerEfmClient /usr/app/TylerEfmClient/
-COPY proxyserver/pom.xml /usr/app/proxyserver/
+COPY proxyserver/pom.xml proxyserver/enunciate.xml /usr/app/proxyserver/
 # Install all of the maven packages, so we don't have to every time we change code
 RUN mvn -f /usr/app/pom.xml -DskipTests clean dependency:resolve dependency:go-offline compile
 

--- a/docs/adr/008-choice-of-rest-docs.md
+++ b/docs/adr/008-choice-of-rest-docs.md
@@ -1,10 +1,10 @@
-# Documentation Site
+# Documentation for REST Endpoints
 
 Author: Bryce Willey
 
-Date: 2023-03-01
+Date: 2023-03-01, re-evaluated 2025-06-25
 
-Status: Decided, in progress
+Status: Implemented
 
 In order for our stand-alone REST server to be useful, we need some sort
 of developer documentation. There are lots of different options of how to
@@ -23,17 +23,15 @@ document a Java REST server, and need to choose and focus on one.
 
 ## Decision Outcome
 
-[Swagger-maven-plugin](https://github.com/swagger-api/swagger-core/tree/master/modules/swagger-maven-plugin) and [OpenAPI's HTML Generator](https://openapi-generator.tech/)
+**Enunciate**
 
-* the swagger maven plugin will generate an OpenAPI YAML specification in `openapi.yaml`, that lists all of the endpoints and what inputs they take
-* OpenAPI's HTML generator turns that into a webpage.
-* We will have to add [specific Annotations](https://github.com/swagger-api/swagger-core/wiki/Swagger-2.X---Getting-started) to our services
-  to describe them, as javadocs don't seem to be picked up. Unfortunately, we don't have a lot of schemas, so we will have to manually describe
-  a lot of the datatypes that people send to us.
-  * we can't really describe the datatypes with Java schemas, since none of them support Optional, and it's not clear what fields are required
-    or not without it.
-* might also have to [adjust the config](https://openapi-generator.tech/docs/generators/html2) for the HTML generator, and maybe the [templates](https://github.com/OpenAPITools/openapi-generator/tree/2458743257e4d722fc7b2fd051ddb9f0dab8582e/modules/openapi-generator/src/main/resources/htmlDocs2)
+* `+` is lighter weight than the OpenAPI generation
+    * automatically includes javadocs
+* `+` scoped well: more focused on HTML documentation
+* `+` still get a generated OpenAPI page
+* `-` has it's own configuration and annotations that can be not the best documented, isn't the standard that OpenAPI annotations have become in the rest of the professional world
 
+Previously was decided to not use it because of lack of support for JDK 17, but [2.15.0-SNAPSHOT fixed this](https://github.com/stoicflame/enunciate/issues/1087).
 
 ### Still to be decided
 
@@ -44,7 +42,8 @@ document a Java REST server, and need to choose and focus on one.
 ### javadoc and mvn site
 
 * `+` a part of pretty much every java project, and already present for us, no extra plugins needed
-* `+` [according to maven](https://maven.apache.org/guides/mini/guide-site.html), you can easily add markdown content. Might be a thing we use later, to write guides, but we'll have to see
+* `+` javadocs still have their use, can be used even without the focus on REST endpoints or mvn site
+* `-` while [it is possible to add markdown content](https://maven.apache.org/guides/mini/guide-site.html), it's not at all easy or intuitive, and won't work with how we structure our docs in GitHub (documentation should be browsable both on the site and through GitHub's UI).
 * `-` the documentation is very class-oriented. This structure focuses on classes and methods, which works when documenting libraries, but doesn't work well when documenting web servers, which have specific endpoints.
 * `-` personal opinion: the default site is horrible, both aesthetically and usability-wise. Nothing is organized well, a lot of the defaults of the maven side of the site (which is where the guides would live) are bad (small font sizes, weird emphasis on the dependencies of the project, etc.)
 
@@ -54,6 +53,20 @@ document a Java REST server, and need to choose and focus on one.
 * `-` the LITLab already is using one SwaggerHub site with SPOT, and we only get one free site
 * `-` there's an emphasis on "interact with the server now", which we aren't designed for, and IMO won't work well
 
+## [Swagger-maven-plugin](https://github.com/swagger-api/swagger-core/tree/master/modules/swagger-maven-plugin) and [OpenAPI's HTML Generator](https://openapi-generator.tech/)
+
+* the swagger maven plugin will generate an OpenAPI YAML specification in `openapi.yaml`, that lists all of the endpoints and what inputs they take
+    * OpenAPI's HTML generator turns that into a webpage.
+    * could also to [adjust the config](https://openapi-generator.tech/docs/generators/html2) for the HTML generator, and maybe the [templates](https://github.com/OpenAPITools/openapi-generator/tree/2458743257e4d722fc7b2fd051ddb9f0dab8582e/modules/openapi-generator/src/main/resources/htmlDocs2)
+* `+` Swagger IMO gives the best UI for actually browsing and understanding the API space ata a glance.
+* `-` We will have to add [specific Annotations](https://github.com/swagger-api/swagger-core/wiki/Swagger-2.X---Getting-started) to our services
+  to describe them
+    * Unfortunately, we don't have a lot of schemas, so we will have to manually describe
+      a lot of the datatypes that people send to us.
+    * we can't really describe the datatypes with Java schemas, since none of them support Optional, and it's not clear what fields are required
+      or not without it.
+* `-` javadocs can't be used (without using Spring as well), resulting in duplicate stuff in the javadocs and the annotations.
+
 ### Doing it the "RESTful" way
 
 * `+` nothing to document!
@@ -61,15 +74,7 @@ document a Java REST server, and need to choose and focus on one.
 * `-` we've already done it; everything under the `codes` endpoint kinda works like that, and TBH no one wants to do that. Only works on Firefox (Chrome won't show you links in JSON), and I'm not supporting returning full HTML
 * `-` TBH, we just weren't always able to design a fully RESTful API, and this very much seems like the "self-documenting code" dream that doesn't exist
 
-### Enunciate
-
-* `+` looks a bit lighter weight than the OpenAPI generation
-* `+` scoped well: more focused on HTML documentation
-* `-` no example pages to see what the result looks like
-* `-` the [sample project](https://github.com/stoicflame/enunciate-sample) itself is poorly documented if you aren't fluent in Maven
-* `-` requires us to change our maven packaging to `war` instead of the default `jar` for some reason. Not a fan of that
-* `-` Doesn't work with JDK 17; support is focused on JDK 8, and apparently [2.15.0-SNAPSHOT fixes this](https://github.com/stoicflame/enunciate/issues/1087), but it's not released on maven yet, and would require us to build from source.
-
 ### WADL
 
 * `-` absolutely not, I am not subjecting our users to SOAP-like nonsense to use our server
+    * enunciate also generates one of these for us.

--- a/docs/adr/008-choice-of-rest-docs.md
+++ b/docs/adr/008-choice-of-rest-docs.md
@@ -29,7 +29,8 @@ document a Java REST server, and need to choose and focus on one.
     * automatically includes javadocs
 * `+` scoped well: more focused on HTML documentation
 * `+` still get a generated OpenAPI page
-* `-` has it's own configuration and annotations that can be not the best documented, isn't the standard that OpenAPI annotations have become in the rest of the professional world
+* `-` has it's own configuration and annotations that can sometimes be poorly documented
+* `-` isn't the well-known standard that OpenAPI annotations have become in the rest of the professional world
 
 Previously was decided to not use it because of lack of support for JDK 17, but [2.15.0-SNAPSHOT fixed this](https://github.com/stoicflame/enunciate/issues/1087).
 
@@ -57,7 +58,7 @@ Previously was decided to not use it because of lack of support for JDK 17, but 
 
 * the swagger maven plugin will generate an OpenAPI YAML specification in `openapi.yaml`, that lists all of the endpoints and what inputs they take
     * OpenAPI's HTML generator turns that into a webpage.
-    * could also to [adjust the config](https://openapi-generator.tech/docs/generators/html2) for the HTML generator, and maybe the [templates](https://github.com/OpenAPITools/openapi-generator/tree/2458743257e4d722fc7b2fd051ddb9f0dab8582e/modules/openapi-generator/src/main/resources/htmlDocs2)
+    * could also [adjust the config](https://openapi-generator.tech/docs/generators/html2) for the HTML generator, and maybe the [templates](https://github.com/OpenAPITools/openapi-generator/tree/2458743257e4d722fc7b2fd051ddb9f0dab8582e/modules/openapi-generator/src/main/resources/htmlDocs2)
 * `+` Swagger IMO gives the best UI for actually browsing and understanding the API space ata a glance.
 * `-` We will have to add [specific Annotations](https://github.com/swagger-api/swagger-core/wiki/Swagger-2.X---Getting-started) to our services
   to describe them

--- a/pom.xml
+++ b/pom.xml
@@ -77,6 +77,22 @@
             <!-- lock down plugins versions to avoid Maven defaults -->
             <plugins>
                 <plugin>
+                    <groupId>com.webcohesion.enunciate</groupId>
+                    <artifactId>enunciate-maven-plugin</artifactId>
+                    <version>2.18.1</version>
+                    <executions>
+                        <execution>
+                            <goals>
+                                <goal>docs</goal>
+                            </goals>
+                            <configuration>
+                                <configFile>enunciate.xml</configFile>
+                                <docsDir>${project.build.directory}/enunciate-docs</docsDir>
+                            </configuration>
+                        </execution>
+                    </executions>
+                </plugin>
+                <plugin>
                   <groupId>com.github.spotbugs</groupId>
                   <artifactId>spotbugs-maven-plugin</artifactId>
                   <version>4.7.2.1</version>
@@ -121,7 +137,7 @@
                 </plugin>
                 <plugin>
                     <artifactId>maven-failsafe-plugin</artifactId>
-                    <version>2.22.1</version>
+                    <version>3.5.3</version>
                 </plugin>
 
                 <plugin>

--- a/proxyserver/enunciate.xml
+++ b/proxyserver/enunciate.xml
@@ -7,7 +7,8 @@
         <docs />
         <swagger>
           <server url="https://efile-test.suffolklitlab.org/" description="The test server" />
-          <server url="https://efile.suffolklitlab.org/" description="The production server" />
+          <!-- The Production server is commented out so we don't unintentionally make calls to it from the docs site. -->
+          <!-- server url="https://efile.suffolklitlab.org/" description="The production server" /-->
         </swagger>
 
         <java-xml-client disabled="true" />

--- a/proxyserver/enunciate.xml
+++ b/proxyserver/enunciate.xml
@@ -1,0 +1,28 @@
+<enunciate xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+          xsi:noNamespaceSchemaLocation="http://enunciate.webcohesion.com/schemas/enunciate-2.18.0.xsd">
+
+    <application root="/" />
+
+    <modules>
+        <docs />
+        <swagger>
+          <server url="https://efile-test.suffolklitlab.org/" description="The test server" />
+          <server url="https://efile.suffolklitlab.org/" description="The production server" />
+        </swagger>
+
+        <java-xml-client disabled="true" />
+        <php-xml-client disabled="true" />
+        <csharp-xml-client disabled="true" />
+        <c-xml-client disabled="true" />
+        <java-json-client disabled="true" />
+        <javascript-client disabled="true" />
+        <obj-c-xml-client disabled="true" />
+        <ruby-json-client disabled="true" />
+        <php-json-client disabled="true" />
+        <java-xml-client disabled="true" />
+        <jaxws disabled="true" />
+        <spring-web disabled="true" />
+        <gwt-json-overlay disabled="true" />
+    </modules>
+
+</enunciate>

--- a/proxyserver/pom.xml
+++ b/proxyserver/pom.xml
@@ -241,6 +241,11 @@
             <version>2.7.0</version>
         </dependency>
         <dependency>
+            <groupId>com.webcohesion.enunciate</groupId>
+            <artifactId>enunciate-core-annotations</artifactId>
+            <version>2.18.1</version>
+        </dependency>
+        <dependency>
             <groupId>com.opencsv</groupId>
             <artifactId>opencsv</artifactId>
             <version>5.7.1</version>
@@ -370,6 +375,10 @@
                         </configuration>
                     </execution>
                 </executions>
+            </plugin>
+            <plugin>
+                <groupId>com.webcohesion.enunciate</groupId>
+                <artifactId>enunciate-maven-plugin</artifactId>
             </plugin>
         </plugins>
     </build>

--- a/proxyserver/src/main/java/edu/suffolk/litlab/efspserver/services/AuthenticationService.java
+++ b/proxyserver/src/main/java/edu/suffolk/litlab/efspserver/services/AuthenticationService.java
@@ -3,6 +3,8 @@ package edu.suffolk.litlab.efspserver.services;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.webcohesion.enunciate.metadata.rs.ResponseCode;
+import com.webcohesion.enunciate.metadata.rs.StatusCodes;
 import edu.suffolk.litlab.efspserver.db.NewTokens;
 import jakarta.ws.rs.POST;
 import jakarta.ws.rs.Path;
@@ -26,7 +28,6 @@ public class AuthenticationService {
     this.security = security;
   }
 
-  @POST
   /**
    * Log in the user to all of the requested e-filing EFMs.
    *
@@ -35,6 +36,11 @@ public class AuthenticationService {
    *     jurisdiction, can be any jurisdiction
    * @return 200 and the logged in tokens to hang on to and send in with every call
    */
+  @StatusCodes({
+    @ResponseCode(code = 200, condition = "success"),
+    @ResponseCode(code = 403, condition = "login information not valid")
+  })
+  @POST
   public Response authenticateUser(String loginInfo) {
     MDC.put(MDCWrappers.OPERATION, "AuthenticationService.authenticateUser");
     ObjectMapper mapper = new ObjectMapper();


### PR DESCRIPTION
Generates a static site to describe endpoints, as well as making a swagger-ui version as well.

To test this:

* run `mvn compile`
* Bring up a local http server (node server or python http.server) in `proxyserver/target/enunciate-docs/apidocs` folder with `python -m http.server 8000` or [your language of choice](https://gist.github.com/willurd/5720255).
* Visit that URL in your browser (likely `127.0.0.1:8000`).

Enunciate:

![Image of Enunciate's docs](https://github.com/user-attachments/assets/1dd208ad-7c18-4301-b993-65b3f36fc027)

Swagger:

![image of swagger's UI](https://github.com/user-attachments/assets/de5db231-d289-4457-936e-ed3e3b2277f9)

Additional changes:

* Adds example [Enunciate annotations](https://github.com/stoicflame/enunciate/wiki/Enunciate-Specific-Annotations) to an endpoint, just for an easy place to continue adding usage
* Updates ADR 8 with this updated decision