### PR TITLE
Put git commit in Manifest and on about page

### DIFF
--- a/.github/workflows/fly.yml
+++ b/.github/workflows/fly.yml
@@ -16,6 +16,6 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - uses: superfly/flyctl-actions/setup-flyctl@master
-      - run: flyctl deploy --remote-only
+      - run: flyctl deploy --remote-only --build-arg CI_COMMIT_SHA=`git rev-parse HEAD`
         env:
           FLY_API_TOKEN: ${{ secrets.FLY_API_TOKEN }}

--- a/dev-compose.yml
+++ b/dev-compose.yml
@@ -5,6 +5,8 @@ services:
       service: efspjava
     build:
       target: build
+      args:
+        - CI_COMMIT_SHA
     # Necessary b/c docassemble is external to the docker network
     ports: !override
       - target: 9009

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -3,6 +3,8 @@ services:
     build:
       context: .
       target: release
+      args:
+        - CI_COMMIT_SHA
     # Necessary b/c docassemble is external to the docker network
     ports:
       - target: 9009

--- a/proxyserver/pom.xml
+++ b/proxyserver/pom.xml
@@ -358,9 +358,12 @@
                             <!-- Needed for CXF to work in a fatjar https://stackoverflow.com/a/68743972/11416267 -->
                             <transformers>
                                 <transformer implementation="org.apache.maven.plugins.shade.resource.ManifestResourceTransformer">
-                                  <manifestEntries>
-                                    <Main-Class>edu.suffolk.litlab.efsp.server.EfspServer</Main-Class>
-                                  </manifestEntries>
+                                    <manifestEntries>
+                                        <Main-Class>edu.suffolk.litlab.efsp.server.EfspServer</Main-Class>
+                                        <Build-Time>${maven.build.timestamp}</Build-Time>
+                                        <Implementation-Version>${project.version}</Implementation-Version>
+                                        <Implementation-SCM-Revision>${build.revision}</Implementation-SCM-Revision>
+                                    </manifestEntries>
                                 </transformer>
                                 <transformer implementation="org.apache.maven.plugins.shade.resource.AppendingTransformer">
                                     <resource>META-INF/cxf/bus-extensions.txt</resource>

--- a/proxyserver/src/main/java/edu/suffolk/litlab/efsp/server/services/RootService.java
+++ b/proxyserver/src/main/java/edu/suffolk/litlab/efsp/server/services/RootService.java
@@ -1,5 +1,7 @@
 package edu.suffolk.litlab.efsp.server.services;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.ObjectNode;
 import edu.suffolk.litlab.efsp.server.utils.EndpointReflection;
 import edu.suffolk.litlab.efsp.server.utils.ServiceHelpers;
 import jakarta.ws.rs.GET;
@@ -35,9 +37,16 @@ public class RootService {
   @Produces(MediaType.APPLICATION_JSON)
   public Response getVersionInfo() {
     final var properties = new Properties();
+    ObjectMapper mapper = new ObjectMapper();
     try (var is = RootService.class.getResourceAsStream("/version.properties")) {
       properties.load(is);
-      return Response.ok("{\"version\": \"" + properties.getProperty("version") + "\"}").build();
+      ObjectNode rootNode = mapper.createObjectNode();
+      rootNode.put("version", properties.getProperty("version"));
+      String commit = properties.getProperty("commit");
+      if (commit != null && !commit.isBlank()) {
+        rootNode.put("commit", commit);
+      }
+      return Response.ok(mapper.writer().writeValueAsString(rootNode)).build();
     } catch (IOException e) {
       return Response.status(500).entity("Could not load version info").build();
     }

--- a/proxyserver/src/main/resources/version.properties
+++ b/proxyserver/src/main/resources/version.properties
@@ -1,1 +1,2 @@
 version = ${project.version}
+commit = ${build.revision}


### PR DESCRIPTION
Only on the test server; will be null (and thus not visible) in production.

Adds passthrough args to several layers:

* the maven / Java layer (`-Dbuild.revision`)
    * which is the part actually included in `version.properties` and ready by `RootService.java`
    * if the commit property is null or empty, it's not shown on the about page
* Dockerfile
    * done as an `ARG CI_COMMIT_SHA` in both stages of the build, set as a Docker label and passed to maven
* Docker compose 
    * as a `build:args` in both. Works on cli as `CI_COMMIT_SHA=... docker compose build`.
* fly
    * just the test deploy workflow, not the production one

