### PR TITLE
Show more context with tyler errors

### DIFF
--- a/proxyserver/src/main/java/edu/suffolk/litlab/efsp/tyler/TylerErrorCodes.java
+++ b/proxyserver/src/main/java/edu/suffolk/litlab/efsp/tyler/TylerErrorCodes.java
@@ -44,6 +44,7 @@ public class TylerErrorCodes {
           Map.entry("95", 400), // Invalid FilingAttorneyID
           Map.entry("96", 400), // Invalid FilingPartyID
           Map.entry("97", 400), // Invalid PaymentID
+          Map.entry("168", 400), // Lower court code not found
           Map.entry("169", 422), // Invalid birthdate
           Map.entry("170", 422), // Invalid password (when making an account? TODO(brycew))
           Map.entry("344", 422) // Doesn't handle cross references


### PR DESCRIPTION
Some tyler errors (like "Lower court not found") aren't possible to easily debug further without additional information. While some of this info  might be able to be traces back to DA servers with request ids, the most relevant information should be displayed in the log itself.

Currently only focuses on `Ecf4Filer.java`, but adds a method that takes the `FilingInformation` already parsed from a filing, and logs the relevant parts of that in regards to the Tyler errors codes.