### PR TITLE
Show current values of wrong vars for errors

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -89,3 +89,5 @@ google-java-format_*
 
 # MKDocs Output
 site
+
+.jqwik-database

--- a/proxyserver/pom.xml
+++ b/proxyserver/pom.xml
@@ -312,6 +312,12 @@
             <version>3.12.4</version>
             <scope>test</scope>
         </dependency>
+        <dependency>
+          <groupId>net.jqwik</groupId>
+          <artifactId>jqwik</artifactId>
+          <version>1.9.3</version>
+          <scope>test</scope>
+        </dependency>
 
     </dependencies>
     <build>

--- a/proxyserver/src/main/java/edu/suffolk/litlab/efspserver/LowerCourtInfo.java
+++ b/proxyserver/src/main/java/edu/suffolk/litlab/efspserver/LowerCourtInfo.java
@@ -16,4 +16,17 @@ public class LowerCourtInfo {
     this.lowerCourtCode = lowerCourtCode;
     this.lowerCourtJudgeName = lowerCourtJudgeName;
   }
+
+  @Override
+  public String toString() {
+    return "[LowerCourtInfo: "
+        + caseTitleText
+        + ", "
+        + caseDocketId
+        + ", "
+        + lowerCourtCode
+        + ", "
+        + lowerCourtJudgeName
+        + "]";
+  }
 }

--- a/proxyserver/src/main/java/edu/suffolk/litlab/efspserver/docassemble/AddressDocassembleJacksonDeserializer.java
+++ b/proxyserver/src/main/java/edu/suffolk/litlab/efspserver/docassemble/AddressDocassembleJacksonDeserializer.java
@@ -77,7 +77,8 @@ public class AddressDocassembleJacksonDeserializer {
               .map((t) -> t.toString())
               .collect(Collectors.toList());
       InterviewVariable countryOptions =
-          collector.requestVar("country", "The 2 letter country code", "choices", countries);
+          collector.requestVar(
+              "country", "The 2 letter country code", "choices", countries, Optional.of(country));
       FilingError err = FilingError.wrongValue(countryOptions);
       collector.error(err);
       throw err;

--- a/proxyserver/src/main/java/edu/suffolk/litlab/efspserver/docassemble/FilingInformationDocassembleJacksonDeserializer.java
+++ b/proxyserver/src/main/java/edu/suffolk/litlab/efspserver/docassemble/FilingInformationDocassembleJacksonDeserializer.java
@@ -136,7 +136,8 @@ public class FilingInformationDocassembleJacksonDeserializer
                 "the side of the matter that current person answering this interview is on (must"
                     + " have is_new=True)",
                 "ALPeopleList",
-                List.of());
+                List.of(),
+                Optional.empty());
         collector.addRequired(varExpected);
         throw FilingError.missingRequired(varExpected);
       }
@@ -147,7 +148,8 @@ public class FilingInformationDocassembleJacksonDeserializer
                 "the opposite side of the matter, the side that current person answering this"
                     + " interview is not on (must have is_new=True)",
                 "ALPeopleList",
-                List.of());
+                List.of(),
+                Optional.empty());
         collector.addOptional(othersExpected);
       }
       JsonNode prefLang = node.get("user_preferred_language");
@@ -162,7 +164,11 @@ public class FilingInformationDocassembleJacksonDeserializer
       if (userEmail.isEmpty() || userEmail.orElse("").isBlank()) {
         InterviewVariable var =
             new InterviewVariable(
-                "users[0].email", "Email is required for at least one user", "text", List.of());
+                "users[0].email",
+                "Email is required for at least one user",
+                "text",
+                List.of(),
+                Optional.empty());
         collector.addRequired(var);
       }
     }
@@ -181,7 +187,8 @@ public class FilingInformationDocassembleJacksonDeserializer
                 "user_started_case",
                 "True if the user is the plaintiff or petitioner",
                 "boolean",
-                List.of("true", "false"));
+                List.of("true", "false"),
+                Optional.empty());
         collector.addRequired(var);
       }
     }
