### PR TITLE
Fix PROD deployment for Fly

### DIFF
--- a/.github/workflows/fly-prod-release.yml
+++ b/.github/workflows/fly-prod-release.yml
@@ -7,6 +7,7 @@ name: Fly Prod release
 on:
   release:
     types: [published]
+  workflow_dispatch:
 
 jobs:
   deploy:
@@ -16,6 +17,6 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - uses: superfly/flyctl-actions/setup-flyctl@master
-      - run: flyctl deploy --remote-only -c fly.production.toml
+      - run: flyctl deploy --remote-only -c fly.production.toml --build-arg CI_COMMIT_SHA=`git rev-parse HEAD`
         env:
-          FLY_API_TOKEN: ${{ secrets.FLY_API_TOKEN }}
+          FLY_API_TOKEN: ${{ secrets.FLY_PROD_API_TOKEN }}


### PR DESCRIPTION
* Adds a prod-enabled API Token
* Start showing the git commit on PROD
    * decided to enable this because we do show the version number, which would be easily tied back to this repo and a small enough set of commits that attackers would be able to find vulnerable versions of libraries anyway. Git commit SHA gives us extra information that wouldn't be easily available to attackers.
* Lets us manually deploy