### PR TITLE
Add Observability headers

### DIFF
--- a/docs/rest_guide.md
+++ b/docs/rest_guide.md
@@ -4,6 +4,18 @@ While most of Suffolk's work is on [docassemble](docassemble.org) and integrates
 
 Note that all of these endpoints start with `/jurisdictions/{jurisdiction_id}`, in order to handle the different jurisdictions like Massachusetts or Illinois. These will be replaced with `...` to focus on the unique parts of the endpoints.
 
+## Headers for all calls
+
+There are several headers that you will need to pass on all or most of your calls to the proxy server.
+Note that all HTTP headers are case insensitive, i.e. `X-API-KEY`, `X-Api-Key`, and `x-api-key` are equivalent.
+
+* `X-API-KEY`: the API Key to the proxy server. This will be given to you by the server admin.
+* `TYLER-TOKEN-{jurisdiction}`: Once you have authenticated an user with the `/authenticate` endpoint, you'll recieve back this key-value pair in the JSON response. It should be put in the Headers as you receive it in order to complete other actions as that user, such as administrative tasks, case searches, and making filings into cases.
+    * For example: `TYLER-TOKEN-ILLINOIS: bwilley@suffolk.edu:eb5cf7fd-...` (with a full UUID)
+* `efsp-session-id` (optional): a UUID that gets included in all log messages. Intended to be the same UUID for an entire user "session" on the client's side (e.g. a whole docassemble interview).
+* `efsp-correlation-id` (optional): a UUID that gets included in all log messages. Intended to be the same UUID for all calls needed to generate a specific page, i.e. what the client would consider as a single operation.
+* `efsp-request-id` (optional): a UUID that gets included in all log messages. Should be different for each call (if not included, on will be generated for you).
+
 ## Account creation and login
 
 TODO

--- a/proxyserver/src/main/java/edu/suffolk/litlab/efsp/server/EfspServer.java
+++ b/proxyserver/src/main/java/edu/suffolk/litlab/efsp/server/EfspServer.java
@@ -24,6 +24,7 @@ import edu.suffolk.litlab.efsp.server.setup.jeffnet.JeffNetModuleSetup;
 import edu.suffolk.litlab.efsp.server.setup.tyler.TylerModuleSetup;
 import edu.suffolk.litlab.efsp.server.utils.HttpsCallbackHandler;
 import edu.suffolk.litlab.efsp.server.utils.JsonExceptionMapper;
+import edu.suffolk.litlab.efsp.server.utils.ObservabilityHeadersInterceptor;
 import edu.suffolk.litlab.efsp.server.utils.OrgMessageSender;
 import edu.suffolk.litlab.efsp.server.utils.SendMessage;
 import edu.suffolk.litlab.efsp.server.utils.ServiceHelpers;
@@ -143,6 +144,7 @@ public class EfspServer {
     sf.setProviders(providers());
 
     sf.setAddress(ServiceHelpers.BASE_LOCAL_URL);
+    sf.getInInterceptors().add(new ObservabilityHeadersInterceptor());
     server = sf.create();
   }
 

--- a/proxyserver/src/main/java/edu/suffolk/litlab/efsp/server/utils/MDCWrappers.java
+++ b/proxyserver/src/main/java/edu/suffolk/litlab/efsp/server/utils/MDCWrappers.java
@@ -9,11 +9,17 @@ import org.slf4j.MDC;
 public class MDCWrappers {
   public static final String SERVER_ID = "serverId";
   public static final String USER_ID = "userId";
+  public static final String SESSION_ID = "sessionId";
+  public static final String CORRELATION_ID = "correlationId";
+  public static final String REQUEST_ID = "requestId";
   public static final String OPERATION = "operation";
 
   public static void removeAllMDCs() {
     MDC.remove(SERVER_ID);
     MDC.remove(USER_ID);
+    MDC.remove(SESSION_ID);
+    MDC.remove(CORRELATION_ID);
+    MDC.remove(REQUEST_ID);
     MDC.remove(OPERATION);
   }
 }

--- a/proxyserver/src/main/java/edu/suffolk/litlab/efsp/server/utils/ObservabilityHeadersInterceptor.java
+++ b/proxyserver/src/main/java/edu/suffolk/litlab/efsp/server/utils/ObservabilityHeadersInterceptor.java
@@ -1,0 +1,67 @@
+package edu.suffolk.litlab.efsp.server.utils;
+
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
+import java.util.regex.Pattern;
+import org.apache.cxf.interceptor.AbstractInDatabindingInterceptor;
+import org.apache.cxf.interceptor.Fault;
+import org.apache.cxf.message.Message;
+import org.apache.cxf.phase.Phase;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.slf4j.MDC;
+
+public class ObservabilityHeadersInterceptor extends AbstractInDatabindingInterceptor {
+  private static final Logger log = LoggerFactory.getLogger(ObservabilityHeadersInterceptor.class);
+
+  private static final String SESSION_ID = "efsp-session-id";
+  private static final String CORRELATION_ID = "efsp-correlation-id";
+  private static final String REQUEST_ID = "efsp-request-id";
+
+  public ObservabilityHeadersInterceptor() {
+    super(Phase.UNMARSHAL);
+  }
+
+  @Override
+  public void handleMessage(Message message) throws Fault {
+    var headers = (Map<String, List<String>>) message.get(Message.PROTOCOL_HEADERS);
+    try {
+      String sessionId = handleHeaderString(headers, SESSION_ID);
+      if (sessionId != null) {
+        MDC.put(MDCWrappers.SESSION_ID, sessionId);
+      }
+      String correlationId = handleHeaderString(headers, CORRELATION_ID);
+      if (correlationId != null) {
+        MDC.put(MDCWrappers.CORRELATION_ID, correlationId);
+      }
+      String requestId = handleHeaderString(headers, REQUEST_ID);
+      if (requestId == null) {
+        requestId = UUID.randomUUID().toString();
+        log.info("Using generated string `{}` as requestId", requestId);
+      }
+      MDC.put(MDCWrappers.REQUEST_ID, requestId);
+    } catch (IllegalArgumentException ex) {
+      log.error("IllegalArgumentException when setting MDC from headers", ex);
+    }
+  }
+
+  private static final Pattern safeRegex = Pattern.compile("^[A-Za-z0-9\\-]{0,36}$");
+
+  private String handleHeaderString(Map<String, List<String>> headers, String headerKey) {
+    var headerList = headers.get(headerKey);
+    if (headerList == null || headerList.isEmpty()) {
+      return null;
+    }
+    String val = headerList.getFirst();
+    if (!safeRegex.matcher(val).matches()) {
+      log.warn(
+          "Not adding the {} header to MDC, as it's not safe (numbers, letters, dashes only)",
+          headerKey);
+      // We only want to put safe strings into our logs; this one doesn't look safe.
+      return null;
+    }
+    log.info("Read in `{}` from the {} header, will use in MDC", val, headerKey);
+    return val;
+  }
+}

