### PR TITLE
Add `responseExample` to custom javadoc tags

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -148,6 +148,13 @@
                     <version>3.11.2</version>
                     <configuration>
                         <additionalparam>-Xdoclint:none</additionalparam>
+                        <tags>
+                            <tag>
+                                <name>responseExample</name>
+                                <placement>a</placement>
+                                <head>An example of the JSON response from this endpoint.</head>
+                            </tag>
+                        </tags>
                     </configuration>
                     <executions>
                         <execution>


### PR DESCRIPTION
Even though enunciate can parse the `responseExample` javadoc tag, we need to tell javadoc about it so it doesn't error.