### PR TITLE
Better Codes API docs

### DIFF
--- a/proxyserver/src/main/java/edu/suffolk/litlab/efsp/server/services/CodesService.java
+++ b/proxyserver/src/main/java/edu/suffolk/litlab/efsp/server/services/CodesService.java
@@ -11,6 +11,7 @@ import jakarta.ws.rs.core.Context;
 import jakarta.ws.rs.core.HttpHeaders;
 import jakarta.ws.rs.core.MediaType;
 import jakarta.ws.rs.core.Response;
+import java.sql.SQLException;
 
 /**
  * The endpoints for the court specific configurations that clients need to use to file properly.
@@ -39,6 +40,197 @@ public abstract class CodesService {
   @GET
   @Path("/courts/{court_id}/codes")
   public abstract Response getCourtLocationCodes(@PathParam("court_id") String courtId);
+
+  @GET
+  @Path("/courts/{court_id}/categories")
+  public abstract Response getCategories(
+      @PathParam("court_id") String courtId,
+      @DefaultValue("false") @QueryParam("fileable_only") boolean fileableOnly,
+      @QueryParam("timing") String timing)
+      throws SQLException;
+
+  @GET
+  @Path("/courts/{court_id}/categories/{cat_code}")
+  public abstract Response getCategoryByCode(
+      @PathParam("court_id") String courtId, @PathParam("cat_code") String catCode)
+      throws SQLException;
+
+  @GET
+  @Path("/courts/{court_id}/case_types")
+  public abstract Response getCaseTypes(
+      @PathParam("court_id") String courtId,
+      @QueryParam("category_id") String categoryId,
+      @QueryParam("timing") String timing)
+      throws SQLException;
+
+  @GET
+  @Path("/courts/{court_id}/name_suffixes")
+  public abstract Response getNameSuffixes(@PathParam("court_id") String courtId)
+      throws SQLException;
+
+  @GET
+  @Path("/courts/{court_id}/case_types/{case_type_id}/case_subtypes")
+  public abstract Response getCaseSubtypes(
+      @PathParam("court_id") String courtId, @PathParam("case_type_id") String caseTypeId)
+      throws SQLException;
+
+  @GET
+  @Path("/courts/{court_id}/service_types")
+  public abstract Response getServiceTypes(@PathParam("court_id") String courtId)
+      throws SQLException;
+
+  @GET
+  @Path("/courts/{court_id}/procedures_or_remedies")
+  public abstract Response getProcedureOrRemedies(
+      @PathParam("court_id") String courtId, @QueryParam("category_id") String categoryId)
+      throws SQLException;
+
+  /**
+   * @param courtId The court id where these filing types are present.
+   * @param categoryId (optional) used to filter by filing types that can only be used with this
+   *     case category.
+   * @param typeId (optional) used to filter by filing types that can only be used with this case
+   *     type
+   * @param initial if true, shows filing types that can be used on initial filings (or initial and
+   *     subsequent filings). If false, shows filings that can be used on subsequent filings.
+   * @return The filing info
+   * @responseExample application/json { "code": "29217", "name": "Proposed Order", "fee": "",
+   *     "casecategory": "", "casetypeid": "", "filingtype": "Both", "iscourtuseonly": false,
+   *     "civilclaimamount": "Not Available", "probateestateamount": "Not Available",
+   *     "amountincontroversy": "Not Available", "useduedate": false, "isproposedorder": false,
+   *     "efspcode": "", "location": "adams" }
+   * @throws SQLException
+   */
+  @GET
+  @Path("/courts/{court_id}/filing_types")
+  public abstract Response getFilingTypes(
+      @PathParam("court_id") String courtId,
+      @QueryParam("category_id") String categoryId,
+      @QueryParam("type_id") String typeId,
+      @QueryParam("initial") boolean initial)
+      throws SQLException;
+
+  @GET
+  @Path("/courts/{court_id}/filer_types")
+  public abstract Response getFilerTypes(@PathParam("court_id") String courtId) throws SQLException;
+
+  @GET
+  @Path("/courts/{court_id}/damage_amounts")
+  public abstract Response getDamageAmounts(
+      @PathParam("court_id") String courtId, @QueryParam("category_id") String categoryId)
+      throws SQLException;
+
+  /**
+   * Used for when you need to populate the party types names for a case search or something similar
+   *
+   * @param courtId
+   * @return
+   * @throws SQLException
+   */
+  @GET
+  @Path("/courts/{court_id}/party_types")
+  public abstract Response getAllPartyTypes(@PathParam("court_id") String courtId)
+      throws SQLException;
+
+  @GET
+  @Path("/courts/{court_id}/party_types/{party_type_id}")
+  public abstract Response getPartyTypeFromAll(
+      @PathParam("court_id") String courtId, @PathParam("party_type_id") String partyTypeId)
+      throws SQLException;
+
+  @GET
+  @Path("/courts/{court_id}/case_types/{case_type_id}/party_types")
+  public abstract Response getPartyTypes(
+      @PathParam("court_id") String courtId, @PathParam("case_type_id") String caseTypeId)
+      throws SQLException;
+
+  @GET
+  @Path("/courts/{court_id}/case_types/{case_type_id}/party_types/{party_type_id}")
+  public abstract Response getPartyType(
+      @PathParam("court_id") String courtId,
+      @PathParam("case_type_id") String caseTypeId,
+      @PathParam("party_type_id") String partyTypeId)
+      throws SQLException;
+
+  @GET
+  @Path("/courts/{court_id}/casetypes/{case_type_id}/cross_references")
+  @Deprecated
+  public abstract Response getCrossReferencesOld(
+      @PathParam("court_id") String courtId, @PathParam("case_type_id") String caseTypeId)
+      throws SQLException;
+
+  @GET
+  @Path("/courts/{court_id}/case_types/{case_type_id}/cross_references")
+  public abstract Response getCrossReferences(
+      @PathParam("court_id") String courtId, @PathParam("case_type_id") String caseTypeId)
+      throws SQLException;
+
+  @GET
+  @Path("/courts/{court_id}/filing_types/{filing_code_id}/document_types")
+  public abstract Response getDocumentTypes(
+      @PathParam("court_id") String courtId, @PathParam("filing_code_id") String filingCodeId)
+      throws SQLException;
+
+  @GET
+  @Path("/courts/{court_id}/filing_types/{filing_code_id}/motion_types")
+  public abstract Response getMotionTypes(
+      @PathParam("court_id") String courtId, @PathParam("filing_code_id") String filingCodeId)
+      throws SQLException;
+
+  @GET
+  @Path("/courts/{court_id}/allowed_file_types")
+  public abstract Response getAllowedFileTypes(@PathParam("court_id") String courtId)
+      throws SQLException;
+
+  @GET
+  @Path("/courts/{court_id}/filing_statuses")
+  public abstract Response getFilingStatuses(@PathParam("court_id") String courtId)
+      throws SQLException;
+
+  @GET
+  @Path("/courts/{court_id}/filing_types/{filing_code_id}/filing_components")
+  public abstract Response getFilingComponents(
+      @PathParam("court_id") String courtId, @PathParam("filing_code_id") String filingCodeId)
+      throws SQLException;
+
+  @GET
+  @Path("/courts/{court_id}/filing_types/{filing_code_id}/optional_services")
+  public abstract Response getOptionalServices(
+      @PathParam("court_id") String courtId, @PathParam("filing_code_id") String filingCodeId)
+      throws SQLException;
+
+  @GET
+  @Path("/courts/{court_id}/countries/{country}/states")
+  public abstract Response getStates(
+      @PathParam("court_id") String courtId, @PathParam("country") String country)
+      throws SQLException;
+
+  @GET
+  @Path("/courts/{court_id}/languages")
+  public abstract Response getLanguages(@PathParam("court_id") String courtId) throws SQLException;
+
+  @GET
+  @Path("/courts/{court_id}/datafields")
+  public abstract Response getDataFields(@PathParam("court_id") String courtId) throws SQLException;
+
+  @GET
+  @Path("/courts/{court_id}/datafields/{field_name}")
+  // TODO(brycew-later): consider a bulk way of getting multiple codes, will be
+  // used heavily in the DA UI
+  public abstract Response getDataField(
+      @PathParam("court_id") String courtId, @PathParam("field_name") String fieldName)
+      throws SQLException;
+
+  @GET
+  @Path("/courts/{court_id}/optional_services/{opt_serv_code}")
+  public abstract Response getOptionalService(
+      @PathParam("court_id") String courtId, @PathParam("opt_serv_code") String optServCode)
+      throws SQLException;
+
+  @GET
+  @Path("/courts/{court_id}/disclaimer_requirements")
+  public abstract Response getDisclaimerRequirements(@PathParam("court_id") String courtId)
+      throws SQLException;
 
   /**
    * Adds proper CORS headers to all responses to the codes API, which is public

--- a/proxyserver/src/main/java/edu/suffolk/litlab/efsp/server/services/CourtsOnlyCodesService.java
+++ b/proxyserver/src/main/java/edu/suffolk/litlab/efsp/server/services/CourtsOnlyCodesService.java
@@ -7,6 +7,7 @@ import edu.suffolk.litlab.efsp.server.utils.EndpointReflection;
 import jakarta.ws.rs.core.HttpHeaders;
 import jakarta.ws.rs.core.Response;
 import java.lang.reflect.Method;
+import java.sql.SQLException;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
@@ -85,5 +86,177 @@ public class CourtsOnlyCodesService extends CodesService {
       return Optional.of(
           cors(Response.status(404).entity("\"Court " + courtId + " does not exist\"")));
     }
+  }
+
+  @Override
+  public Response getCategories(String courtId, boolean fileableOnly, String timing)
+      throws SQLException {
+    // TODO Auto-generated method stub
+    throw new UnsupportedOperationException("Unimplemented method 'getCategories'");
+  }
+
+  @Override
+  public Response getCategoryByCode(String courtId, String catCode) throws SQLException {
+    // TODO Auto-generated method stub
+    throw new UnsupportedOperationException("Unimplemented method 'getCategoryByCode'");
+  }
+
+  @Override
+  public Response getCaseTypes(String courtId, String categoryId, String timing)
+      throws SQLException {
+    // TODO Auto-generated method stub
+    throw new UnsupportedOperationException("Unimplemented method 'getCaseTypes'");
+  }
+
+  @Override
+  public Response getNameSuffixes(String courtId) throws SQLException {
+    // TODO Auto-generated method stub
+    throw new UnsupportedOperationException("Unimplemented method 'getNameSuffixes'");
+  }
+
+  @Override
+  public Response getCaseSubtypes(String courtId, String caseTypeId) throws SQLException {
+    // TODO Auto-generated method stub
+    throw new UnsupportedOperationException("Unimplemented method 'getCaseSubtypes'");
+  }
+
+  @Override
+  public Response getServiceTypes(String courtId) throws SQLException {
+    // TODO Auto-generated method stub
+    throw new UnsupportedOperationException("Unimplemented method 'getServiceTypes'");
+  }
+
+  @Override
+  public Response getProcedureOrRemedies(String courtId, String categoryId) throws SQLException {
+    // TODO Auto-generated method stub
+    throw new UnsupportedOperationException("Unimplemented method 'getProcedureOrRemedies'");
+  }
+
+  @Override
+  public Response getFilingTypes(String courtId, String categoryId, String typeId, boolean initial)
+      throws SQLException {
+    // TODO Auto-generated method stub
+    throw new UnsupportedOperationException("Unimplemented method 'getFilingTypes'");
+  }
+
+  @Override
+  public Response getFilerTypes(String courtId) throws SQLException {
+    // TODO Auto-generated method stub
+    throw new UnsupportedOperationException("Unimplemented method 'getFilerTypes'");
+  }
+
+  @Override
+  public Response getDamageAmounts(String courtId, String categoryId) throws SQLException {
+    // TODO Auto-generated method stub
+    throw new UnsupportedOperationException("Unimplemented method 'getDamageAmounts'");
+  }
+
+  @Override
+  public Response getAllPartyTypes(String courtId) throws SQLException {
+    // TODO Auto-generated method stub
+    throw new UnsupportedOperationException("Unimplemented method 'getAllPartyTypes'");
+  }
+
+  @Override
+  public Response getPartyTypeFromAll(String courtId, String partyTypeId) throws SQLException {
+    // TODO Auto-generated method stub
+    throw new UnsupportedOperationException("Unimplemented method 'getPartyTypeFromAll'");
+  }
+
+  @Override
+  public Response getPartyTypes(String courtId, String caseTypeId) throws SQLException {
+    // TODO Auto-generated method stub
+    throw new UnsupportedOperationException("Unimplemented method 'getPartyTypes'");
+  }
+
+  @Override
+  public Response getPartyType(String courtId, String caseTypeId, String partyTypeId)
+      throws SQLException {
+    // TODO Auto-generated method stub
+    throw new UnsupportedOperationException("Unimplemented method 'getPartyType'");
+  }
+
+  @Override
+  public Response getCrossReferencesOld(String courtId, String caseTypeId) throws SQLException {
+    // TODO Auto-generated method stub
+    throw new UnsupportedOperationException("Unimplemented method 'getCrossReferencesOld'");
+  }
+
+  @Override
+  public Response getCrossReferences(String courtId, String caseTypeId) throws SQLException {
+    // TODO Auto-generated method stub
+    throw new UnsupportedOperationException("Unimplemented method 'getCrossReferences'");
+  }
+
+  @Override
+  public Response getDocumentTypes(String courtId, String filingCodeId) throws SQLException {
+    // TODO Auto-generated method stub
+    throw new UnsupportedOperationException("Unimplemented method 'getDocumentTypes'");
+  }
+
+  @Override
+  public Response getMotionTypes(String courtId, String filingCodeId) throws SQLException {
+    // TODO Auto-generated method stub
+    throw new UnsupportedOperationException("Unimplemented method 'getMotionTypes'");
+  }
+
+  @Override
+  public Response getAllowedFileTypes(String courtId) throws SQLException {
+    // TODO Auto-generated method stub
+    throw new UnsupportedOperationException("Unimplemented method 'getAllowedFileTypes'");
+  }
+
+  @Override
+  public Response getFilingStatuses(String courtId) throws SQLException {
+    // TODO Auto-generated method stub
+    throw new UnsupportedOperationException("Unimplemented method 'getFilingStatuses'");
+  }
+
+  @Override
+  public Response getFilingComponents(String courtId, String filingCodeId) throws SQLException {
+    // TODO Auto-generated method stub
+    throw new UnsupportedOperationException("Unimplemented method 'getFilingComponents'");
+  }
+
+  @Override
+  public Response getOptionalServices(String courtId, String filingCodeId) throws SQLException {
+    // TODO Auto-generated method stub
+    throw new UnsupportedOperationException("Unimplemented method 'getOptionalServices'");
+  }
+
+  @Override
+  public Response getStates(String courtId, String country) throws SQLException {
+    // TODO Auto-generated method stub
+    throw new UnsupportedOperationException("Unimplemented method 'getStates'");
+  }
+
+  @Override
+  public Response getLanguages(String courtId) throws SQLException {
+    // TODO Auto-generated method stub
+    throw new UnsupportedOperationException("Unimplemented method 'getLanguages'");
+  }
+
+  @Override
+  public Response getDataFields(String courtId) throws SQLException {
+    // TODO Auto-generated method stub
+    throw new UnsupportedOperationException("Unimplemented method 'getDataFields'");
+  }
+
+  @Override
+  public Response getDataField(String courtId, String fieldName) throws SQLException {
+    // TODO Auto-generated method stub
+    throw new UnsupportedOperationException("Unimplemented method 'getDataField'");
+  }
+
+  @Override
+  public Response getOptionalService(String courtId, String optServCode) throws SQLException {
+    // TODO Auto-generated method stub
+    throw new UnsupportedOperationException("Unimplemented method 'getOptionalService'");
+  }
+
+  @Override
+  public Response getDisclaimerRequirements(String courtId) throws SQLException {
+    // TODO Auto-generated method stub
+    throw new UnsupportedOperationException("Unimplemented method 'getDisclaimerRequirements'");
   }
 }

--- a/proxyserver/src/main/java/edu/suffolk/litlab/efsp/server/services/JurisdictionServiceHandle.java
+++ b/proxyserver/src/main/java/edu/suffolk/litlab/efsp/server/services/JurisdictionServiceHandle.java
@@ -141,6 +141,7 @@ public class JurisdictionServiceHandle {
     return adminUser.orElse(null);
   }
 
+  /** Handle ECF 'codes', or court configurations and metadata relating to filing options. */
   @Path("/codes")
   public CodesService getCodesService() {
     return codes.orElse(null);

--- a/proxyserver/src/main/java/edu/suffolk/litlab/efsp/server/services/JurisdictionSwitch.java
+++ b/proxyserver/src/main/java/edu/suffolk/litlab/efsp/server/services/JurisdictionSwitch.java
@@ -26,6 +26,14 @@ public class JurisdictionSwitch {
     return Response.ok(ef.pathParamsToMap(jurisdictions.keySet().stream())).build();
   }
 
+  /**
+   * Chooses the specific jurisdiction (i.e. US State or other court system) that you are filing
+   * into.
+   *
+   * @param jurisdictionId the full name of the state, usually lower case ("massachusetts", or
+   *     "illinois").
+   * @return
+   */
   @Path("{jurisdiction_id}")
   public JurisdictionServiceHandle getJurisdictionService(
       @PathParam("jurisdiction_id") String jurisdictionId) {

--- a/proxyserver/src/test/java/edu/suffolk/litlab/efsp/server/services/CodesServiceTest.java
+++ b/proxyserver/src/test/java/edu/suffolk/litlab/efsp/server/services/CodesServiceTest.java
@@ -120,7 +120,9 @@ public class CodesServiceTest {
   public void testGetAll() throws JsonMappingException, JsonProcessingException {
     ObjectMapper mapper = new ObjectMapper();
     JsonNode node = mapper.readTree(getServerResponseAt("/"));
-    assertTrue(node.has("getCodesUnderCourt"), "didn't have codes post court: " + node);
+    assertTrue(
+        node.has("getCodesUnderCourt"),
+        "didn't have codes post court (`getCodesUnderCourt`): " + node);
     assertTrue(node.has("getCourtLocationCodes"), "didn't have court location codes: " + node);
     assertTrue(node.has("getCaseTypes"));
     assertTrue(node.has("getCaseSubtypes"));
@@ -145,7 +147,7 @@ public class CodesServiceTest {
   public void testGetCase() throws JsonMappingException, JsonProcessingException {
     ObjectMapper mapper = new ObjectMapper();
     JsonNode node = mapper.readTree(getServerResponseAt("/courts/adams/case_types/25361"));
-    assertTrue(node.has("getCaseSubtypes"), "didn't have case sub types. Response was: " + node);
+    assertTrue(node.has("getCaseSubtypes"), "didn't have `getCaseSubtypes`. Response was: " + node);
     assertEquals(
         ServiceHelpers.EXTERNAL_URL
             + "/jurisdictions/illinois/codes/courts/adams/case_types/25361/case_subtypes",


### PR DESCRIPTION
Added all codes endpoints to the abstract `CodesService` class so enunciate could pick them up for documentation. They are marked as `Unimplemented` in the JeffNet version (which is deprecated and will be removed soon anyway. I'll take the increase in boilerplate for the moment knowing that).

All of the implementations in `EcfCodesService` have been marked with `@Override` and had the JAX-RS annotations removed, but not functionality has changed. Confirmed that enunciate can pick up javadocs from classes earlier in the path. The `@responseExample` javadoc annotation isn't great, but gets the job done.

To keep the HATEOS stuff from completely breaking, I needed to also look through the parent class for annotations. It's a bit precarious, but tests still pass, and tbh, once the rest of the documentation (and the code search interviews) are up and running better, I'll probably deprecate the HATEOS functionality; it's only been useful for me and not any production functionality.

Addresses my concerns for an alternate in #190. 

Will get this merged, and will then work on documenting the rest of the parameters as needed.