@@ -369,20 +376,30 @@ public class FilingInformationDocassembleJacksonDeserializer
               collector.requestVar(
                   "party_association",
                   "Party association should be text, is" + partyAssoc.toString(),
-                  "text"));
+                  "text",
+                  List.of(),
+                  Optional.of(partyAssoc.toString())));
         }
         JsonNode contactId = servObj.get("contact_id");
         if (contactId == null || !contactId.isTextual()) {
           collector.addWrong(
               collector.requestVar(
-                  "contact_id", "Service contacts must have a contact id", "text"));
+                  "contact_id",
+                  "Service contacts must have a contact id",
+                  "text",
+                  List.of(),
+                  Optional.ofNullable(contactId).map(JsonNode::toString)));
           contactId = NullNode.getInstance();
         }
         JsonNode serviceType = servObj.get("service_type");
         if (serviceType == null || !serviceType.isTextual()) {
           collector.addWrong(
               collector.requestVar(
-                  "service_type", "Service contacts must have a service type code", "text"));
+                  "service_type",
+                  "Service contacts must have a service type code",
+                  "text",
+                  List.of(),
+                  Optional.ofNullable(serviceType).map(JsonNode::toString)));
           serviceType = NullNode.getInstance();
         }
         CaseServiceContact contact =
@@ -463,7 +480,12 @@ public class FilingInformationDocassembleJacksonDeserializer
             Optional.of(LocalDate.parse(jsonReturnDate.asText(), DateTimeFormatter.ISO_DATE));
       } catch (DateTimeParseException ex) {
         InterviewVariable var =
-            collector.requestVar("return_date", "Should be as YYYY-MM-DD+01:00", "date");
+            collector.requestVar(
+                "return_date",
+                "Should be as YYYY-MM-DD+01:00",
+                "date",
+                List.of(),
+                Optional.of(jsonReturnDate.asText()));
         collector.addWrong(var);
       }
     }

--- a/proxyserver/src/main/java/edu/suffolk/litlab/efspserver/docassemble/PersonDocassembleJacksonDeserializer.java
+++ b/proxyserver/src/main/java/edu/suffolk/litlab/efspserver/docassemble/PersonDocassembleJacksonDeserializer.java
@@ -49,7 +49,7 @@ public class PersonDocassembleJacksonDeserializer {
       }
     } else {
       InterviewVariable var =
-          collector.requestVar("mobile_number", "A mobile or cell phone number", "text", List.of());
+          collector.requestVar("mobile_number", "A mobile or cell phone number", "text");
       collector.addOptional(var);
     }
 
@@ -67,7 +67,7 @@ public class PersonDocassembleJacksonDeserializer {
       }
     } else {
       InterviewVariable var =
-          collector.requestVar("phone_number", "A mobile or cell phone number", "text", List.of());
+          collector.requestVar("phone_number", "A mobile or cell phone number", "text");
       collector.addOptional(var);
     }
 
@@ -118,22 +118,34 @@ public class PersonDocassembleJacksonDeserializer {
 
     Optional<String> efmId = getStringMember(node, "tyler_id");
     if (node.has("is_new")) {
-      if (!node.get("is_new").isBoolean()) {
+      var isNew = node.get("is_new");
+      if (!isNew.isBoolean()) {
         collector.addWrong(
-            collector.requestVar("is_new", "if the party is new to the the case", "bool"));
+            collector.requestVar(
+                "is_new",
+                "if the party is new to the the case",
+                "bool",
+                List.of(),
+                Optional.of(isNew.toString())));
       }
-      if (node.get("is_new").asBoolean() && efmId.isPresent()) {
+      if (isNew.asBoolean() && efmId.isPresent()) {
         collector.addWrong(
             collector.requestVar(
                 "is_new",
                 "Can't have an EFM (tyler) ID on a "
                     + "brand new party to the case: their tyler id shouldn't exist yet",
-                "bool"));
+                "bool",
+                List.of(),
+                Optional.of(isNew.toString())));
       }
-      if (!node.get("is_new").asBoolean() && efmId.isEmpty()) {
+      if (!isNew.asBoolean() && efmId.isEmpty()) {
         collector.addWrong(
             collector.requestVar(
-                "tyler_id", "Can't be marked as not new, but not have an EFM ID", "text"));
+                "tyler_id",
+                "Can't be marked as not new, but not have an EFM ID",
+                "text",
+                List.of(),
+                Optional.of(isNew.toString())));
       }
       // if marked as is_new and no EFM id, that's fine! They're brand new to the case
     }

