### PR TITLE
Fixed conversion issue with enums

### DIFF
--- a/TylerEfmClient/src/main/java/edu/suffolk/litlab/efsp/tyler/TylerClients.java
+++ b/TylerEfmClient/src/main/java/edu/suffolk/litlab/efsp/tyler/TylerClients.java
@@ -19,7 +19,7 @@ public class TylerClients {
           "california", TylerVersion.v2024_6,
           "illinois", TylerVersion.v2024_6,
           "indiana", TylerVersion.v2024_6,
-          "massachusetts", TylerVersion.v2022_1,
+          "massachusetts", TylerVersion.v2025_0,
           "texas", TylerVersion.v2024_6);
 
   private static final Map<String, TylerVersion> PROD_VERSION_MAP =

--- a/TylerEfmClient/src/main/java/edu/suffolk/litlab/efsp/tyler/TylerClients.java
+++ b/TylerEfmClient/src/main/java/edu/suffolk/litlab/efsp/tyler/TylerClients.java
@@ -19,7 +19,7 @@ public class TylerClients {
           "california", TylerVersion.v2024_6,
           "illinois", TylerVersion.v2024_6,
           "indiana", TylerVersion.v2024_6,
-          "massachusetts", TylerVersion.v2025_0,
+          "massachusetts", TylerVersion.v2022_1,
           "texas", TylerVersion.v2024_6);
 
   private static final Map<String, TylerVersion> PROD_VERSION_MAP =
