### PR TITLE
Handle JSON parsing errors reasonably

### DIFF
--- a/proxyserver/pom.xml
+++ b/proxyserver/pom.xml
@@ -309,7 +309,7 @@
         <dependency>
             <groupId>org.mockito</groupId>
             <artifactId>mockito-core</artifactId>
-            <version>3.12.4</version>
+            <version>5.18.0</version>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/proxyserver/src/main/java/edu/suffolk/litlab/efsp/server/EfspServer.java
+++ b/proxyserver/src/main/java/edu/suffolk/litlab/efsp/server/EfspServer.java
@@ -23,6 +23,7 @@ import edu.suffolk.litlab.efsp.server.setup.EfmRestCallbackInterface;
 import edu.suffolk.litlab.efsp.server.setup.jeffnet.JeffNetModuleSetup;
 import edu.suffolk.litlab.efsp.server.setup.tyler.TylerModuleSetup;
 import edu.suffolk.litlab.efsp.server.utils.HttpsCallbackHandler;
+import edu.suffolk.litlab.efsp.server.utils.JsonExceptionMapper;
 import edu.suffolk.litlab.efsp.server.utils.OrgMessageSender;
 import edu.suffolk.litlab.efsp.server.utils.SendMessage;
 import edu.suffolk.litlab.efsp.server.utils.ServiceHelpers;
@@ -139,11 +140,7 @@ public class EfspServer {
         Map.of(
             "xml", MediaType.APPLICATION_XML,
             "json", MediaType.APPLICATION_JSON));
-    sf.setProviders(
-        List.of(
-            new JAXBElementProvider<Object>(),
-            new JacksonJsonProvider(),
-            new SoapExceptionMapper()));
+    sf.setProviders(providers());
 
     sf.setAddress(ServiceHelpers.BASE_LOCAL_URL);
     server = sf.create();
@@ -205,6 +202,14 @@ public class EfspServer {
       log.error("SQLException when setting up / creating tables", ex);
       System.exit(2);
     }
+  }
+
+  public static List<?> providers() {
+    return List.of(
+        new JAXBElementProvider<Object>(),
+        new JacksonJsonProvider(), // TODO(brycew): JAXBJSon?
+        new SoapExceptionMapper(),
+        new JsonExceptionMapper());
   }
 
   public static void main(String[] args) throws Exception {

--- a/proxyserver/src/main/java/edu/suffolk/litlab/efsp/server/utils/JsonExceptionMapper.java
+++ b/proxyserver/src/main/java/edu/suffolk/litlab/efsp/server/utils/JsonExceptionMapper.java
@@ -1,0 +1,19 @@
+package edu.suffolk.litlab.efsp.server.utils;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import jakarta.ws.rs.core.Response;
+import jakarta.ws.rs.ext.ExceptionMapper;
+import jakarta.ws.rs.ext.Provider;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+@Provider
+public class JsonExceptionMapper implements ExceptionMapper<JsonProcessingException> {
+  Logger log = LoggerFactory.getLogger(JsonExceptionMapper.class);
+
+  @Override
+  public Response toResponse(JsonProcessingException exception) {
+    log.error("Exception when processing JSON input:", exception);
+    return Response.status(Response.Status.BAD_REQUEST).entity(exception.getMessage()).build();
+  }
+}

--- a/proxyserver/src/test/java/edu/suffolk/litlab/efsp/server/services/AdminUserServiceTest.java
+++ b/proxyserver/src/test/java/edu/suffolk/litlab/efsp/server/services/AdminUserServiceTest.java
@@ -1,0 +1,77 @@
+package edu.suffolk.litlab.efsp.server.services;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import com.hubspot.algebra.Result;
+import edu.suffolk.litlab.efsp.server.EfspServer;
+import edu.suffolk.litlab.efsp.server.utils.ServiceHelpers;
+import edu.suffolk.litlab.efsp.tyler.TylerFirmClient;
+import jakarta.ws.rs.core.MediaType;
+import jakarta.ws.rs.core.Response;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import org.apache.cxf.endpoint.Server;
+import org.apache.cxf.jaxrs.JAXRSServerFactoryBean;
+import org.apache.cxf.jaxrs.client.WebClient;
+import org.apache.cxf.jaxrs.lifecycle.SingletonResourceProvider;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+import tyler.efm.latest.services.schema.registrationresponse.RegistrationResponseType;
+
+public class AdminUserServiceTest {
+
+  private static final String ENDPOINT_ADDRESS = "http://localhost:9090";
+  private Server server;
+
+  private void startServer() throws Exception {
+    TylerFirmClient client = mock(TylerFirmClient.class);
+    RegistrationResponseType resp = new RegistrationResponseType();
+    resp.setUserID("abc123");
+    resp.setPasswordHash("the_hash");
+    when(client.registerUser(any())).thenReturn(resp);
+
+    Mockito.mockStatic(ServiceHelpers.class)
+        .when(() -> ServiceHelpers.setupFirmPort(any(), any()))
+        .thenReturn(Optional.of(client));
+
+    JAXRSServerFactoryBean sf = new JAXRSServerFactoryBean();
+    sf.setResourceClasses(AdminUserService.class);
+    sf.setResourceProvider(
+        AdminUserService.class,
+        new SingletonResourceProvider(
+            new AdminUserService("illinois", "stage", null, null, (a) -> Result.nullOk())));
+    sf.setAddress(ENDPOINT_ADDRESS);
+    Map<Object, Object> extensionMappings = Map.of("json", MediaType.APPLICATION_JSON);
+    sf.setExtensionMappings(extensionMappings);
+    List<?> providers = EfspServer.providers();
+    sf.setProviders(providers);
+    server = sf.create();
+  }
+
+  @BeforeEach
+  void init() throws Exception {
+    startServer();
+  }
+
+  @AfterEach
+  public void destroy() throws Exception {
+    server.stop();
+    server.destroy();
+  }
+
+  @Test
+  public void testBadInputToRegisterUser() {
+    WebClient client = WebClient.create(ENDPOINT_ADDRESS);
+    client.accept("application/json");
+    client.type(MediaType.APPLICATION_JSON);
+    client.path("/users");
+    Response resp = client.post("{\"email\": \"\", \"registrationType\": \"Individual\"}");
+    assertThat(resp.getStatus()).isEqualTo(400);
+  }
+}


### PR DESCRIPTION
Found this by passing an invalid `RegistrationRequestType` to the `registerUser` endpoint (it needs to be all caps).

But for some reason, instead of erroring out, the server would return a 204, making it seem like some sort of user had been registered. Was able to track the 204 down to the fact that CXF catches IOExceptions (JAXRSInvoker.java:L287), which the JSON exception is considered a part of, but there were no exception handlers to handle the exception, so it was treated as empty.

The fix involved making an exception handler to properly handle and category the exception as a user input exception (400).

Also added a unit test on the AdminUserService as a regression test for this. Had to update mockito to mock static methods, and refactored a small bit of the EfspServer setup into a static method so we can easily use the same providers when testing as we do on the real server.