### PR TITLE
Fix relative links to the javadocs and enunciate pages

### DIFF
--- a/.github/workflows/docs_site.yml
+++ b/.github/workflows/docs_site.yml
@@ -53,4 +53,3 @@ jobs:
         with:
           path: site/
       - uses: actions/deploy-pages@v4
-      

--- a/docs/.nav.yml
+++ b/docs/.nav.yml
@@ -3,6 +3,6 @@ nav:
   - developing.md
   - operations_guide/index.md
   - architecture.md
-  - "REST API Docs 🔗": /endpoints
-  - "Javadocs 🔗": /apidocs
+  - "REST API Docs 🔗": endpoints
+  - "Javadocs 🔗": apidocs
   - "*"

--- a/docs/developing.md
+++ b/docs/developing.md
@@ -101,3 +101,6 @@ Some misc links that I used while researching:
 * [The original WS-Security spec document](http://docs.oasis-open.org/wss/2004/01/oasis-200401-wss-soap-message-security-1.0.pdf)
 * [WS-Security Policy stuff](https://www.ibm.com/docs/en/was-liberty/nd?topic=wssml-securing-web-service-by-using-ws-security-policy)
 
+## Using with Docassemble
+
+See the docs for the [docassemble-EFSPIntegration](https://github.com/SuffolkLITLab/docassemble-EFSPIntegration/) package at the main [Assembly Line documentation](https://assemblyline.suffolklitlab.org/docs/components/EFSPIntegration/overview).


### PR DESCRIPTION
The relative links to https://projects.suffolklitlab.org/EfileProxyServer/endpoints/ and https://projects.suffolklitlab.org/EfileProxyServer/apidocs/ were broken (because GH pages deploys from a subpath, not at the root of the domain). 

Also adds the old documentation link somewhere. Docs need a rather large re-haul soon anyway.