### PR TITLE
Notify Filing Review Complete Logs are too big

### DIFF
--- a/proxyserver/src/main/java/edu/suffolk/litlab/efsp/server/setup/tyler/OasisEcfWsCallback.java
+++ b/proxyserver/src/main/java/edu/suffolk/litlab/efsp/server/setup/tyler/OasisEcfWsCallback.java
@@ -20,7 +20,6 @@ import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
 import java.util.function.Supplier;
-import javax.sql.DataSource;
 import oasis.names.specification.ubl.schema.xsd.commonaggregatecomponents_2.AllowanceChargeType;
 import oasis.names.specification.ubl.schema.xsd.commonaggregatecomponents_2.CardAccountType;
 import oasis.names.tc.legalxml_courtfiling.schema.xsd.commontypes_4.DocumentRenditionType;
@@ -56,18 +55,16 @@ public class OasisEcfWsCallback implements FilingAssemblyMDEPort {
 
   private final ObjectFactory recepitFac;
   private final Supplier<CodeDatabase> cdSupplier;
-  private final DataSource userDs;
+  private final Supplier<UserDatabase> udSupplier;
   private final OrgMessageSender msgSender;
 
   public OasisEcfWsCallback(
-      String jurisdiction,
-      String env,
       Supplier<CodeDatabase> cdSupplier,
-      DataSource userDs,
+      Supplier<UserDatabase> udSupplier,
       OrgMessageSender msgSender) {
     this.recepitFac = new ObjectFactory();
     this.cdSupplier = cdSupplier;
-    this.userDs = userDs;
+    this.udSupplier = udSupplier;
     this.msgSender = msgSender;
   }
 
@@ -294,7 +291,7 @@ public class OasisEcfWsCallback implements FilingAssemblyMDEPort {
       }
     }
     Optional<Transaction> trans = Optional.empty();