--- a/proxyserver/src/main/java/edu/suffolk/litlab/efspserver/ecf4/Ecf4Filer.java
+++ b/proxyserver/src/main/java/edu/suffolk/litlab/efspserver/ecf4/Ecf4Filer.java
@@ -221,7 +221,9 @@ public class Ecf4Filer extends EfmCheckableFilingInterface {
               collector.requestVar(
                   "previous_case_id",
                   "Could not find the given case id (" + info.getPreviousCaseId().get() + ")",
-                  "text");
+                  "text",
+                  List.of(),
+                  info.getPreviousCaseId());
           collector.addWrong(filingVar);
         }
 
@@ -238,7 +240,11 @@ public class Ecf4Filer extends EfmCheckableFilingInterface {
         if (maybeFilingCodes.stream().anyMatch(fc -> fc.isEmpty())) {
           InterviewVariable filingVar =
               collector.requestVar(
-                  "court_bundle[i].filing_type", "What filing type is this?", "text");
+                  "court_bundle[i].filing_type",
+                  "What filing type is this?",
+                  "text",
+                  List.of(),
+                  Optional.empty());
           collector.addRequired(filingVar);
         }
         List<String> filingCodeStrs =
@@ -282,7 +288,8 @@ public class Ecf4Filer extends EfmCheckableFilingInterface {
                   "service_contact[" + i + "].service_type",
                   "service type should be",
                   "choices",
-                  types.stream().map(t -> t.code).collect(Collectors.toList()));
+                  types.stream().map(t -> t.code).collect(Collectors.toList()),
+                  Optional.of(servContact.serviceType));
           collector.addWrong(var);
         }
         /*

--- a/proxyserver/src/main/java/edu/suffolk/litlab/efspserver/ecf4/EcfCaseTypeFactory.java
+++ b/proxyserver/src/main/java/edu/suffolk/litlab/efspserver/ecf4/EcfCaseTypeFactory.java
@@ -336,7 +336,9 @@ public class EcfCaseTypeFactory {
                   + " support ("
                   + comboCodes.cat.ecfcasetype
                   + ")",
-              "text");
+              "text",
+              List.of(),
+              Optional.of(comboCodes.cat.code));
       collector.addWrong(var);
       FilingError err = FilingError.wrongValue(var);
       throw err;
@@ -349,7 +351,9 @@ public class EcfCaseTypeFactory {
                   + " Case category requires an ECF case type that we don't know about or support ("
                   + comboCodes.cat.ecfcasetype
                   + ")",
-              "text");
+              "text",
+              List.of(),
+              Optional.of(comboCodes.cat.code));
       collector.addWrong(var);
       FilingError err = FilingError.wrongValue(var);
       throw err;
@@ -411,7 +415,8 @@ public class EcfCaseTypeFactory {
                 "efile_case_subtype",
                 "Sub type of the case",
                 "choices",
-                subTypes.stream().map(nac -> nac.getName()).collect(Collectors.toList()));
+                subTypes.stream().map(nac -> nac.getName()).collect(Collectors.toList()),
+                Optional.of(info.getCaseSubtypeCode()));
         collector.addWrong(subTypeVar);
       }
     }
@@ -661,7 +666,8 @@ public class EcfCaseTypeFactory {
               filerTypeName,
               "Metadata about the filer of this case",
               "choices",
-              allTypes.stream().map(t -> t.code).collect(Collectors.toList()));
+              allTypes.stream().map(t -> t.code).collect(Collectors.toList()),
+              Optional.ofNullable(filerTypeNode).map(JsonNode::toString));
       if (filerTypeNode != null && filerTypeNode.isTextual()) {
         String filerType = filerTypeNode.asText();
         Optional<FilerType> typeInfo =
@@ -730,6 +736,7 @@ public class EcfCaseTypeFactory {
       procedureView = serializer.allDataFields.getFieldRow(procedureViewName);
     }
     InterviewVariable var;
+    JsonNode proRem = miscInfo.get("procedure_remedy");
     if (procedureRemedies.isEmpty()) {
       var = collector.requestVar("procedure_remedy", "Procedure Remedy", "text");
     } else {
@@ -738,10 +745,10 @@ public class EcfCaseTypeFactory {
               "procedure_remedy",
               "Procedure Remedy",
               "choices",
-              procedureRemedies.stream().map(nac -> nac.getName()).collect(Collectors.toList()));
+              procedureRemedies.stream().map(nac -> nac.getName()).collect(Collectors.toList()),
+              Optional.ofNullable(proRem).map(JsonNode::toString));
     }
     ProcedureRemedyType type = new ProcedureRemedyType();
-    JsonNode proRem = miscInfo.get("procedure_remedy");
     if (proRem != null && !proRem.isNull() && proRem.isTextual()) {
       if (procedureView.isvisible) {
         List<NameAndCode> maybeProcedures =
@@ -789,6 +796,7 @@ public class EcfCaseTypeFactory {
           serializer.allDataFields.getFieldRow(
               "CivilCaseDamageAmount" + ((initial) ? "Initial" : "Subsequent"));
     }
+    JsonNode jsonDmg = miscInfo.get("damage_amount");
     InterviewVariable docVar;
     if (damageAmounts.isEmpty()) {
       docVar = collector.requestVar("procedure_remedy", "Procedure Remedy", "text");
@@ -798,9 +806,9 @@ public class EcfCaseTypeFactory {
               "procedure_remedy",
               "Procedure Remedy",
               "choices",
-              damageAmounts.stream().map(nac -> nac.getName()).collect(Collectors.toList()));
+              damageAmounts.stream().map(nac -> nac.getName()).collect(Collectors.toList()),
+              Optional.ofNullable(jsonDmg).map(JsonNode::toString));
     }
-    JsonNode jsonDmg = miscInfo.get("damage_amount");
     if (jsonDmg != null && !jsonDmg.isNull() && jsonDmg.isTextual()) {
       if (damageConfig.isvisible) {
         Optional<NameAndCode> maybeDmg =
@@ -909,10 +917,15 @@ public class EcfCaseTypeFactory {
 
     CaseType ct = niemObjFac.createCaseType();
 
-    InterviewVariable lowerNameVar =
-        collector.requestVar("trial_court.name", "The lower court name", "text");
     if (info.getLowerCourtInfo().isPresent()) {
       var lowerInfo = info.getLowerCourtInfo().get();
+      InterviewVariable lowerNameVar =
+          collector.requestVar(
+              "trial_court.name",
+              "The lower court name",
+              "text",
+              List.of(),
+              Optional.ofNullable(lowerInfo).map(l -> l.toString()));
       if (lowerInfo.lowerCourtCode == null || lowerInfo.lowerCourtCode.isBlank()) {
         // Lower court code doesn't seem to actually be required on the eFileMA site and its kind of
         // broken, so commenting this out

--- a/proxyserver/src/main/java/edu/suffolk/litlab/efspserver/ecf4/Ecfv5CaseTypeFactory.java
+++ b/proxyserver/src/main/java/edu/suffolk/litlab/efspserver/ecf4/Ecfv5CaseTypeFactory.java
@@ -152,7 +152,9 @@ public class Ecfv5CaseTypeFactory {
                 collector.requestVar(
                     "party_to_attorneys",
                     "Can't find the existing party ID in the existing parties",
-                    "text"));
+                    "text",
+                    List.of(),
+                    Optional.of(partyAndAtt.getKey().toString())));
           }
           EntityType ent =
               serializeExistingParticipant(
@@ -287,7 +289,11 @@ public class Ecfv5CaseTypeFactory {
           partyTypes.stream().map(p -> p.code).collect(Collectors.toList());
       InterviewVariable ptVar =
           collector.requestVar(
-              "party_type", "Legal role of the party", "choices", partyTypeChoices);
+              "party_type",
+              "Legal role of the party",
+              "choices",
+              partyTypeChoices,
+              Optional.of(per.getRole()));
       collector.addWrong(ptVar);
     }
     EntityType ent = niemObjFac.createEntityType();

--- a/proxyserver/src/main/java/edu/suffolk/litlab/efspserver/services/CasesService.java
+++ b/proxyserver/src/main/java/edu/suffolk/litlab/efspserver/services/CasesService.java
@@ -273,6 +273,7 @@ public class CasesService {
         // If the response has issues connecting with the CMS, we are still supposed to allow
         // for case search / e-filing. So, we'll return an error with the error code, but also any
         // cases that were still present.
+        // -15: CMS timed out, -11: CMS is unavailable, -10: some info in case might be missing
         Set<String> cmsConnectionErrors = Set.of("-11", "-15", "-10");
         if (resp.getError().stream()
             .anyMatch(err -> cmsConnectionErrors.contains(err.getErrorCode().getValue()))) {

--- a/proxyserver/src/main/java/edu/suffolk/litlab/efspserver/services/FilingError.java
+++ b/proxyserver/src/main/java/edu/suffolk/litlab/efspserver/services/FilingError.java
@@ -2,6 +2,7 @@ package edu.suffolk.litlab.efspserver.services;
 
 import java.util.Optional;
 import org.apache.commons.lang3.builder.HashCodeBuilder;
+import org.apache.commons.text.StringEscapeUtils;
 
 public class FilingError extends Exception {
   private static final long serialVersionUID = 1L;
@@ -78,7 +79,7 @@ public class FilingError extends Exception {
         "description": "%s"
       }
       """
-          .formatted(this.description);
+          .formatted(StringEscapeUtils.escapeJson(this.description));
     } else if (type.equals(Type.MalformedInterview)) {
       return """
       {
@@ -86,7 +87,7 @@ public class FilingError extends Exception {
         "description": "%s"
       }
       """
-          .formatted(this.description);
+          .formatted(StringEscapeUtils.escapeJson(this.description));
     } else if (missingVariable.isPresent()) { // Missing Required
       InterviewVariable var = missingVariable.get();
       return var.toJson();
@@ -97,7 +98,7 @@ public class FilingError extends Exception {
       "description": "%s"
     }
     """
-        .formatted(this.type + " :: " + this.description);
+        .formatted(this.type + " :: " + StringEscapeUtils.escapeJson(this.description));
   }
 
   public Type getType() {

--- a/proxyserver/src/main/java/edu/suffolk/litlab/efspserver/services/InfoCollector.java
+++ b/proxyserver/src/main/java/edu/suffolk/litlab/efspserver/services/InfoCollector.java
@@ -122,15 +122,21 @@ public abstract class InfoCollector {
    * @param desc
    * @param datatype
    * @param choices
+   * @param currentVal the current value (if any) of the variable in this round of processing
    * @return
    */
   public InterviewVariable requestVar(
-      String localName, String desc, String datatype, List<String> choices) {
-    return new InterviewVariable(currentAttributeStack() + localName, desc, datatype, choices);
+      String localName,
+      String desc,
+      String datatype,
+      List<String> choices,
+      Optional<String> currentVal) {
+    return new InterviewVariable(
+        currentAttributeStack() + localName, desc, datatype, choices, currentVal);
   }
 
   public InterviewVariable requestVar(String localName, String description, String datatype) {
-    return requestVar(localName, description, datatype, List.of());
+    return requestVar(localName, description, datatype, List.of(), Optional.empty());
   }
 
   public String jsonSummary() {

--- a/proxyserver/src/main/java/edu/suffolk/litlab/efspserver/services/InterviewVariable.java
+++ b/proxyserver/src/main/java/edu/suffolk/litlab/efspserver/services/InterviewVariable.java
@@ -1,7 +1,9 @@
 package edu.suffolk.litlab.efspserver.services;
 
 import java.util.Collection;
+import java.util.Optional;
 import org.apache.commons.lang3.builder.HashCodeBuilder;
+import org.apache.commons.text.StringEscapeUtils;
 
 public class InterviewVariable {
   /** An enum for how other variables rely on this one. */
@@ -10,14 +12,20 @@ public class InterviewVariable {
   private final String description;
   private final String datatype;
   private final Collection<String> choices;
+  private final Optional<String> currentVal;
 
   /** Default constructor, directly assing all variables from params. */
   public InterviewVariable(
-      String name, String description, String datatype, Collection<String> choices) {
+      String name,
+      String description,
+      String datatype,
+      Collection<String> choices,
+      Optional<String> currentVal) {
     this.name = name;
     this.description = description;
     this.datatype = datatype;
     this.choices = choices;
+    this.currentVal = currentVal;
   }
 
   public String getName() {
@@ -29,7 +37,7 @@ public class InterviewVariable {
   }
 
   public InterviewVariable appendDesc(String newDescription) {
-    return new InterviewVariable(name, description + newDescription, datatype, choices);
+    return new InterviewVariable(name, description + newDescription, datatype, choices, currentVal);
   }
 
   public String getDatatype() {
@@ -46,7 +54,7 @@ public class InterviewVariable {
         if (!firstTime) {
           sb.append(",");
         }
-        sb.append("\"").append(choice).append("\"");
+        sb.append("\"").append(StringEscapeUtils.escapeJson(choice)).append("\"");
         firstTime = false;
       }
       sb.append("]");
@@ -57,17 +65,27 @@ public class InterviewVariable {
       "name": "%s",
       "description": "%s",
       "datatype": "%s",
+      "currentVal": "%s",
       "choices": %s
     }
     """
-        .formatted(name, description.replace("\"", "\\\""), datatype, choicesStr);
+        .formatted(
+            StringEscapeUtils.escapeJson(name),
+            StringEscapeUtils.escapeJson(description),
+            StringEscapeUtils.escapeJson(datatype),
+            StringEscapeUtils.escapeJson(currentVal.orElse("")),
+            choicesStr);
   }
 
   @Override
   public String toString() {
     StringBuilder sb = new StringBuilder();
-    sb.append(name).append(' ').append(description).append(' ');
-    sb.append(datatype).append(' ').append(choices).append(' ');
+    sb.append("[InterviewVariable: ");
+    sb.append("name: `").append(name).append("`, ");
+    sb.append("description: `").append(description).append("`, ");
+    sb.append("datatype: `").append(datatype).append(", ");
+    sb.append("choices: `").append(choices).append("`, ");
+    sb.append("currentVal: `").append(currentVal).append("]");
     return sb.toString();
   }
 
@@ -83,12 +101,13 @@ public class InterviewVariable {
     InterviewVariable other = (InterviewVariable) obj;
     return this.name.equals(other.name)
         && this.datatype.equals(other.datatype)
-        && this.choices.equals(other.choices);
+        && this.choices.equals(other.choices)
+        && this.currentVal.equals(other.currentVal);
   }
 
   @Override
   public int hashCode() {
     HashCodeBuilder bd = new HashCodeBuilder();
-    return bd.append(name).append(datatype).append(choices).build();
+    return bd.append(name).append(datatype).append(choices).append(currentVal).build();
   }
 }

--- a/proxyserver/src/test/java/edu/suffolk/litlab/efspserver/InterviewVariableExample.java
+++ b/proxyserver/src/test/java/edu/suffolk/litlab/efspserver/InterviewVariableExample.java
@@ -1,0 +1,27 @@
+package edu.suffolk.litlab.efspserver;
+
+import edu.suffolk.litlab.efspserver.services.InterviewVariable;
+import java.util.List;
+import net.jqwik.api.Arbitraries;
+import net.jqwik.api.Arbitrary;
+import net.jqwik.api.Combinators;
+import net.jqwik.api.Provide;
+import net.jqwik.api.domains.DomainContextBase;
+
+public class InterviewVariableExample extends DomainContextBase {
+
+  @Provide
+  Arbitrary<InterviewVariable> vars() {
+    Arbitrary<List<String>> choicePossibilities = Arbitraries.strings().collect(l -> l.size() > 10);
+    return Combinators.combine(
+            Arbitraries.strings(),
+            Arbitraries.strings(),
+            Arbitraries.strings(),
+            choicePossibilities,
+            Arbitraries.strings().optional())
+        .as(
+            (name, description, datatype, choice, currentVal) -> {
+              return new InterviewVariable(name, description, datatype, choice, currentVal);
+            });
+  }
+}

--- a/proxyserver/src/test/java/edu/suffolk/litlab/efspserver/docassemble/DocassembleToFilingInformationConverterTest.java
+++ b/proxyserver/src/test/java/edu/suffolk/litlab/efspserver/docassemble/DocassembleToFilingInformationConverterTest.java
@@ -19,6 +19,7 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.nio.charset.StandardCharsets;
 import java.util.List;
+import java.util.Optional;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
@@ -80,7 +81,7 @@ public class DocassembleToFilingInformationConverterTest {
         .isErr()
         .containsErr(
             FilingError.missingRequired(
-                new InterviewVariable("users[0].email", "", "text", List.of())));
+                new InterviewVariable("users[0].email", "", "text", List.of(), Optional.empty())));
   }
 
   @Test


### PR DESCRIPTION
In order to effectively debug errors that happen, we need to know the current state of the interview (it's easier than trying to evaluate all the ways a docassemble interview could get the wrong value). This adds a `currentVal` attribute to `InteriewVariable`, which is returned whenever there is an error in the provided filing. Defaults to `Optional.empty()`.

Also added unit tests with jqwik to check that we can serialize InfoCollection to JSON reliably, and properly escaped JSON strings for that reason.