--- a/proxyserver/src/main/resources/logback.xml
+++ b/proxyserver/src/main/resources/logback.xml
@@ -2,19 +2,19 @@
 
   <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
     <encoder>
-      <pattern>%d{yyyy-MM-dd HH:mm:ss.SSS} [%X{serverId}] [%X{userId}] [%X{operation}] [%thread] %-5level %logger{50} - %msg %rEx%n</pattern>
+      <pattern>%d{yyyy-MM-dd HH:mm:ss.SSS} [server=%X{serverId}] [user=%X{userId}] [session=%X{sessionId}] [corr=%X{correlationId}] [req=%X{requestId}] [op=%X{operation}] %-5level %logger{40} - %msg %rEx%n</pattern>
     </encoder>
   </appender>
   <appender name="PerServer" class="edu.suffolk.litlab.efsp.server.logging.ServerSpecificAppender">
     <encoder>
-      <Pattern>| %d{yyyy-MM-dd HH:mm:ss.SSS} | %X{serverId} | %X{userId} | %X{operation} | %thread | %-5level | %logger{50} |- %msg | %rEx |%n</Pattern>
+      <Pattern>| %d{yyyy-MM-dd HH:mm:ss.SSS} | %X{serverId} | %X{userId} | %X{sessionId} | %X{correlationId} | %X{requestId} | %X{operation} | %thread | %-5level | %logger{40} |- %msg | %rEx |%n</Pattern>
     </encoder>
   </appender>
   <if condition='isDefined("PAPERTRAIL_HOST")'>
     <then>
       <appender name="SYSLOG-TLS" class="com.papertrailapp.logback.Syslog4jAppender">
         <layout class="ch.qos.logback.classic.PatternLayout">
-          <pattern>[%X{serverId}] [%X{userId}] [%X{operation}] %-5level %logger{35}: %m%n%rEx</pattern>
+          <pattern>[server=%X{serverId}] [user=%X{userId}] [session=%X{sessionId}] [corr=%X{correlationId}] [req=%X{requestId}] [op=%X{operation}] %-5level %logger{35}: %m%n%rEx</pattern>
         </layout>
 
         <syslogConfig class="org.productivity.java.syslog4j.impl.net.tcp.ssl.SSLTCPNetSyslogConfig">

--- a/proxyserver/src/test/java/edu/suffolk/litlab/efsp/server/utils/ObservabilityHeadersInterceptorTest.java
+++ b/proxyserver/src/test/java/edu/suffolk/litlab/efsp/server/utils/ObservabilityHeadersInterceptorTest.java
@@ -1,0 +1,35 @@
+package edu.suffolk.litlab.efsp.server.utils;
+
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import java.util.List;
+import java.util.Map;
+import net.jqwik.api.ForAll;
+import net.jqwik.api.Property;
+import org.apache.cxf.message.Message;
+import org.slf4j.MDC;
+
+public class ObservabilityHeadersInterceptorTest {
+
+  ObservabilityHeadersInterceptor interceptor = new ObservabilityHeadersInterceptor();
+
+  @Property
+  boolean interceptorHandlesAllHeaders(
+      @ForAll String sessionId, @ForAll String corrId, @ForAll String reqId) {
+    Message m = mock(Message.class);
+    when(m.get(Message.PROTOCOL_HEADERS))
+        .thenReturn(
+            Map.of(
+                "efsp-session-id",
+                List.of(sessionId),
+                "efsp-correlation-id",
+                List.of(corrId),
+                "efsp-request-id",
+                List.of(reqId)));
+    interceptor.handleMessage(m);
+
+    // Request should always be present, but as long as we don't crash we're good.
+    return MDC.get(MDCWrappers.REQUEST_ID) != null;
+  }
+}


### PR DESCRIPTION
Adds existing observability points (server ID, user token hash, and operation) to fly/papertrail logs, as well as adding 3 new headers (`efsp-session-id`, `efsp-correlation-id`, `efsp-request-id`) that will be added to logs as well. This will make it easier to troubleshoot and respond to bugs and issues with the stage and prod servers.

Tests that we can handle pretty much any string, and that only limited length strings (ideally UUIDs) will be added to the logs.

Also should be a template of how we can have code that acts on every endpoint. At somepoint, will have to refactor API keys and auth to go through those systems as well.