-    try (UserDatabase ud = new UserDatabase(userDs.getConnection())) {
+    try (UserDatabase ud = udSupplier.get()) {
       trans = ud.findTransaction(UUID.fromString(filingId));
     } catch (SQLException e) {
       log.error("Couldn't connect to the SQL database to get the transaction: " + e.toString());

--- a/proxyserver/src/main/java/edu/suffolk/litlab/efsp/server/setup/tyler/OasisEcfWsCallback.java
+++ b/proxyserver/src/main/java/edu/suffolk/litlab/efsp/server/setup/tyler/OasisEcfWsCallback.java
@@ -69,6 +69,9 @@ public class OasisEcfWsCallback implements FilingAssemblyMDEPort {
   }
 
   private static String chargeToStr(AllowanceChargeType charge) {
+    if (charge == null) {
+      return "";
+    }
     StringBuilder chargeReason = new StringBuilder();
     String amountText = Ecf4Helper.amountToString(charge.getAmount());
     chargeReason.append(amountText);
@@ -78,6 +81,9 @@ public class OasisEcfWsCallback implements FilingAssemblyMDEPort {
     charge.getPaymentMeans().stream()
         .forEach(
             m -> {
+              if (m == null) {
+                return;
+              }
               CardAccountType acct = m.getCardAccount();
               if (acct != null) {
                 String cardInfo = "";

--- a/proxyserver/src/main/java/edu/suffolk/litlab/efsp/server/setup/tyler/OasisEcfv5WsCallback.java
+++ b/proxyserver/src/main/java/edu/suffolk/litlab/efsp/server/setup/tyler/OasisEcfv5WsCallback.java
@@ -36,7 +36,6 @@ import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
 import java.util.function.Supplier;
-
 import oasis.names.specification.ubl.schema.xsd.commonaggregatecomponents_2.AllowanceChargeType;
 import oasis.names.specification.ubl.schema.xsd.commonaggregatecomponents_2.CardAccountType;
 import org.slf4j.Logger;

--- a/proxyserver/src/main/java/edu/suffolk/litlab/efsp/server/setup/tyler/OasisEcfv5WsCallback.java
+++ b/proxyserver/src/main/java/edu/suffolk/litlab/efsp/server/setup/tyler/OasisEcfv5WsCallback.java
@@ -35,7 +35,8 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
-import javax.sql.DataSource;
+import java.util.function.Supplier;
+
 import oasis.names.specification.ubl.schema.xsd.commonaggregatecomponents_2.AllowanceChargeType;
 import oasis.names.specification.ubl.schema.xsd.commonaggregatecomponents_2.CardAccountType;
 import org.slf4j.Logger;
@@ -53,22 +54,16 @@ import org.slf4j.LoggerFactory;
 public class OasisEcfv5WsCallback implements FilingAssemblyMDE {
   private static Logger log = LoggerFactory.getLogger(Ecf4Filer.class);
 
-  private final DataSource codeDs;
-  private final DataSource userDs;
+  private final Supplier<CodeDatabase> cdSupplier;
+  private final Supplier<UserDatabase> udSupplier;
   private final OrgMessageSender msgSender;
-  private final String jurisdiction;
-  private final String env;
 
   public OasisEcfv5WsCallback(
-      String jurisdiction,
-      String env,
-      DataSource codeDs,
-      DataSource userDs,
+      Supplier<CodeDatabase> cdSupplier,
+      Supplier<UserDatabase> udSupplier,
       OrgMessageSender msgSender) {
-    this.jurisdiction = jurisdiction;
-    this.env = env;
-    this.codeDs = codeDs;
-    this.userDs = userDs;
+    this.cdSupplier = cdSupplier;
+    this.udSupplier = udSupplier;
     this.msgSender = msgSender;
   }
 
@@ -167,7 +162,7 @@ public class OasisEcfv5WsCallback implements FilingAssemblyMDE {
   private String reviewedFilingStatusText(
       NotifyFilingReviewCompleteMessageType revFiling, Transaction trans) {
     List<NameAndCode> names = List.of();
-    try (CodeDatabase cd = new CodeDatabase(jurisdiction, env, codeDs.getConnection())) {
+    try (CodeDatabase cd = cdSupplier.get()) {
       names = cd.getFilingStatuses(trans.courtId);
     } catch (SQLException ex) {
       log.error("In ECF v4 callback, couldn't get codes db: " + StdLib.strFromException(ex));
@@ -265,7 +260,7 @@ public class OasisEcfv5WsCallback implements FilingAssemblyMDE {
               "Filing code not found in message"));
       return reply;
     }
-    try (UserDatabase ud = new UserDatabase(userDs.getConnection())) {
+    try (UserDatabase ud = udSupplier.get()) {
       Optional<Transaction> trans = ud.findTransaction(UUID.fromString(filingId));
       if (trans.isEmpty()) {
         log.warn("No transaction on record for filingId: " + filingId + " no one to send to");
@@ -281,7 +276,7 @@ public class OasisEcfv5WsCallback implements FilingAssemblyMDE {
       UpdateMessageStatus status = reviewedFilingStatusCode(revFiling);
       String courtName =
           trans.get().courtId.substring(0, 1).toUpperCase() + trans.get().courtId.substring(1);
-      try (CodeDatabase cd = new CodeDatabase(jurisdiction, env, codeDs.getConnection())) {
+      try (CodeDatabase cd = cdSupplier.get()) {
         courtName =
             cd.getFullLocationInfo(trans.get().courtId).map(li -> li.name).orElse(courtName);
       } catch (SQLException ex) {

--- a/proxyserver/src/main/java/edu/suffolk/litlab/efsp/server/setup/tyler/TylerModuleSetup.java
+++ b/proxyserver/src/main/java/edu/suffolk/litlab/efsp/server/setup/tyler/TylerModuleSetup.java
@@ -361,13 +361,9 @@ public class TylerModuleSetup implements EfmModuleSetup {
 
   @Override
   public void setupGlobals() {
-    Supplier<CodeDatabase> cdSupplier =
-        () -> {
-          return CodeDatabase.fromDS(getJurisdiction(), this.tylerEnv, this.codeDs);
-        };
-
-    OasisEcfWsCallback implementor =
-        new OasisEcfWsCallback(tylerJurisdiction, tylerEnv, cdSupplier, userDs, sender);
+    Supplier<CodeDatabase> makeCD = () -> CodeDatabase.fromDS(tylerJurisdiction, tylerEnv, codeDs);
+    Supplier<UserDatabase> makeUD = () -> UserDatabase.fromDS(userDs);
+    OasisEcfWsCallback implementor = new OasisEcfWsCallback(makeCD, makeUD, sender);
     String baseLocalUrl = ServiceHelpers.BASE_LOCAL_URL;
     String address =
         baseLocalUrl + "/jurisdictions/" + tylerJurisdiction + ServiceHelpers.ASSEMBLY_PORT;
@@ -378,8 +374,7 @@ public class TylerModuleSetup implements EfmModuleSetup {
     log.info("Address : " + jaxWsEndpoint.getAddress());
     log.info("Bean name: " + jaxWsEndpoint.getBeanName());
 
-    OasisEcfv5WsCallback impl2 =
-        new OasisEcfv5WsCallback(tylerJurisdiction, tylerEnv, codeDs, userDs, sender);
+    OasisEcfv5WsCallback impl2 = new OasisEcfv5WsCallback(makeCD, makeUD, sender);
     String v5Address =
         baseLocalUrl + "/jurisdictions/" + tylerJurisdiction + ServiceHelpers.ASSEMBLY_PORT_V5;
     EndpointImpl jaxWsV5Endpoint = (EndpointImpl) jakarta.xml.ws.Endpoint.publish(v5Address, impl2);

--- a/proxyserver/src/test/java/edu/suffolk/litlab/efsp/server/ecf4/EcfCaseTypeFactoryTest.java
+++ b/proxyserver/src/test/java/edu/suffolk/litlab/efsp/server/ecf4/EcfCaseTypeFactoryTest.java
@@ -1,4 +1,4 @@
-package edu.suffolk.litlab.efsp.server.ecf;
+package edu.suffolk.litlab.efsp.server.ecf4;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -15,8 +15,6 @@ import edu.suffolk.litlab.efsp.ecfcodes.tyler.DataFieldRow;
 import edu.suffolk.litlab.efsp.model.FilingInformation;
 import edu.suffolk.litlab.efsp.model.PartyId;
 import edu.suffolk.litlab.efsp.model.Person;
-import edu.suffolk.litlab.efsp.server.ecf4.Ecf4Helper;
-import edu.suffolk.litlab.efsp.server.ecf4.EcfCaseTypeFactory;
 import edu.suffolk.litlab.efsp.utils.FailFastCollector;
 import edu.suffolk.litlab.efsp.utils.FilingError;
 import edu.suffolk.litlab.efsp.utils.InfoCollector;

--- a/proxyserver/src/test/java/edu/suffolk/litlab/efsp/server/ecf4/EcfCourtSpecificSerializerTest.java
+++ b/proxyserver/src/test/java/edu/suffolk/litlab/efsp/server/ecf4/EcfCourtSpecificSerializerTest.java
@@ -1,4 +1,4 @@
-package edu.suffolk.litlab.efsp.server.ecf;
+package edu.suffolk.litlab.efsp.server.ecf4;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -21,8 +21,6 @@ import edu.suffolk.litlab.efsp.ecfcodes.tyler.PartyType;
 import edu.suffolk.litlab.efsp.model.ContactInformation;
 import edu.suffolk.litlab.efsp.model.Name;
 import edu.suffolk.litlab.efsp.model.Person;
-import edu.suffolk.litlab.efsp.server.ecf4.Ecf4Helper;
-import edu.suffolk.litlab.efsp.server.ecf4.EcfCourtSpecificSerializer;
 import edu.suffolk.litlab.efsp.utils.FailFastCollector;
 import edu.suffolk.litlab.efsp.utils.FilingError;
 import edu.suffolk.litlab.efsp.utils.InfoCollector;

--- a/proxyserver/src/test/java/edu/suffolk/litlab/efsp/server/ecf4/ReviewedFilingExamples.java
+++ b/proxyserver/src/test/java/edu/suffolk/litlab/efsp/server/ecf4/ReviewedFilingExamples.java
@@ -4,6 +4,7 @@ import gov.niem.niem.niem_core._2.BinaryType;
 import java.time.LocalDate;
 import java.util.GregorianCalendar;
 import java.util.List;
+import java.util.function.Supplier;
 import javax.xml.datatype.DatatypeFactory;
 import javax.xml.datatype.XMLGregorianCalendar;
 import net.jqwik.api.Arbitraries;
@@ -25,23 +26,22 @@ public class ReviewedFilingExamples extends DomainContextBase {
           .ObjectFactory
       commonOf =
           new oasis.names.specification.ubl.schema.xsd.commonbasiccomponents_2.ObjectFactory();
+
   private static final DatatypeFactory dateFactory = DatatypeFactory.newDefaultInstance();
+
+  static final Supplier<Arbitrary<String>> strs = () -> Arbitraries.strings().injectNull(0.2);
 
   @Provide
   public Arbitrary<ReviewedDocumentType> docs() {
-    return Combinators.combine(
-            Arbitraries.strings().injectNull(0.2),
-            Arbitraries.strings().injectNull(0.2),
-            Arbitraries.strings().injectNull(0.2),
-            Arbitraries.strings().injectNull(0.2))
+    return Combinators.combine(strs.get(), strs.get(), strs.get(), strs.get())
         .as(
-            (a, b, c, d) -> {
+            (str1, str2, str3, str4) -> {
               var doc = new ReviewedDocumentType();
-              doc.setDocumentDescriptionText(Ecf4Helper.convertText(a));
+              doc.setDocumentDescriptionText(Ecf4Helper.convertText(str1));
               doc.setDocumentBinary(new BinaryType());
-              doc.getDocumentBinary().setBinaryDescriptionText(Ecf4Helper.convertText(b));
-              doc.setFilingReviewCommentsText(Ecf4Helper.convertText(c));
-              doc.setRejectReasonText(Ecf4Helper.convertText(d));
+              doc.getDocumentBinary().setBinaryDescriptionText(Ecf4Helper.convertText(str2));
+              doc.setFilingReviewCommentsText(Ecf4Helper.convertText(str3));
+              doc.setRejectReasonText(Ecf4Helper.convertText(str4));
 
               return doc;
             });
@@ -61,7 +61,7 @@ public class ReviewedFilingExamples extends DomainContextBase {
                   amount.setValue(value);
                   return amount;
                 });
-    Arbitrary<String> reasons = Arbitraries.strings().injectNull(0.1);
+    Arbitrary<String> reasons = strs.get();
     Arbitrary<List<PaymentMeansType>> means = paymentMeans().injectNull(0.2).list().ofMaxSize(3);
     return Builders.withBuilder(() -> new AllowanceChargeType())
         .use(amounts)
@@ -86,8 +86,8 @@ public class ReviewedFilingExamples extends DomainContextBase {
 
   @Provide
   public Arbitrary<PaymentMeansType> paymentMeans() {
-    Arbitrary<String> cardTypes = Arbitraries.strings();
-    Arbitrary<String> idTypes = Arbitraries.strings();
+    Arbitrary<String> cardTypes = strs.get();
+    Arbitrary<String> idTypes = strs.get();
     Arbitrary<XMLGregorianCalendar> dates = dates();
 
     return Builders.withBuilder(() -> new CardAccountType())

--- a/proxyserver/src/test/java/edu/suffolk/litlab/efsp/server/ecf4/ReviewedFilingExamples.java
+++ b/proxyserver/src/test/java/edu/suffolk/litlab/efsp/server/ecf4/ReviewedFilingExamples.java
@@ -1,0 +1,145 @@
+package edu.suffolk.litlab.efsp.server.ecf4;
+
+import gov.niem.niem.niem_core._2.BinaryType;
+import java.time.LocalDate;
+import java.util.GregorianCalendar;
+import java.util.List;
+import javax.xml.datatype.DatatypeFactory;
+import javax.xml.datatype.XMLGregorianCalendar;
+import net.jqwik.api.Arbitraries;
+import net.jqwik.api.Arbitrary;
+import net.jqwik.api.Builders;
+import net.jqwik.api.Combinators;
+import net.jqwik.api.Provide;
+import net.jqwik.api.domains.DomainContextBase;
+import oasis.names.specification.ubl.schema.xsd.commonaggregatecomponents_2.AllowanceChargeType;
+import oasis.names.specification.ubl.schema.xsd.commonaggregatecomponents_2.CardAccountType;
+import oasis.names.specification.ubl.schema.xsd.commonaggregatecomponents_2.PaymentMeansType;
+import oasis.names.specification.ubl.schema.xsd.commonbasiccomponents_2.AllowanceChargeReasonType;
+import oasis.names.specification.ubl.schema.xsd.commonbasiccomponents_2.AmountType;
+import tyler.ecf.extensions.common.ReviewedDocumentType;
+
+public class ReviewedFilingExamples extends DomainContextBase {
+
+  private static final oasis.names.specification.ubl.schema.xsd.commonbasiccomponents_2
+          .ObjectFactory
+      commonOf =
+          new oasis.names.specification.ubl.schema.xsd.commonbasiccomponents_2.ObjectFactory();
+  private static final DatatypeFactory dateFactory = DatatypeFactory.newDefaultInstance();
+
+  @Provide
+  public Arbitrary<ReviewedDocumentType> docs() {
+    return Combinators.combine(
+            Arbitraries.strings().injectNull(0.2),
+            Arbitraries.strings().injectNull(0.2),
+            Arbitraries.strings().injectNull(0.2),
+            Arbitraries.strings().injectNull(0.2))
+        .as(
+            (a, b, c, d) -> {
+              var doc = new ReviewedDocumentType();
+              doc.setDocumentDescriptionText(Ecf4Helper.convertText(a));
+              doc.setDocumentBinary(new BinaryType());
+              doc.getDocumentBinary().setBinaryDescriptionText(Ecf4Helper.convertText(b));
+              doc.setFilingReviewCommentsText(Ecf4Helper.convertText(c));
+              doc.setRejectReasonText(Ecf4Helper.convertText(d));
+
+              return doc;
+            });
+  }
+
+  @Provide
+  public Arbitrary<AllowanceChargeType> charges() {
+    Arbitrary<String> currencyIds =
+        Arbitraries.strings().withCharRange('A', 'Z').ofMinLength(2).ofMaxLength(3).injectNull(0.2);
+
+    Arbitrary<AmountType> amounts =
+        Combinators.combine(currencyIds, Arbitraries.bigDecimals())
+            .as(
+                (id, value) -> {
+                  var amount = new AmountType();
+                  amount.setCurrencyID(id);
+                  amount.setValue(value);
+                  return amount;
+                });
+    Arbitrary<String> reasons = Arbitraries.strings().injectNull(0.1);
+    Arbitrary<List<PaymentMeansType>> means = paymentMeans().injectNull(0.2).list().ofMaxSize(3);
+    return Builders.withBuilder(() -> new AllowanceChargeType())
+        .use(amounts)
+        .inSetter(AllowanceChargeType::setAmount)
+        .use(reasons)
+        .in(
+            (charge, r) -> {
+              var reasonType = new AllowanceChargeReasonType();
+              reasonType.setLanguageID("en");
+              reasonType.setValue(r);
+              charge.setAllowanceChargeReason(reasonType);
+              return charge;
+            })
+        .use(means)
+        .in(
+            (charge, meanList) -> {
+              charge.getPaymentMeans().addAll(meanList);
+              return charge;
+            })
+        .build();
+  }
+
+  @Provide
+  public Arbitrary<PaymentMeansType> paymentMeans() {
+    Arbitrary<String> cardTypes = Arbitraries.strings();
+    Arbitrary<String> idTypes = Arbitraries.strings();
+    Arbitrary<XMLGregorianCalendar> dates = dates();
+
+    return Builders.withBuilder(() -> new CardAccountType())
+        .use(cardTypes)
+        .in(
+            (acct, card) -> {
+              var code = commonOf.createCardTypeCodeType();
+              code.setValue(card);
+              acct.setCardTypeCode(code);
+              return acct;
+            })
+        .use(idTypes)
+        .in(
+            (acct, id) -> {
+              var number = commonOf.createPrimaryAccountNumberIDType();
+              number.setValue(id);
+              acct.setPrimaryAccountNumberID(number);
+              return acct;
+            })
+        .use(dates)
+        .withProbability(0.5)
+        .in(
+            (acct, date) -> {
+              var expiryDate = commonOf.createExpiryDateType();
+              expiryDate.setValue(date);
+              acct.setExpiryDate(expiryDate);
+              return acct;
+            })
+        .build()
+        .map(
+            acct -> {
+              var means = new PaymentMeansType();
+              means.setCardAccount(acct);
+              return means;
+            });
+  }
+
+  @Provide
+  private Arbitrary<XMLGregorianCalendar> dates() {
+    // most dates between 1970 and 2028
+    return Arbitraries.longs()
+        .lessOrEqual(740842)
+        .greaterOrEqual(-400_000)
+        .map(LocalDate::ofEpochDay)
+        .map(
+            date -> {
+              GregorianCalendar cal = new GregorianCalendar();
+              // TODO(#47): DEFAULT TIMEZONE IS WRONG: how should LocalDate +
+              // GregorianCalendar operate?
+              cal.set(date.getYear(), date.getMonthValue() - 1, date.getDayOfMonth(), 0, 0, 0);
+              XMLGregorianCalendar x = dateFactory.newXMLGregorianCalendar(cal);
+              return x;
+            });
+  }
+}

--- a/proxyserver/src/test/java/edu/suffolk/litlab/efsp/server/setup/tyler/OasisEcfWsCallbackTest.java
+++ b/proxyserver/src/test/java/edu/suffolk/litlab/efsp/server/setup/tyler/OasisEcfWsCallbackTest.java
@@ -1,0 +1,216 @@
+package edu.suffolk.litlab.efsp.server.setup.tyler;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.ArgumentMatchers.nullable;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
+import static org.mockito.Mockito.when;
+
+import edu.suffolk.litlab.efsp.db.UserDatabase;
+import edu.suffolk.litlab.efsp.db.model.Transaction;
+import edu.suffolk.litlab.efsp.ecfcodes.tyler.CodeDatabase;
+import edu.suffolk.litlab.efsp.ecfcodes.tyler.CourtLocationInfo;
+import edu.suffolk.litlab.efsp.server.ecf4.Ecf4Helper;
+import edu.suffolk.litlab.efsp.server.ecf4.ReviewedFilingExamples;
+import edu.suffolk.litlab.efsp.server.services.api.UpdateMessageStatus;
+import edu.suffolk.litlab.efsp.server.utils.OrgMessageSender;
+import gov.niem.niem.niem_core._2.IdentificationType;
+import java.sql.SQLException;
+import java.time.LocalDate;
+import java.util.Optional;
+import java.util.UUID;
+import net.jqwik.api.Example;
+import net.jqwik.api.ForAll;
+import net.jqwik.api.Group;
+import net.jqwik.api.Property;
+import net.jqwik.api.domains.Domain;
+import net.jqwik.api.lifecycle.BeforeProperty;
+import net.jqwik.api.lifecycle.BeforeTry;
+import oasis.names.specification.ubl.schema.xsd.commonaggregatecomponents_2.AllowanceChargeType;
+import oasis.names.tc.legalxml_courtfiling.schema.xsd.commontypes_4.FilingStatusType;
+import oasis.names.tc.legalxml_courtfiling.schema.xsd.paymentmessage_4.PaymentMessageType;
+import oasis.names.tc.legalxml_courtfiling.schema.xsd.reviewfilingcallbackmessage_4.ReviewFilingCallbackMessageType;
+import oasis.names.tc.legalxml_courtfiling.wsdl.webservicesprofile_definitions_4.NotifyFilingReviewCompleteRequestMessageType;
+import org.junit.jupiter.api.DisplayName;
+import tyler.ecf.extensions.common.ReviewedDocumentType;
+
+public class OasisEcfWsCallbackTest {
+
+  private static final gov.niem.niem.niem_core._2.ObjectFactory niemOf =
+      new gov.niem.niem.niem_core._2.ObjectFactory();
+  private static final oasis.names.tc.legalxml_courtfiling.schema.xsd.civilcase_4.ObjectFactory
+      civilOf = new oasis.names.tc.legalxml_courtfiling.schema.xsd.civilcase_4.ObjectFactory();
+  private static final oasis.names.tc.legalxml_courtfiling.schema.xsd.commontypes_4.ObjectFactory
+      commonOf = new oasis.names.tc.legalxml_courtfiling.schema.xsd.commontypes_4.ObjectFactory();
+
+  private OasisEcfWsCallback cb;
+  private CodeDatabase mockCd;
+  private UserDatabase mockUd;
+  private OrgMessageSender mockSender;
+
+  @BeforeProperty
+  public void setUp() {
+    mockCd = mock(CodeDatabase.class);
+    mockUd = mock(UserDatabase.class);
+  }
+
+  @Group
+  @DisplayName("`notifyFilingReviewComplete`")
+  class NotifyFilingReviewCompleteTest {
+
+    private final String filingId = "12345678-1234-1234-1234-12345678abcd";
+    private final String userEmail = "bob@example.com";
+    private final String docketNumber = "2022CR0001";
+    private final String repNumber = "1234567";
+    private final String caseTitle = "Brown vs Brown";
+
+    private String sentMsg;
+    private UpdateMessageStatus status;
+
+    @BeforeTry
+    public void setUp() throws SQLException {
+      mockSender = mock(OrgMessageSender.class);
+
+      cb = new OasisEcfWsCallback(() -> mockCd, () -> mockUd, mockSender);
+
+      var trans = new Transaction();
+      trans.name = "Bob Brown";
+      trans.phoneNumber = Optional.empty();
+      trans.email = userEmail;
+      trans.transactionId = UUID.fromString(filingId);
+      trans.courtId = "adams";
+      trans.caseTitle = caseTitle;
+      trans.serverId = UUID.randomUUID();
+      when(mockUd.findTransaction(eq(UUID.fromString(filingId)))).thenReturn(Optional.of(trans));
+
+      var courtInfo = new CourtLocationInfo();
+      courtInfo.code = "adams";
+      courtInfo.name = "Adams County";
+      when(mockCd.getFullLocationInfo(eq("adams"))).thenReturn(Optional.of(courtInfo));
+      when(mockSender.sendMessage(
+              any(),
+              any(),
+              nullable(String.class),
+              nullable(String.class),
+              nullable(String.class),
+              nullable(String.class),
+              nullable(String.class)))
+          .thenReturn(true);
+    }
+
+    @Example
+    public void testFailedShouldNotSendEmail() throws SQLException {
+      // Just make sure we don't throw exceptions
+      // cb.notifyFilingReviewComplete(null);
+      cb.notifyFilingReviewComplete(new NotifyFilingReviewCompleteRequestMessageType());
+
+      when(mockCd.getFullLocationInfo(eq("adams"))).thenReturn(Optional.empty());
+      cb.notifyFilingReviewComplete(makeMsg(null, null));
+
+      when(mockUd.findTransaction(eq(UUID.fromString(filingId)))).thenReturn(Optional.empty());
+      cb.notifyFilingReviewComplete(makeMsg(null, null));
+
+      verifyNoInteractions(mockSender);
+    }
+
+    @Example
+    public void testSuccessfulPlain() {
+
+      when(mockSender.sendMessage(
+              any(),
+              any(),
+              nullable(String.class),
+              nullable(String.class),
+              nullable(String.class),
+              nullable(String.class),
+              nullable(String.class)))
+          .thenAnswer(
+              (invoc) -> {
+                sentMsg = invoc.getArgument(3, String.class);
+                status = invoc.getArgument(1, UpdateMessageStatus.class);
+                return true;
+              });
+
+      cb.notifyFilingReviewComplete(makeMsg(null, null));
+
+      verify(mockSender)
+          .sendMessage(
+              any(),
+              any(),
+              nullable(String.class),
+              nullable(String.class),
+              nullable(String.class),
+              nullable(String.class),
+              nullable(String.class));
+
+      assertThat(sentMsg).isEqualTo("\nfiling has been accepted by the court");
+      assertThat(status).isEqualTo(UpdateMessageStatus.ACCEPTED);
+    }
+
+    @Property
+    @Domain(ReviewedFilingExamples.class)
+    public void testSuccessfulResponse(
+        @ForAll AllowanceChargeType charge, @ForAll ReviewedDocumentType doc) {
+      cb.notifyFilingReviewComplete(makeMsg(charge, doc));
+
+      verify(mockSender)
+          .sendMessage(
+              any(),
+              any(),
+              nullable(String.class),
+              nullable(String.class),
+              nullable(String.class),
+              nullable(String.class),
+              nullable(String.class));
+    }
+
+    // add a J case aug
+    // add filingdocs
+    // add charge
+    private NotifyFilingReviewCompleteRequestMessageType makeMsg(
+        AllowanceChargeType charge, ReviewedDocumentType doc) {
+      var msg = new NotifyFilingReviewCompleteRequestMessageType();
+      msg.setReviewFilingCallbackMessage(makeMsgType(doc));
+      var paymentMsg = new PaymentMessageType();
+      paymentMsg.getAllowanceCharge().add(charge);
+      msg.setPaymentReceiptMessage(paymentMsg);
+      return msg;
+    }
+
+    private ReviewFilingCallbackMessageType makeMsgType(ReviewedDocumentType doc) {
+      var msg = new ReviewFilingCallbackMessageType();
+      msg.setDocumentFiledDate(Ecf4Helper.convertDate(LocalDate.of(2025, 07, 04)));
+      var idType = new IdentificationType();
+      idType.setIdentificationID(Ecf4Helper.convertString(filingId));
+      idType.setIdentificationCategory(
+          niemOf.createIdentificationCategoryText(Ecf4Helper.convertText("FILINGID")));
+      msg.getDocumentIdentification().add(idType);
+
+      msg.setReviewedLeadDocument(commonOf.createReviewedLeadDocument(doc));
+      // TODO: connected too?
+
+      var sendingLocation = new IdentificationType();
+      sendingLocation.setIdentificationID(Ecf4Helper.convertString("http://filingreviewmde.com"));
+      msg.setSendingMDELocationID(sendingLocation);
+
+      var civilCase = civilOf.createCivilCaseType();
+      civilCase.setCaseTrackingID(Ecf4Helper.convertString(repNumber));
+      civilCase.setCaseDocketID(Ecf4Helper.convertString(docketNumber));
+      civilCase.setCaseTitleText(Ecf4Helper.convertText("Brown vs Brown"));
+      civilCase.setCaseCategoryText(Ecf4Helper.convertText("1234"));
+      msg.setCase(civilOf.createCivilCase(civilCase));
+
+      var filingStatus = new FilingStatusType();
+      filingStatus.setFilingStatusCode("accepted");
+      filingStatus
+          .getStatusDescriptionText()
+          .add(Ecf4Helper.convertText("filing has been accepted by the court"));
+      msg.setFilingStatus(filingStatus);
+
+      return msg;
+    }
+  }
+}


### PR DESCRIPTION
* Remove all of the possible document binaries (the main point of this PR)
    * was previously only removing the main document binary from the lead document; now removes all document renditions from lead and connected documents.
    * this is interfering with the logs; the document binaries are too big and seem to prevent other valid logs from those requests from showing up. Considered taking out all of the XML object printing, but some are still needed for debugging. Will work on bringing those down in the future.
* use log formatting when possible
* slight renaming of methods
* All of the refactoring necessary to enable the above
    * using suppliers in constructors
    * mocking out Tyler / database stuff to actually test the class with jqwik.   