### PR TITLE
Misc testing fixes

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -171,7 +171,7 @@
                 <plugin>
                     <groupId>org.jacoco</groupId>
                     <artifactId>jacoco-maven-plugin</artifactId>
-                    <version>0.8.12</version>
+                    <version>0.8.13</version>
                     <configuration>
                         <excludes>
                             <exclude>ecfv5/**/*.class</exclude>

--- a/proxyserver/src/main/java/edu/suffolk/litlab/efsp/server/setup/tyler/OasisEcfWsCallback.java
+++ b/proxyserver/src/main/java/edu/suffolk/litlab/efsp/server/setup/tyler/OasisEcfWsCallback.java
@@ -291,6 +291,9 @@ public class OasisEcfWsCallback implements FilingAssemblyMDEPort {
     // Now for the review filing
     String filingId = "";
     for (IdentificationType id : revFiling.getDocumentIdentification()) {
+      if (id == null) {
+        continue;
+      }
       if (id.getIdentificationCategory().getValue() instanceof TextType category) {
         if (category.getValue() != null && category.getValue().equalsIgnoreCase("FILINGID")) {
           filingId = id.getIdentificationID().getValue();

--- a/proxyserver/src/main/java/edu/suffolk/litlab/efsp/tyler/TylerErrorCodes.java
+++ b/proxyserver/src/main/java/edu/suffolk/litlab/efsp/tyler/TylerErrorCodes.java
@@ -47,6 +47,7 @@ public class TylerErrorCodes {
           Map.entry("168", 400), // Lower court code not found
           Map.entry("169", 422), // Invalid birthdate
           Map.entry("170", 422), // Invalid password (when making an account? TODO(brycew))
+          Map.entry("177", 403), // Operation not available for individual filers
           Map.entry("344", 422) // Doesn't handle cross references
           );
 

--- a/proxyserver/src/test/java/edu/suffolk/litlab/efsp/server/setup/tyler/OasisEcfWsCallbackTest.java
+++ b/proxyserver/src/test/java/edu/suffolk/litlab/efsp/server/setup/tyler/OasisEcfWsCallbackTest.java
@@ -106,8 +106,9 @@ public class OasisEcfWsCallbackTest {
     @Example
     public void testFailedShouldNotSendEmail() throws SQLException {
       // Just make sure we don't throw exceptions
-      // cb.notifyFilingReviewComplete(null);
+      cb.notifyFilingReviewComplete(null);
       cb.notifyFilingReviewComplete(new NotifyFilingReviewCompleteRequestMessageType());
+      cb.notifyFilingReviewComplete(makeNullIdMsg());
 
       when(mockCd.getFullLocationInfo(eq(courtId))).thenReturn(Optional.empty());
       cb.notifyFilingReviewComplete(makeMsg(null, null));
@@ -165,6 +166,18 @@ public class OasisEcfWsCallbackTest {
       msg.setReviewFilingCallbackMessage(makeMsgType(doc));
       var paymentMsg = new PaymentMessageType();
       paymentMsg.getAllowanceCharge().add(charge);
+      msg.setPaymentReceiptMessage(paymentMsg);
+      return msg;
+    }
+
+    private NotifyFilingReviewCompleteRequestMessageType makeNullIdMsg() {
+      var msg = new NotifyFilingReviewCompleteRequestMessageType();
+      var rev = new ReviewFilingCallbackMessageType();
+      rev.setDocumentFiledDate(Ecf4Helper.convertDate(LocalDate.of(2025, 07, 04)));
+      rev.getDocumentIdentification().add(null);
+      msg.setReviewFilingCallbackMessage(rev);
+      var paymentMsg = new PaymentMessageType();
+      paymentMsg.getAllowanceCharge().add(null);
       msg.setPaymentReceiptMessage(paymentMsg);
       return msg;
     }

--- a/proxyserver/src/test/resources/logback.xml
+++ b/proxyserver/src/test/resources/logback.xml
@@ -1,0 +1,18 @@
+<configuration scan="true" scanPeriod="30 seconds">
+
+  <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
+    <encoder>
+      <pattern>%d{yyyy-MM-dd HH:mm:ss.SSS} [server=%X{serverId}] [user=%X{userId}] [session=%X{sessionId}] [corr=%X{correlationId}] [req=%X{requestId}] [op=%X{operation}] %-5level %logger{40} - %msg %rEx%n</pattern>
+    </encoder>
+  </appender>
+  <logger name="org.ehcache.core.EhcacheManager" level="ERROR"/>
+  <logger name="org.apache.cxf.wsdl.service.factory" level="WARN"/>
+  <!-- Ignoring "WARN  org.eclipse.jetty.server.handler.ContextHandler - Unimplemented getRequestCharacterEncoding() - use org.eclipse.jetty.servlet.ServletContextHandler" -->
+  <logger name="org.eclipse.jetty.server.handler.ContextHandler" level="ERROR"/>
+  <!--logger name="org.eclipse.jetty" level="DEBUG"/-->
+
+  <root level="info">
+    <appender-ref ref="STDOUT" />
+    <appender-ref ref="PerServer"/>
+  </root>
+</configuration>


### PR DESCRIPTION
* Upgrade Jacoco to 0.8.13 to support Java 24
    * Jacoco would include tons of error messages about not supporting class file major version 68 (some library must be using it)
* Add some null checks that had been left out of previous commits
    * add tests that cover those null checks
* Add a better error code for operations not allowed to inidivudal filers (403)
* add a test `logback.xml` that doesn't make a new "per-server" log file on each new test run. Was managable previously to just delete the generated ones, but with jqwik running 1000 tests each time, it would generate 1000 new files on each test run. Better to just not generate those (also cuts 10s off of the test runtime).