### PR TITLE
Stop passsing around DataSources, use Suppliers

### DIFF
--- a/proxyserver/src/main/java/edu/suffolk/litlab/efsp/db/LoginDatabase.java
+++ b/proxyserver/src/main/java/edu/suffolk/litlab/efsp/db/LoginDatabase.java
@@ -64,11 +64,9 @@ public class LoginDatabase extends Database {
 
   public static LoginDatabase fromDS(DataSource ds) {
     try {
-      LoginDatabase cd = new LoginDatabase(ds.getConnection());
-      return cd;
+      return new LoginDatabase(ds.getConnection());
     } catch (SQLException ex) {
-      log.error(
-          "In LoginDatabase constructor, can't get connection: " + StdLib.strFromException(ex));
+      log.error("In LoginDatabase constructor, can't get connection: ", ex);
       throw new RuntimeException(ex);
     }
   }

--- a/proxyserver/src/main/java/edu/suffolk/litlab/efsp/db/MessageSettingsDatabase.java
+++ b/proxyserver/src/main/java/edu/suffolk/litlab/efsp/db/MessageSettingsDatabase.java
@@ -9,6 +9,7 @@ import java.sql.SQLException;
 import java.sql.Statement;
 import java.util.Optional;
 import java.util.UUID;
+import javax.sql.DataSource;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -17,6 +18,15 @@ public class MessageSettingsDatabase extends Database {
 
   public MessageSettingsDatabase(Connection conn) {
     super(conn);
+  }
+
+  public static MessageSettingsDatabase fromDS(DataSource ds) {
+    try {
+      return new MessageSettingsDatabase(ds.getConnection());
+    } catch (SQLException ex) {
+      log.error("In MessageSettingsDatabase constructor, can't get connection: ", ex);
+      throw new RuntimeException(ex);
+    }
   }
 
   @Override

--- a/proxyserver/src/main/java/edu/suffolk/litlab/efsp/db/UserDatabase.java
+++ b/proxyserver/src/main/java/edu/suffolk/litlab/efsp/db/UserDatabase.java
@@ -11,6 +11,7 @@ import java.sql.Timestamp;
 import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
+import javax.sql.DataSource;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -27,6 +28,15 @@ public class UserDatabase extends Database {
 
   public UserDatabase(Connection conn) {
     super(conn);
+  }
+
+  public static UserDatabase fromDS(DataSource ds) {
+    try {
+      return new UserDatabase(ds.getConnection());
+    } catch (SQLException ex) {
+      log.error("In UserDatabase constructor, can't get connection", ex);
+      throw new RuntimeException(ex);
+    }
   }
 
   /** Creates the userdatabase table if it doesn't exist yet. */

--- a/proxyserver/src/main/java/edu/suffolk/litlab/efsp/server/services/ApiUserSettingsService.java
+++ b/proxyserver/src/main/java/edu/suffolk/litlab/efsp/server/services/ApiUserSettingsService.java
@@ -16,15 +16,15 @@ import java.io.File;
 import java.sql.SQLException;
 import java.util.List;
 import java.util.Optional;
-import javax.sql.DataSource;
+import java.util.function.Supplier;
 
 @Path("/api_user_settings")
 @Produces({MediaType.APPLICATION_JSON})
 public class ApiUserSettingsService {
-  private final DataSource ds;
+  private final Supplier<LoginDatabase> ldSupplier;
 
-  public ApiUserSettingsService(DataSource ds) {
-    this.ds = ds;
+  public ApiUserSettingsService(Supplier<LoginDatabase> ldSupplier) {
+    this.ldSupplier = ldSupplier;
   }
 
   @GET
@@ -39,7 +39,7 @@ public class ApiUserSettingsService {
   @GET
   @Path("/name")
   public Response getName(@Context HttpHeaders httpHeaders) {
-    try (LoginDatabase ld = new LoginDatabase(ds.getConnection())) {
+    try (LoginDatabase ld = ldSupplier.get()) {
       Optional<AtRest> atRest = ld.getAtRestInfo(httpHeaders.getHeaderString("X-API-KEY"));
       if (atRest.isEmpty()) {
         return Response.status(401).entity("\"Not logged in to efile\"").build();
@@ -55,7 +55,7 @@ public class ApiUserSettingsService {
   @GET
   @Path("/serverid")
   public Response getServerId(@Context HttpHeaders httpHeaders) {
-    try (LoginDatabase ld = new LoginDatabase(ds.getConnection())) {
+    try (LoginDatabase ld = ldSupplier.get()) {
       Optional<AtRest> atRest = ld.getAtRestInfo(httpHeaders.getHeaderString("X-API-KEY"));
       if (atRest.isEmpty()) {
         return Response.status(401).entity("\"Not logged in to efile\"").build();
@@ -72,7 +72,7 @@ public class ApiUserSettingsService {
   @Path("/name")
   public Response changeName(@Context HttpHeaders httpHeaders, String newName) {
     String apiKey = httpHeaders.getHeaderString("X-API-KEY");
-    try (LoginDatabase ld = new LoginDatabase(ds.getConnection())) {
+    try (LoginDatabase ld = ldSupplier.get()) {
       Optional<AtRest> atRest = ld.getAtRestInfo(apiKey);
       if (atRest.isEmpty()) {
         return Response.status(401).entity("\"Not logged in to efile\"").build();
@@ -90,7 +90,7 @@ public class ApiUserSettingsService {
   @Produces(MediaType.APPLICATION_OCTET_STREAM)
   @Path("/logs")
   public Response getLogs(@Context HttpHeaders httpHeaders) {
-    try (LoginDatabase ld = new LoginDatabase(ds.getConnection())) {
+    try (LoginDatabase ld = ldSupplier.get()) {
       Optional<AtRest> atRest = ld.getAtRestInfo(httpHeaders.getHeaderString("X-API-KEY"));
       if (atRest.isEmpty()) {
         return Response.status(401).entity("\"Not logged in to efile\"").build();

--- a/proxyserver/src/main/java/edu/suffolk/litlab/efsp/server/setup/jeffnet/JeffNetModuleSetup.java
+++ b/proxyserver/src/main/java/edu/suffolk/litlab/efsp/server/setup/jeffnet/JeffNetModuleSetup.java
@@ -1,6 +1,8 @@
 package edu.suffolk.litlab.efsp.server.setup.jeffnet;
 
 import com.opencsv.exceptions.CsvValidationException;
+import edu.suffolk.litlab.efsp.db.LoginDatabase;
+import edu.suffolk.litlab.efsp.db.UserDatabase;
 import edu.suffolk.litlab.efsp.server.EfspServer;
 import edu.suffolk.litlab.efsp.server.services.CourtsOnlyCodesService;
 import edu.suffolk.litlab.efsp.server.services.FilingReviewService;
@@ -20,6 +22,7 @@ import java.util.HashMap;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
+import java.util.function.Supplier;
 import javax.sql.DataSource;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -95,9 +98,18 @@ public class JeffNetModuleSetup implements EfmModuleSetup {
       getCallback().ifPresent(call -> callbackMap.put(court, call));
     }
 
+    Supplier<LoginDatabase> ldSupplier = () -> LoginDatabase.fromDS(this.userDs);
+    Supplier<UserDatabase> udSupplier = () -> UserDatabase.fromDS(this.userDs);
+
     var filingReview =
         new FilingReviewService(
-            getJurisdiction(), this.userDs, converterMap, filingMap, callbackMap, this.sender);
+            getJurisdiction(),
+            ldSupplier,
+            udSupplier,
+            converterMap,
+            filingMap,
+            callbackMap,
+            this.sender);
     var codes =
         new CourtsOnlyCodesService(getJurisdiction(), Map.of("jefferson", "Jefferson Parish"));
     return new JurisdictionServiceHandle(getJurisdiction(), filingReview, codes);

--- a/proxyserver/src/main/java/edu/suffolk/litlab/efsp/server/utils/ServiceHelpers.java
+++ b/proxyserver/src/main/java/edu/suffolk/litlab/efsp/server/utils/ServiceHelpers.java
@@ -17,8 +17,8 @@ import java.sql.SQLException;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+import java.util.function.Supplier;
 import java.util.stream.Collectors;
-import javax.sql.DataSource;
 import org.apache.cxf.headers.Header;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -148,19 +148,22 @@ public class ServiceHelpers {
   }
 
   public static Optional<TylerFirmClient> setupFirmPort(
-      EfmFirmService firmFactory, HttpHeaders httpHeaders, DataSource userDs, String jurisdiction) {
-    return setupFirmPort(firmFactory, httpHeaders, userDs, true, jurisdiction);
+      EfmFirmService firmFactory,
+      HttpHeaders httpHeaders,
+      Supplier<LoginDatabase> ldSupplier,
+      String jurisdiction) {
+    return setupFirmPort(firmFactory, httpHeaders, ldSupplier, true, jurisdiction);
   }
 
   // TODO(bryce): should this take not a firm service but a normal port?
   public static Optional<TylerFirmClient> setupFirmPort(
       EfmFirmService firmFactory,
       HttpHeaders httpHeaders,
-      DataSource userDs,
+      Supplier<LoginDatabase> ldSupplier,
       boolean needsSoapHeader,
       String jurisdiction) {
     String activeToken = httpHeaders.getHeaderString("X-API-KEY");
-    try (LoginDatabase ld = new LoginDatabase(userDs.getConnection())) {
+    try (LoginDatabase ld = ldSupplier.get()) {
       Optional<AtRest> atRest = ld.getAtRestInfo(activeToken);
       if (atRest.isEmpty()) {
         log.warn("Couldn't find server api key");


### PR DESCRIPTION
i.e. Supplier<LoginDatabase>, Supplier<UserDatabase>, etc.

Previously, we were passing around the direct `DataSource` object, which is an argument for the Database object (`LoginDatabase`, `UserDatabase`) constructors. Works okay, but not easy to mock or handle what behaviors we really want from the Database objects.

By using suppliers for the actual database objects, it's easier to mock, and has a lower surface area for what methods a class can use on db anyway (so, ideally less likely to make a mistake in future refactors).

1 of 2 pre-req PRs needed for improving service testing a lot. 2nd one will add actual factories to how we connect to Tyler. Also this is a change that we needed to make to get Ecf5 working smoothly: I'm trying to merge all of the Ecf5 bits that we can ASAP to make the actual migration easier when it happens.