@@ -70,14 +70,8 @@ public class TylerClients {
   }
 
   private static Optional<TylerVersion> getVersion(String jurisdiction, TylerEnv tylerEnv) {
-    if (tylerEnv.equals(TylerEnv.TEST)) {
-      log.warn("TylerEnv.TEST not supported yet (i.e. we don't call their test server)");
-      Optional.empty();
-    }
-
     Map<String, TylerVersion> versionMap =
         switch (tylerEnv) {
-          case TylerEnv.TEST -> Map.of();
           case TylerEnv.STAGE -> STAGE_VERSION_MAP;
           case TylerEnv.PROD -> PROD_VERSION_MAP;
         };

--- a/TylerEfmClient/src/main/java/edu/suffolk/litlab/efsp/tyler/TylerEnv.java
+++ b/TylerEfmClient/src/main/java/edu/suffolk/litlab/efsp/tyler/TylerEnv.java
@@ -4,8 +4,6 @@ package edu.suffolk.litlab.efsp.tyler;
 public enum TylerEnv {
   /// i.e. the production / live environment
   PROD("prod"),
-  /// should be "identical" to PROD
-  TEST("test"),
   /// to "deploy patches and new releases prior to introduction into" PROD
   STAGE("stage");
 
@@ -24,8 +22,6 @@ public enum TylerEnv {
       return STAGE;
     } else if (value.equalsIgnoreCase(PROD.getPath())) {
       return PROD;
-    } else if (value.equalsIgnoreCase(TEST.getPath())) {
-      return TEST;
     } else {
       throw new IllegalArgumentException("Can't make a `TylerEnv` from: " + value);
     }

--- a/TylerEfmClient/src/main/java/edu/suffolk/litlab/efsp/tyler/TylerFirmClient.java
+++ b/TylerEfmClient/src/main/java/edu/suffolk/litlab/efsp/tyler/TylerFirmClient.java
@@ -90,9 +90,10 @@ public class TylerFirmClient {
 
   public GetAttorneyResponseType getAttorney(GetAttorneyRequestType getAttorneyRequest) {
     if (version == v2022_1) {
-      var req = new tyler.efm.v2022_1.services.schema.getattorneyrequest.GetAttorneyRequestType();
-      var resp = v2022Port.getAttorney(Conversion.convert(req, getAttorneyRequest));
-      return Conversion.convert(new GetAttorneyResponseType(), resp);
+      var resp = v2022Port.getAttorney(Conversion.convert(
+        tyler.efm.v2022_1.services.schema.getattorneyrequest.GetAttorneyRequestType.class,
+        getAttorneyRequest));
+      return Conversion.convert(GetAttorneyResponseType.class, resp);
     } else {
       return latestPort.getAttorney(getAttorneyRequest);
     }
@@ -101,12 +102,12 @@ public class TylerFirmClient {
   public UpdatePaymentAccountResponseType updatePaymentAccount(
       UpdatePaymentAccountRequestType updatePaymentAccountRequest) {
     if (version == v2022_1) {
-      var req =
-          new tyler.efm.v2022_1.services.schema.updatepaymentaccountrequest
-              .UpdatePaymentAccountRequestType();
       var resp =
-          v2022Port.updatePaymentAccount(Conversion.convert(req, updatePaymentAccountRequest));
-      return Conversion.convert(new UpdatePaymentAccountResponseType(), resp);
+          v2022Port.updatePaymentAccount(Conversion.convert(
+            tyler.efm.v2022_1.services.schema.updatepaymentaccountrequest
+              .UpdatePaymentAccountRequestType.class,
+              updatePaymentAccountRequest));
+      return Conversion.convert(UpdatePaymentAccountResponseType.class, resp);
     } else {
       return latestPort.updatePaymentAccount(updatePaymentAccountRequest);
     }
@@ -115,12 +116,12 @@ public class TylerFirmClient {
   public GetVitalChekPaymentAccountIdResponseType getVitalChekPaymentAccountId(
       GetPaymentAccountRequestType getPaymentAccountRequest) {
     if (version == v2022_1) {
-      var req =
-          new tyler.efm.v2022_1.services.schema.getpaymentaccountrequest
-              .GetPaymentAccountRequestType();
       var resp =
-          v2022Port.getVitalChekPaymentAccountId(Conversion.convert(req, getPaymentAccountRequest));
-      return Conversion.convert(new GetVitalChekPaymentAccountIdResponseType(), resp);
+          v2022Port.getVitalChekPaymentAccountId(Conversion.convert(
+            tyler.efm.v2022_1.services.schema.getpaymentaccountrequest
+              .GetPaymentAccountRequestType.class,
+              getPaymentAccountRequest));
+      return Conversion.convert(GetVitalChekPaymentAccountIdResponseType.class, resp);
     } else {
       return latestPort.getVitalChekPaymentAccountId(getPaymentAccountRequest);
     }
@@ -129,10 +130,10 @@ public class TylerFirmClient {
   public ServiceContactListResponseType getPublicList(
       GetPublicListRequestType getPublicListRequest) {
     if (version == v2022_1) {
-      var req =
-          new tyler.efm.v2022_1.services.schema.getpubliclistrequest.GetPublicListRequestType();
-      var resp = v2022Port.getPublicList(Conversion.convert(req, getPublicListRequest));
-      return Conversion.convert(new ServiceContactListResponseType(), resp);
+      var resp = v2022Port.getPublicList(Conversion.convert(
+        tyler.efm.v2022_1.services.schema.getpubliclistrequest.GetPublicListRequestType.class,
+        getPublicListRequest));
+      return Conversion.convert(ServiceContactListResponseType.class, resp);
     } else {
       return latestPort.getPublicList(getPublicListRequest);
     }
@@ -140,9 +141,10 @@ public class TylerFirmClient {
 
   public GetUserResponseType getUser(GetUserRequestType getUserRequest) {
     if (version == v2022_1) {
-      var req = new tyler.efm.v2022_1.services.schema.getuserrequest.GetUserRequestType();
-      var resp = v2022Port.getUser(Conversion.convert(req, getUserRequest));
-      return Conversion.convert(new GetUserResponseType(), resp);
+      var resp = v2022Port.getUser(Conversion.convert(
+        tyler.efm.v2022_1.services.schema.getuserrequest.GetUserRequestType.class,
+        getUserRequest));
+      return Conversion.convert(GetUserResponseType.class, resp);
     } else {
       return latestPort.getUser(getUserRequest);
     }
@@ -161,11 +163,10 @@ public class TylerFirmClient {
   public GetServiceContactResponseType getServiceContact(
       GetServiceContactRequestType getServiceContactRequest) {
     if (version == v2022_1) {
-      var req =
-          new tyler.efm.v2022_1.services.schema.getservicecontactrequest
-              .GetServiceContactRequestType();
-      var resp = v2022Port.getServiceContact(Conversion.convert(req, getServiceContactRequest));
-      return Conversion.convert(new GetServiceContactResponseType(), resp);
+      var resp = v2022Port.getServiceContact(Conversion.convert(
+        tyler.efm.v2022_1.services.schema.getservicecontactrequest.GetServiceContactRequestType.class,
+        getServiceContactRequest));
+      return Conversion.convert(GetServiceContactResponseType.class, resp);
     } else {
       return latestPort.getServiceContact(getServiceContactRequest);
     }
@@ -174,12 +175,11 @@ public class TylerFirmClient {
   public CreatePaymentAccountResponseType createPaymentAccount(
       CreatePaymentAccountRequestType createPaymentAccountRequest) {
     if (version == v2022_1) {
-      var req =
-          new tyler.efm.v2022_1.services.schema.createpaymentaccountrequest
-              .CreatePaymentAccountRequestType();
       var resp =
-          v2022Port.createPaymentAccount(Conversion.convert(req, createPaymentAccountRequest));
-      return Conversion.convert(new CreatePaymentAccountResponseType(), resp);
+          v2022Port.createPaymentAccount(Conversion.convert(
+            tyler.efm.v2022_1.services.schema.createpaymentaccountrequest.CreatePaymentAccountRequestType.class,
+            createPaymentAccountRequest));
+      return Conversion.convert(CreatePaymentAccountResponseType.class, resp);
     } else {
       return latestPort.createPaymentAccount(createPaymentAccountRequest);
     }
@@ -188,7 +188,7 @@ public class TylerFirmClient {
   public NotificationPreferencesListResponseType getNotificationPreferencesList() {
     if (version == v2022_1) {
       var resp = v2022Port.getNotificationPreferencesList();
-      return Conversion.convert(new NotificationPreferencesListResponseType(), resp);
+      return Conversion.convert(NotificationPreferencesListResponseType.class, resp);
     } else {
       return latestPort.getNotificationPreferencesList();
     }
@@ -197,13 +197,12 @@ public class TylerFirmClient {
   public GetPaymentAccountResponseType getGlobalPaymentAccount(
       GetPaymentAccountRequestType getGlobalPaymentAccountRequest) {
     if (version == v2022_1) {
-      var req =
-          new tyler.efm.v2022_1.services.schema.getpaymentaccountrequest
-              .GetPaymentAccountRequestType();
       var resp =
           v2022Port.getGlobalPaymentAccount(
-              Conversion.convert(req, getGlobalPaymentAccountRequest));
-      return Conversion.convert(new GetPaymentAccountResponseType(), resp);
+              Conversion.convert(
+                tyler.efm.v2022_1.services.schema.getpaymentaccountrequest.GetPaymentAccountRequestType.class,
+                getGlobalPaymentAccountRequest));
+      return Conversion.convert(GetPaymentAccountResponseType.class, resp);
     } else {
       return latestPort.getGlobalPaymentAccount(getGlobalPaymentAccountRequest);
     }
@@ -212,13 +211,12 @@ public class TylerFirmClient {
   public UpdatePaymentAccountResponseType updateGlobalPaymentAccount(
       UpdatePaymentAccountRequestType updateGlobalPaymentAccountRequest) {
     if (version == v2022_1) {
-      var req =
-          new tyler.efm.v2022_1.services.schema.updatepaymentaccountrequest
-              .UpdatePaymentAccountRequestType();
       var resp =
           v2022Port.updateGlobalPaymentAccount(
-              Conversion.convert(req, updateGlobalPaymentAccountRequest));
-      return Conversion.convert(new UpdatePaymentAccountResponseType(), resp);
+              Conversion.convert(
+              tyler.efm.v2022_1.services.schema.updatepaymentaccountrequest.UpdatePaymentAccountRequestType.class,
+              updateGlobalPaymentAccountRequest));
+      return Conversion.convert(UpdatePaymentAccountResponseType.class, resp);
     } else {
       return latestPort.updateGlobalPaymentAccount(updateGlobalPaymentAccountRequest);
     }
@@ -227,13 +225,13 @@ public class TylerFirmClient {
   public CreatePaymentAccountResponseType createInactivePaymentAccount(
       CreatePaymentAccountRequestType createPaymentAccountRequest) {
     if (version == v2022_1) {
-      var req =
-          new tyler.efm.v2022_1.services.schema.createpaymentaccountrequest
-              .CreatePaymentAccountRequestType();
       var resp =
           v2022Port.createInactivePaymentAccount(
-              Conversion.convert(req, createPaymentAccountRequest));
-      return Conversion.convert(new CreatePaymentAccountResponseType(), resp);
+              Conversion.convert(
+              tyler.efm.v2022_1.services.schema.createpaymentaccountrequest
+              .CreatePaymentAccountRequestType.class,
+              createPaymentAccountRequest));
+      return Conversion.convert(CreatePaymentAccountResponseType.class, resp);
     } else {
       return latestPort.createInactivePaymentAccount(createPaymentAccountRequest);
     }
@@ -242,12 +240,11 @@ public class TylerFirmClient {
   public BaseResponseType resendActivationEmail(
       ResendActivationEmailRequestType resendActivationEmailRequest) {
     if (version == v2022_1) {
-      var req =
-          new tyler.efm.v2022_1.services.schema.resendactivationemailrequest
-              .ResendActivationEmailRequestType();
       var resp =
-          v2022Port.resendActivationEmail(Conversion.convert(req, resendActivationEmailRequest));
-      return Conversion.convert(new BaseResponseType(), resp);
+          v2022Port.resendActivationEmail(Conversion.convert(
+            tyler.efm.v2022_1.services.schema.resendactivationemailrequest.ResendActivationEmailRequestType.class,
+            resendActivationEmailRequest));
+      return Conversion.convert(BaseResponseType.class, resp);
     } else {
       return latestPort.resendActivationEmail(resendActivationEmailRequest);
     }
@@ -256,11 +253,11 @@ public class TylerFirmClient {
   public GetPaymentAccountResponseType getPaymentAccount(
       GetPaymentAccountRequestType getPaymentAccountRequest) {
     if (version == v2022_1) {
-      var req =
-          new tyler.efm.v2022_1.services.schema.getpaymentaccountrequest
-              .GetPaymentAccountRequestType();
-      var resp = v2022Port.getPaymentAccount(Conversion.convert(req, getPaymentAccountRequest));
-      return Conversion.convert(new GetPaymentAccountResponseType(), resp);
+      var resp = v2022Port.getPaymentAccount(Conversion.convert(
+          tyler.efm.v2022_1.services.schema.getpaymentaccountrequest
+              .GetPaymentAccountRequestType.class,
+          getPaymentAccountRequest));
+      return Conversion.convert(GetPaymentAccountResponseType.class, resp);
     } else {
       return latestPort.getPaymentAccount(getPaymentAccountRequest);
     }
@@ -269,12 +266,12 @@ public class TylerFirmClient {
   public BaseResponseType detachServiceContact(
       DetachServiceContactRequestType detachServiceContactRequest) {
     if (version == v2022_1) {
-      var req =
-          new tyler.efm.v2022_1.services.schema.detachservicecontactrequest
-              .DetachServiceContactRequestType();
       var resp =
-          v2022Port.detachServiceContact(Conversion.convert(req, detachServiceContactRequest));
-      return Conversion.convert(new BaseResponseType(), resp);
+          v2022Port.detachServiceContact(Conversion.convert(
+          tyler.efm.v2022_1.services.schema.detachservicecontactrequest
+              .DetachServiceContactRequestType.class,
+              detachServiceContactRequest));
+      return Conversion.convert(BaseResponseType.class, resp);
     } else {
       return latestPort.detachServiceContact(detachServiceContactRequest);
     }
@@ -283,7 +280,7 @@ public class TylerFirmClient {
   public ServiceContactListResponseType getServiceContactList() {
     if (version.equals(TylerVersion.v2022_1)) {
       var resp = v2022Port.getServiceContactList();
-      return Conversion.convert(new ServiceContactListResponseType(), resp);
+      return Conversion.convert(ServiceContactListResponseType.class, resp);
     } else {
       return latestPort.getServiceContactList();
     }
@@ -293,7 +290,7 @@ public class TylerFirmClient {
   public UserListResponseType getUserList(GetUserListRequest getUserListRequest) {
     if (version.equals(TylerVersion.v2022_1)) {
       // Can ignore the paging values passed in; just return it all.
-      var resp = Conversion.convert(new UserListResponseType(), v2022Port.getUserList());
+      var resp = Conversion.convert(UserListResponseType.class, v2022Port.getUserList());
       var paging = new PagingType();
       paging.setPageIndex(0);
       paging.setPageSize(resp.getUser().size());
@@ -308,7 +305,7 @@ public class TylerFirmClient {
   public PaymentAccountTypeListResponseType getPaymentAccountTypeList() {
     if (version == v2022_1) {
       var resp = v2022Port.getPaymentAccountTypeList();
-      return Conversion.convert(new PaymentAccountTypeListResponseType(), resp);
+      return Conversion.convert(PaymentAccountTypeListResponseType.class, resp);
     } else {
       return latestPort.getPaymentAccountTypeList();
     }
@@ -316,9 +313,10 @@ public class TylerFirmClient {
 
   public BaseResponseType removeUser(RemoveUserRequestType removeUserRequest) {
     if (version == v2022_1) {
-      var req = new tyler.efm.v2022_1.services.schema.removeuserrequest.RemoveUserRequestType();
-      var resp = v2022Port.removeUser(Conversion.convert(req, removeUserRequest));
-      return Conversion.convert(new BaseResponseType(), resp);
+      var resp = v2022Port.removeUser(Conversion.convert(
+        tyler.efm.v2022_1.services.schema.removeuserrequest.RemoveUserRequestType.class,
+        removeUserRequest));
+      return Conversion.convert(BaseResponseType.class, resp);
     } else {
       return latestPort.removeUser(removeUserRequest);
     }
@@ -327,12 +325,12 @@ public class TylerFirmClient {
   public PaymentAccountListResponseType getPaymentAccountList(
       GetPaymentAccountListRequestType getPaymentAccountListRequest) {
     if (version == v2022_1) {
-      var req =
-          new tyler.efm.v2022_1.services.schema.getpaymentaccountlistrequest
-              .GetPaymentAccountListRequestType();
       var resp =
-          v2022Port.getPaymentAccountList(Conversion.convert(req, getPaymentAccountListRequest));
-      return Conversion.convert(new PaymentAccountListResponseType(), resp);
+          v2022Port.getPaymentAccountList(Conversion.convert(
+            tyler.efm.v2022_1.services.schema.getpaymentaccountlistrequest
+              .GetPaymentAccountListRequestType.class,
+            getPaymentAccountListRequest));
+      return Conversion.convert(PaymentAccountListResponseType.class, resp);
     } else {
       return latestPort.getPaymentAccountList(getPaymentAccountListRequest);
     }
@@ -340,10 +338,10 @@ public class TylerFirmClient {
 
   public BaseResponseType removeAttorney(RemoveAttorneyRequestType removeAttorneyRequest) {
     if (version == v2022_1) {
-      var req =
-          new tyler.efm.v2022_1.services.schema.removeattorneyrequest.RemoveAttorneyRequestType();
-      var resp = v2022Port.removeAttorney(Conversion.convert(req, removeAttorneyRequest));
-      return Conversion.convert(new CreatePaymentAccountResponseType(), resp);
+      var resp = v2022Port.removeAttorney(Conversion.convert(
+          tyler.efm.v2022_1.services.schema.removeattorneyrequest.RemoveAttorneyRequestType.class,
+          removeAttorneyRequest));
+      return Conversion.convert(CreatePaymentAccountResponseType.class, resp);
     } else {
       return latestPort.removeAttorney(removeAttorneyRequest);
     }
@@ -352,7 +350,7 @@ public class TylerFirmClient {
   public PaymentAccountListResponseType getGlobalPaymentAccountList() {
     if (version == v2022_1) {
       var resp = v2022Port.getGlobalPaymentAccountList();
-      return Conversion.convert(new PaymentAccountListResponseType(), resp);
+      return Conversion.convert(PaymentAccountListResponseType.class, resp);
     } else {
       return latestPort.getGlobalPaymentAccountList();
     }
@@ -361,13 +359,13 @@ public class TylerFirmClient {
   public BaseResponseType removeGlobalPaymentAccount(
       RemovePaymentAccountRequestType removeGlobalPaymentAccountRequest) {
     if (version == v2022_1) {
-      var req =
-          new tyler.efm.v2022_1.services.schema.removepaymentaccountrequest
-              .RemovePaymentAccountRequestType();
       var resp =
           v2022Port.removeGlobalPaymentAccount(
-              Conversion.convert(req, removeGlobalPaymentAccountRequest));
-      return Conversion.convert(new BaseResponseType(), resp);
+              Conversion.convert(
+              tyler.efm.v2022_1.services.schema.removepaymentaccountrequest
+              .RemovePaymentAccountRequestType.class,
+                removeGlobalPaymentAccountRequest));
+      return Conversion.convert(BaseResponseType.class, resp);
     } else {
       return latestPort.removeGlobalPaymentAccount(removeGlobalPaymentAccountRequest);
     }
@@ -376,9 +374,10 @@ public class TylerFirmClient {
   public UpdateUserResponseType updateUser(UpdateUserRequestType updateUserRequest) {
     if (version.equals(TylerVersion.v2022_1)) {
       // TODO
-      var req = new tyler.efm.v2022_1.services.schema.updateuserrequest.UpdateUserRequestType();
-      var resp = v2022Port.updateUser(Conversion.convert(req, updateUserRequest.getUser()));
-      return Conversion.convert(new UpdateUserResponseType(), resp);
+      var resp = v2022Port.updateUser(Conversion.convert(
+        tyler.efm.v2022_1.services.schema.updateuserrequest.UpdateUserRequestType.class,
+        updateUserRequest.getUser()));
+      return Conversion.convert(UpdateUserResponseType.class, resp);
     } else {
       return latestPort.updateUser(updateUserRequest);
     }
@@ -387,12 +386,12 @@ public class TylerFirmClient {
   public BaseResponseType attachServiceContact(
       AttachServiceContactRequestType attachServiceContactRequest) {
     if (version == v2022_1) {
-      var req =
-          new tyler.efm.v2022_1.services.schema.attachservicecontactrequest
-              .AttachServiceContactRequestType();
       var resp =
-          v2022Port.attachServiceContact(Conversion.convert(req, attachServiceContactRequest));
-      return Conversion.convert(new BaseResponseType(), resp);
+          v2022Port.attachServiceContact(Conversion.convert(
+            tyler.efm.v2022_1.services.schema.attachservicecontactrequest
+              .AttachServiceContactRequestType.class,
+            attachServiceContactRequest));
+      return Conversion.convert(BaseResponseType.class, resp);
     } else {
       return latestPort.attachServiceContact(attachServiceContactRequest);
     }
@@ -400,10 +399,10 @@ public class TylerFirmClient {
 
   public BaseResponseType removeUserRole(RemoveUserRoleRequestType removeUserRoleRequest) {
     if (version == v2022_1) {
-      var req =
-          new tyler.efm.v2022_1.services.schema.removeuserrolerequest.RemoveUserRoleRequestType();
-      var resp = v2022Port.removeUserRole(Conversion.convert(req, removeUserRoleRequest));
-      return Conversion.convert(new BaseResponseType(), resp);
+      var resp = v2022Port.removeUserRole(Conversion.convert(
+        tyler.efm.v2022_1.services.schema.removeuserrolerequest.RemoveUserRoleRequestType.class,
+        removeUserRoleRequest));
+      return Conversion.convert(BaseResponseType.class, resp);
     } else {
       return latestPort.removeUserRole(removeUserRoleRequest);
     }
@@ -412,7 +411,7 @@ public class TylerFirmClient {
   public AttorneyListResponseType getAttorneyList() {
     if (version == v2022_1) {
       var resp = v2022Port.getAttorneyList();
-      return Conversion.convert(new AttorneyListResponseType(), resp);
+      return Conversion.convert(AttorneyListResponseType.class, resp);
     } else {
       return latestPort.getAttorneyList();
     }
@@ -421,12 +420,12 @@ public class TylerFirmClient {
   public UpdateServiceContactResponseType updateServiceContact(
       UpdateServiceContactRequestType updateServiceContactRequest) {
     if (version.equals(TylerVersion.v2022_1)) {
-      var req =
-          new tyler.efm.v2022_1.services.schema.updateservicecontactrequest
-              .UpdateServiceContactRequestType();
       var resp =
-          v2022Port.updateServiceContact(Conversion.convert(req, updateServiceContactRequest));
-      return Conversion.convert(new UpdateServiceContactResponseType(), resp);
+          v2022Port.updateServiceContact(Conversion.convert(
+            tyler.efm.v2022_1.services.schema.updateservicecontactrequest
+              .UpdateServiceContactRequestType.class,
+            updateServiceContactRequest));
+      return Conversion.convert(UpdateServiceContactResponseType.class, resp);
     } else {
       return latestPort.updateServiceContact(updateServiceContactRequest);
     }
@@ -435,12 +434,12 @@ public class TylerFirmClient {
   public BaseResponseType removeServiceContact(
       RemoveServiceContactRequestType removeServiceContactRequest) {
     if (version == v2022_1) {
-      var req =
-          new tyler.efm.v2022_1.services.schema.removeservicecontactrequest
-              .RemoveServiceContactRequestType();
       var resp =
-          v2022Port.removeServiceContact(Conversion.convert(req, removeServiceContactRequest));
-      return Conversion.convert(new BaseResponseType(), resp);
+          v2022Port.removeServiceContact(Conversion.convert(
+            tyler.efm.v2022_1.services.schema.removeservicecontactrequest
+              .RemoveServiceContactRequestType.class,
+            removeServiceContactRequest));
+      return Conversion.convert(BaseResponseType.class, resp);
     } else {
       return latestPort.removeServiceContact(removeServiceContactRequest);
     }
@@ -448,9 +447,10 @@ public class TylerFirmClient {
 
   public BaseResponseType addUserRole(AddUserRoleRequestType addUserRoleRequest) {
     if (version == v2022_1) {
-      var req = new tyler.efm.v2022_1.services.schema.adduserrolerequest.AddUserRoleRequestType();
-      var resp = v2022Port.addUserRole(Conversion.convert(req, addUserRoleRequest));
-      return Conversion.convert(new BaseResponseType(), resp);
+      var resp = v2022Port.addUserRole(Conversion.convert(
+        tyler.efm.v2022_1.services.schema.adduserrolerequest.AddUserRoleRequestType.class,
+        addUserRoleRequest));
+      return Conversion.convert(BaseResponseType.class, resp);
     } else {
       return latestPort.addUserRole(addUserRoleRequest);
     }
@@ -459,10 +459,10 @@ public class TylerFirmClient {
   public CreateAttorneyResponseType createAttorney(
       CreateAttorneyRequestType createAttorneyRequest) {
     if (version == v2022_1) {
-      var req =
-          new tyler.efm.v2022_1.services.schema.createattorneyrequest.CreateAttorneyRequestType();
-      var resp = v2022Port.createAttorney(Conversion.convert(req, createAttorneyRequest));
-      return Conversion.convert(new CreateAttorneyResponseType(), resp);
+      var resp = v2022Port.createAttorney(Conversion.convert(
+          tyler.efm.v2022_1.services.schema.createattorneyrequest.CreateAttorneyRequestType.class,
+        createAttorneyRequest));
+      return Conversion.convert(CreateAttorneyResponseType.class, resp);
     } else {
       return latestPort.createAttorney(createAttorneyRequest);
     }
@@ -471,12 +471,12 @@ public class TylerFirmClient {
   public BaseResponseType removePaymentAccount(
       RemovePaymentAccountRequestType removePaymentAccountRequest) {
     if (version == v2022_1) {
-      var req =
-          new tyler.efm.v2022_1.services.schema.removepaymentaccountrequest
-              .RemovePaymentAccountRequestType();
       var resp =
-          v2022Port.removePaymentAccount(Conversion.convert(req, removePaymentAccountRequest));
-      return Conversion.convert(new BaseResponseType(), resp);
+          v2022Port.removePaymentAccount(Conversion.convert(
+            tyler.efm.v2022_1.services.schema.removepaymentaccountrequest
+              .RemovePaymentAccountRequestType.class,
+            removePaymentAccountRequest));
+      return Conversion.convert(BaseResponseType.class, resp);
     } else {
       return latestPort.removePaymentAccount(removePaymentAccountRequest);
     }
@@ -485,12 +485,12 @@ public class TylerFirmClient {
   public CreateServiceContactResponseType createServiceContact(
       CreateServiceContactRequestType createServiceContactRequest) {
     if (version.equals(TylerVersion.v2022_1)) {
-      var req =
-          new tyler.efm.v2022_1.services.schema.createservicecontactrequest
-              .CreateServiceContactRequestType();
       var resp =
-          v2022Port.createServiceContact(Conversion.convert(req, createServiceContactRequest));
-      return Conversion.convert(new CreateServiceContactResponseType(), resp);
+          v2022Port.createServiceContact(Conversion.convert(
+            tyler.efm.v2022_1.services.schema.createservicecontactrequest
+              .CreateServiceContactRequestType.class,
+            createServiceContactRequest));
+      return Conversion.convert(CreateServiceContactResponseType.class, resp);
     } else {
       return latestPort.createServiceContact(createServiceContactRequest);
     }
@@ -499,10 +499,10 @@ public class TylerFirmClient {
   public UpdateAttorneyResponseType updateAttorney(
       UpdateAttorneyRequestType updateAttorneyRequest) {
     if (version == v2022_1) {
-      var req =
-          new tyler.efm.v2022_1.services.schema.updateattorneyrequest.UpdateAttorneyRequestType();
-      var resp = v2022Port.updateAttorney(Conversion.convert(req, updateAttorneyRequest));
-      return Conversion.convert(new UpdateAttorneyResponseType(), resp);
+      var resp = v2022Port.updateAttorney(Conversion.convert(
+        tyler.efm.v2022_1.services.schema.updateattorneyrequest.UpdateAttorneyRequestType.class,
+        updateAttorneyRequest));
+      return Conversion.convert(UpdateAttorneyResponseType.class, resp);
     } else {
       return latestPort.updateAttorney(updateAttorneyRequest);
     }
@@ -510,9 +510,10 @@ public class TylerFirmClient {
 
   public RegistrationResponseType registerUser(RegistrationRequestType registerUserRequest) {
     if (version == v2022_1) {
-      var req = new tyler.efm.v2022_1.services.schema.registrationrequest.RegistrationRequestType();
-      var resp = v2022Port.registerUser(Conversion.convert(req, registerUserRequest));
-      return Conversion.convert(new RegistrationResponseType(), resp);
+      var resp = v2022Port.registerUser(Conversion.convert(
+        tyler.efm.v2022_1.services.schema.registrationrequest.RegistrationRequestType.class,
+        registerUserRequest));
+      return Conversion.convert(RegistrationResponseType.class, resp);
     } else {
       return latestPort.registerUser(registerUserRequest);
     }
@@ -520,9 +521,10 @@ public class TylerFirmClient {
 
   public BaseResponseType updateFirm(UpdateFirmRequestType updateFirmRequest) {
     if (version == v2022_1) {
-      var req = new tyler.efm.v2022_1.services.schema.updatefirmrequest.UpdateFirmRequestType();
-      var resp = v2022Port.updateFirm(Conversion.convert(req, updateFirmRequest));
-      return Conversion.convert(new BaseResponseType(), resp);
+      var resp = v2022Port.updateFirm(Conversion.convert(
+        tyler.efm.v2022_1.services.schema.updatefirmrequest.UpdateFirmRequestType.class,
+        updateFirmRequest));
+      return Conversion.convert(BaseResponseType.class, resp);
     } else {
       return latestPort.updateFirm(updateFirmRequest);
     }
@@ -531,11 +533,11 @@ public class TylerFirmClient {
   public ResetPasswordResponseType resetUserPassword(
       ResetUserPasswordRequestType resetUserPasswordRequest) {
     if (version == v2022_1) {
-      var req =
-          new tyler.efm.v2022_1.services.schema.resetuserpasswordrequest
-              .ResetUserPasswordRequestType();
-      var resp = v2022Port.resetUserPassword(Conversion.convert(req, resetUserPasswordRequest));
-      return Conversion.convert(new ResetPasswordResponseType(), resp);
+      var resp = v2022Port.resetUserPassword(Conversion.convert(
+          tyler.efm.v2022_1.services.schema.resetuserpasswordrequest
+              .ResetUserPasswordRequestType.class,
+          resetUserPasswordRequest));
+      return Conversion.convert(ResetPasswordResponseType.class, resp);
     } else {
       return latestPort.resetUserPassword(resetUserPasswordRequest);
     }
@@ -543,7 +545,7 @@ public class TylerFirmClient {
 
   public GetFirmResponseType getFirm() {
     if (version == v2022_1) {
-      return Conversion.convert(new GetFirmResponseType(), v2022Port.getFirm());
+      return Conversion.convert(GetFirmResponseType.class, v2022Port.getFirm());
     } else {
       return latestPort.getFirm();
     }
@@ -552,13 +554,13 @@ public class TylerFirmClient {
   public CreatePaymentAccountResponseType createGlobalPaymentAccount(
       CreatePaymentAccountRequestType createGlobalPaymentAccountRequest) {
     if (version == v2022_1) {
-      var req =
-          new tyler.efm.v2022_1.services.schema.createpaymentaccountrequest
-              .CreatePaymentAccountRequestType();
       var resp =
           v2022Port.createGlobalPaymentAccount(
-              Conversion.convert(req, createGlobalPaymentAccountRequest));
-      return Conversion.convert(new CreatePaymentAccountResponseType(), resp);
+              Conversion.convert(
+              tyler.efm.v2022_1.services.schema.createpaymentaccountrequest
+              .CreatePaymentAccountRequestType.class,
+              createGlobalPaymentAccountRequest));
+      return Conversion.convert(CreatePaymentAccountResponseType.class, resp);
     } else {
       return latestPort.createGlobalPaymentAccount(createGlobalPaymentAccountRequest);
     }

--- a/TylerEfmClient/src/main/java/edu/suffolk/litlab/efsp/tyler/TylerUserClient.java
+++ b/TylerEfmClient/src/main/java/edu/suffolk/litlab/efsp/tyler/TylerUserClient.java
@@ -60,9 +60,10 @@ public class TylerUserClient {
 
   public AuthenticateResponseType authenticateUser(AuthenticateRequestType authenticateRequest) {
     if (version == v2022_1) {
-      var req = new tyler.efm.v2022_1.services.schema.authenticaterequest.AuthenticateRequestType();
-      var resp = v2022Port.authenticateUser(Conversion.convert(req, authenticateRequest));
-      return Conversion.convert(new AuthenticateResponseType(), resp);
+      var resp = v2022Port.authenticateUser(Conversion.convert(
+        tyler.efm.v2022_1.services.schema.authenticaterequest.AuthenticateRequestType.class,
+        authenticateRequest));
+      return Conversion.convert(AuthenticateResponseType.class, resp);
     } else {
       return latestPort.authenticateUser(authenticateRequest);
     }
@@ -70,9 +71,10 @@ public class TylerUserClient {
 
   public UpdateUserResponseType updateUser(UpdateUserRequestType updateUserRequest) {
     if (version == v2022_1) {
-      var req = new tyler.efm.v2022_1.services.schema.updateuserrequest.UpdateUserRequestType();
-      var resp = v2022Port.updateUser(Conversion.convert(req, updateUserRequest));
-      return Conversion.convert(new UpdateUserResponseType(), resp);
+      var resp = v2022Port.updateUser(Conversion.convert(
+        tyler.efm.v2022_1.services.schema.updateuserrequest.UpdateUserRequestType.class,
+        updateUserRequest));
+      return Conversion.convert(UpdateUserResponseType.class, resp);
     } else {
       return latestPort.updateUser(updateUserRequest);
     }
@@ -81,7 +83,7 @@ public class TylerUserClient {
   public NotificationPreferencesResponseType getNotificationPreferences() {
     if (version == v2022_1) {
       return Conversion.convert(
-          new NotificationPreferencesResponseType(), v2022Port.getNotificationPreferences());
+          NotificationPreferencesResponseType.class, v2022Port.getNotificationPreferences());
     } else {
       return latestPort.getNotificationPreferences();
     }
@@ -89,9 +91,10 @@ public class TylerUserClient {
 
   public GetUserResponseType getUser(GetUserRequestType getUserRequest) {
     if (version == v2022_1) {
-      var req = new tyler.efm.v2022_1.services.schema.getuserrequest.GetUserRequestType();
-      var resp = v2022Port.getUser(Conversion.convert(req, getUserRequest));
-      return Conversion.convert(new GetUserResponseType(), resp);
+      var resp = v2022Port.getUser(Conversion.convert(
+        tyler.efm.v2022_1.services.schema.getuserrequest.GetUserRequestType.class,
+        getUserRequest));
+      return Conversion.convert(GetUserResponseType.class, resp);
     } else {
       return latestPort.getUser(getUserRequest);
     }
@@ -100,13 +103,12 @@ public class TylerUserClient {
   public BaseResponseType selfResendActivationEmail(
       SelfResendActivationEmailRequestType selfResendActivationEmailRequest) {
     if (version == v2022_1) {
-      var req =
-          new tyler.efm.v2022_1.services.schema.selfresendactivationemailrequest
-              .SelfResendActivationEmailRequestType();
       var resp =
           v2022Port.selfResendActivationEmail(
-              Conversion.convert(req, selfResendActivationEmailRequest));
-      return Conversion.convert(new BaseResponseType(), resp);
+              Conversion.convert(
+              tyler.efm.v2022_1.services.schema.selfresendactivationemailrequest.SelfResendActivationEmailRequestType.class,
+                selfResendActivationEmailRequest));
+      return Conversion.convert(BaseResponseType.class, resp);
     } else {
       return latestPort.selfResendActivationEmail(selfResendActivationEmailRequest);
     }
@@ -114,10 +116,10 @@ public class TylerUserClient {
 
   public ResetPasswordResponseType resetPassword(ResetPasswordRequestType resetPasswordRequest) {
     if (version == v2022_1) {
-      var req =
-          new tyler.efm.v2022_1.services.schema.resetpasswordrequest.ResetPasswordRequestType();
-      var resp = v2022Port.resetPassword(Conversion.convert(req, resetPasswordRequest));
-      return Conversion.convert(new ResetPasswordResponseType(), resp);
+      var resp = v2022Port.resetPassword(Conversion.convert(
+        tyler.efm.v2022_1.services.schema.resetpasswordrequest.ResetPasswordRequestType.class,
+        resetPasswordRequest));
+      return Conversion.convert(ResetPasswordResponseType.class, resp);
     } else {
       return latestPort.resetPassword(resetPasswordRequest);
     }
@@ -126,11 +128,10 @@ public class TylerUserClient {
   public PasswordQuestionResponseType getPasswordQuestion(
       GetPasswordQuestionRequestType getPasswordQuestionRequest) {
     if (version == v2022_1) {
-      var req =
-          new tyler.efm.v2022_1.services.schema.getpasswordquestionrequest
-              .GetPasswordQuestionRequestType();
-      var resp = v2022Port.getPasswordQuestion(Conversion.convert(req, getPasswordQuestionRequest));
-      return Conversion.convert(new PasswordQuestionResponseType(), resp);
+      var resp = v2022Port.getPasswordQuestion(Conversion.convert(
+        tyler.efm.v2022_1.services.schema.getpasswordquestionrequest.GetPasswordQuestionRequestType.class,
+        getPasswordQuestionRequest));
+      return Conversion.convert(PasswordQuestionResponseType.class, resp);
     } else {
       return latestPort.getPasswordQuestion(getPasswordQuestionRequest);
     }
@@ -139,10 +140,10 @@ public class TylerUserClient {
   public ChangePasswordResponseType changePassword(
       ChangePasswordRequestType changePasswordRequest) {
     if (version == v2022_1) {
-      var req =
-          new tyler.efm.v2022_1.services.schema.changepasswordrequest.ChangePasswordRequestType();
-      var resp = v2022Port.changePassword(Conversion.convert(req, changePasswordRequest));
-      return Conversion.convert(new ChangePasswordResponseType(), resp);
+      var resp = v2022Port.changePassword(Conversion.convert(
+          tyler.efm.v2022_1.services.schema.changepasswordrequest.ChangePasswordRequestType.class,
+        changePasswordRequest));
+      return Conversion.convert(ChangePasswordResponseType.class, resp);
     } else {
       return latestPort.changePassword(changePasswordRequest);
     }
@@ -151,13 +152,13 @@ public class TylerUserClient {
   public BaseResponseType updateNotificationPreferences(
       UpdateNotificationPreferencesRequestType updateNotificationPreferencesRequest) {
     if (version == v2022_1) {
-      var req =
-          new tyler.efm.v2022_1.services.schema.updatenotificationpreferencesrequest
-              .UpdateNotificationPreferencesRequestType();
       var resp =
           v2022Port.updateNotificationPreferences(
-              Conversion.convert(req, updateNotificationPreferencesRequest));
-      return Conversion.convert(new BaseResponseType(), resp);
+              Conversion.convert(
+                tyler.efm.v2022_1.services.schema.updatenotificationpreferencesrequest
+                  .UpdateNotificationPreferencesRequestType.class,
+                  updateNotificationPreferencesRequest));
+      return Conversion.convert(BaseResponseType.class, resp);
     } else {
       return latestPort.updateNotificationPreferences(updateNotificationPreferencesRequest);
     }

--- a/TylerEfmClient/src/test/java/edu/suffolk/litlab/efsp/tyler/ConversionTest.java
+++ b/TylerEfmClient/src/test/java/edu/suffolk/litlab/efsp/tyler/ConversionTest.java
@@ -12,26 +12,34 @@ public class ConversionTest {
   public void testAuth() {
     var oldAuth = new tyler.efm.v2022_1.services.schema.authenticaterequest.AuthenticateRequestType();
     oldAuth.setEmail("idk@idk.com");
-    var newAuth = new tyler.efm.latest.services.schema.authenticaterequest.AuthenticateRequestType();
-    Conversion.convert(newAuth, oldAuth);
-    assertThat(oldAuth.getEmail()).isEqualTo(newAuth.getEmail());
+    var newAuth = Conversion.convert(tyler.efm.latest.services.schema.authenticaterequest.AuthenticateRequestType.class, oldAuth);
+    assertThat(newAuth.getEmail()).isEqualTo(oldAuth.getEmail());
   }
 
   @Test
-  public void allRequets() throws InstantiationException, IllegalAccessException, IllegalArgumentException, InvocationTargetException, NoSuchMethodException, SecurityException {
+  public void allRequests() throws InstantiationException, IllegalAccessException, IllegalArgumentException, InvocationTargetException, NoSuchMethodException, SecurityException {
     ArrayList<Class<?>> v2022_classes = new ArrayList<>();
     v2022_classes.add(tyler.efm.v2022_1.services.schema.authenticaterequest.AuthenticateRequestType.class);
     v2022_classes.add(tyler.efm.v2022_1.services.schema.updatenotificationpreferencesrequest.UpdateNotificationPreferencesRequestType.class);
+    v2022_classes.add(tyler.efm.v2022_1.services.schema.registrationrequest.RegistrationRequestType.class);
+    v2022_classes.add(tyler.efm.v2022_1.services.schema.registrationresponse.RegistrationResponseType.class);
     ArrayList<Class<?>> v2025_classes = new ArrayList<>();
     v2025_classes.add(tyler.efm.latest.services.schema.authenticaterequest.AuthenticateRequestType.class);
     v2025_classes.add(tyler.efm.latest.services.schema.updatenotificationpreferencesrequest.UpdateNotificationPreferencesRequestType.class);
+    v2025_classes.add(tyler.efm.latest.services.schema.registrationrequest.RegistrationRequestType.class);
+    v2025_classes.add(tyler.efm.latest.services.schema.registrationresponse.RegistrationResponseType.class);
     for (int i = 0; i < v2022_classes.size(); i++ ) {
-      var newObj = v2025_classes.get(i).getDeclaredConstructor().newInstance();
       var oldObj = v2022_classes.get(i).getDeclaredConstructor().newInstance();
-      var replacementObj = v2022_classes.get(i).getDeclaredConstructor().newInstance();
-      newObj = Conversion.convert(newObj, oldObj);
-      replacementObj = Conversion.convert(replacementObj, newObj);
+      var newObj = Conversion.convert(v2025_classes.get(i), oldObj);
+      var replacementObj = Conversion.convert(v2022_classes.get(i), newObj);
       assertThat(EqualsBuilder.reflectionEquals(oldObj, replacementObj)).isTrue();
     }
+  }
+
+  @Test
+  public void allEnums() {
+    var oldReg = tyler.efm.v2022_1.services.schema.common.RegistrationType.FIRM_ADMINISTRATOR;
+    var newReg = Conversion.convert(tyler.efm.latest.services.schema.common.RegistrationType.class, oldReg);
+    assertThat(newReg.value()).isEqualTo(oldReg.value());
   }
 }

--- a/TylerEfmClient/src/test/java/edu/suffolk/litlab/efsp/tyler/TylerClientsTest.java
+++ b/TylerEfmClient/src/test/java/edu/suffolk/litlab/efsp/tyler/TylerClientsTest.java
@@ -24,7 +24,7 @@ public class TylerClientsTest {
                 assertThat(TylerClients.getEfmUserFactory(jurisdiction, env)).isNotNull();
             }
         }
-        assertThat(TylerClients.getEfmUserFactory("texas", TylerEnv.TEST)).isEmpty();
+        assertThat(TylerClients.getEfmUserFactory("antartica", TylerEnv.STAGE)).isEmpty();
         assertThat(TylerClients.getEfmUserFactory("massachusetts", TylerEnv.PROD)).isNotEmpty();
         assertThat(TylerClients.getEfmUserFactory("illinois", TylerEnv.STAGE)).isNotEmpty();
     }


### PR DESCRIPTION
BeanUtils doesn't actually handle enums, and our method tried to call their default constructor (which they don't have).

This commit makes things use `value` to get the src enum's value, and `fromValue` from the destination class to set it instead.

Also:

* Refactored conversion to accept a class as an input instead of an already constructed object, that would be overwritten.
* removed TEST TylerEnv: it doesn't exist anymore, only Stage and PROD