### PR TITLE
Show return status to all calls where our logic runs

### DIFF
--- a/proxyserver/src/main/java/edu/suffolk/litlab/efsp/server/EfspServer.java
+++ b/proxyserver/src/main/java/edu/suffolk/litlab/efsp/server/EfspServer.java
@@ -149,8 +149,6 @@ public class EfspServer {
     sf.setProviders(providers());
 
     sf.setAddress(ServiceHelpers.BASE_LOCAL_URL);
-    sf.getInInterceptors().add(new ObservabilityHeadersInterceptor());
-    sf.getOutInterceptors().add(new ObservabilityResetInterceptor());
     server = sf.create();
   }
 
@@ -217,7 +215,9 @@ public class EfspServer {
         new JAXBElementProvider<Object>(),
         new JacksonJsonProvider(), // TODO(brycew): JAXBJSon?
         new SoapExceptionMapper(),
-        new JsonExceptionMapper());
+        new JsonExceptionMapper(),
+        new ObservabilityHeadersInterceptor(),
+        new ObservabilityResetInterceptor());
   }
 
   public static void main(String[] args) throws Exception {

--- a/proxyserver/src/main/java/edu/suffolk/litlab/efsp/server/utils/ObservabilityHeadersInterceptor.java
+++ b/proxyserver/src/main/java/edu/suffolk/litlab/efsp/server/utils/ObservabilityHeadersInterceptor.java
@@ -1,33 +1,32 @@
 package edu.suffolk.litlab.efsp.server.utils;
 
+import jakarta.ws.rs.container.ContainerRequestContext;
+import jakarta.ws.rs.container.ContainerRequestFilter;
+import jakarta.ws.rs.container.PreMatching;
+import jakarta.ws.rs.ext.Provider;
+import java.io.IOException;
 import java.util.List;
 import java.util.Map;
 import java.util.UUID;
 import java.util.regex.Pattern;
-import org.apache.cxf.interceptor.AbstractInDatabindingInterceptor;
-import org.apache.cxf.interceptor.Fault;
-import org.apache.cxf.message.Message;
-import org.apache.cxf.phase.Phase;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.slf4j.MDC;
+import org.springframework.stereotype.Component;
 
-public class ObservabilityHeadersInterceptor extends AbstractInDatabindingInterceptor {
+@Component
+@Provider
+@PreMatching // lets this run on all requests, not just those that match an endpoint
+public class ObservabilityHeadersInterceptor implements ContainerRequestFilter {
   private static final Logger log = LoggerFactory.getLogger(ObservabilityHeadersInterceptor.class);
 
   private static final String SESSION_ID = "efsp-session-id";
   private static final String CORRELATION_ID = "efsp-correlation-id";
   private static final String REQUEST_ID = "efsp-request-id";
 
-  public ObservabilityHeadersInterceptor() {
-    // See https://cxf.apache.org/docs/interceptors.html for phase descriptions
-    super(Phase.UNMARSHAL);
-  }
-
   @Override
-  public void handleMessage(Message message) throws Fault {
-    @SuppressWarnings("unchecked")
-    var headers = (Map<String, List<String>>) message.get(Message.PROTOCOL_HEADERS);
+  public void filter(ContainerRequestContext requestContext) throws IOException {
+    var headers = requestContext.getHeaders();
     try {
       String sessionId = handleHeaderString(headers, SESSION_ID);
       if (sessionId != null) {

--- a/proxyserver/src/main/java/edu/suffolk/litlab/efsp/server/utils/ObservabilityResetInterceptor.java
+++ b/proxyserver/src/main/java/edu/suffolk/litlab/efsp/server/utils/ObservabilityResetInterceptor.java
@@ -1,20 +1,27 @@
 package edu.suffolk.litlab.efsp.server.utils;
 
-import org.apache.cxf.interceptor.AbstractOutDatabindingInterceptor;
-import org.apache.cxf.interceptor.Fault;
-import org.apache.cxf.message.Message;
-import org.apache.cxf.phase.Phase;
+import jakarta.ws.rs.container.ContainerRequestContext;
+import jakarta.ws.rs.container.ContainerResponseContext;
+import jakarta.ws.rs.container.ContainerResponseFilter;
+import jakarta.ws.rs.ext.Provider;
+import java.io.IOException;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.stereotype.Component;
 
+@Component
+@Provider
 /** Clears all MDC entries after our business logic finishes running. */
-public class ObservabilityResetInterceptor extends AbstractOutDatabindingInterceptor {
-
-  public ObservabilityResetInterceptor() {
-    // See https://cxf.apache.org/docs/interceptors.html for phase descriptions
-    super(Phase.POST_LOGICAL);
-  }
+public class ObservabilityResetInterceptor implements ContainerResponseFilter {
+  private static final Logger log = LoggerFactory.getLogger(ObservabilityResetInterceptor.class);
 
   @Override
-  public void handleMessage(Message message) throws Fault {
+  public void filter(ContainerRequestContext request, ContainerResponseContext response)
+      throws IOException {
+    log.info(
+        "Sending back status of {} in response to {}",
+        response.getStatus(),
+        request.getUriInfo().getPath());
     MDCWrappers.removeAllMDCs();
   }
 }

--- a/proxyserver/src/main/resources/logback.xml
+++ b/proxyserver/src/main/resources/logback.xml
@@ -41,6 +41,7 @@
   <!-- Ignoring "WARN  org.eclipse.jetty.server.handler.ContextHandler - Unimplemented getRequestCharacterEncoding() - use org.eclipse.jetty.servlet.ServletContextHandler" -->
   <logger name="org.eclipse.jetty.server.handler.ContextHandler" level="ERROR"/>
   <!--logger name="org.eclipse.jetty" level="DEBUG"/-->
+  <!--logger name="edu.suffolk.litlab.efsp" level="TRACE"/-->
 
   <root level="info">
     <appender-ref ref="STDOUT" />

--- a/proxyserver/src/test/java/edu/suffolk/litlab/efsp/server/utils/ObservabilityHeadersInterceptorTest.java
+++ b/proxyserver/src/test/java/edu/suffolk/litlab/efsp/server/utils/ObservabilityHeadersInterceptorTest.java
@@ -3,11 +3,11 @@ package edu.suffolk.litlab.efsp.server.utils;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
-import java.util.List;
-import java.util.Map;
+import jakarta.ws.rs.container.ContainerRequestContext;
+import jakarta.ws.rs.core.MultivaluedHashMap;
+import java.io.IOException;
 import net.jqwik.api.ForAll;
 import net.jqwik.api.Property;
-import org.apache.cxf.message.Message;
 import org.slf4j.MDC;
 
 public class ObservabilityHeadersInterceptorTest {
@@ -16,18 +16,15 @@ public class ObservabilityHeadersInterceptorTest {
 
   @Property
   boolean interceptorHandlesAllHeaders(
-      @ForAll String sessionId, @ForAll String corrId, @ForAll String reqId) {
-    Message m = mock(Message.class);
-    when(m.get(Message.PROTOCOL_HEADERS))
-        .thenReturn(
-            Map.of(
-                "efsp-session-id",
-                List.of(sessionId),
-                "efsp-correlation-id",
-                List.of(corrId),
-                "efsp-request-id",
-                List.of(reqId)));
-    interceptor.handleMessage(m);
+      @ForAll String sessionId, @ForAll String corrId, @ForAll String reqId) throws IOException {
+    ContainerRequestContext ctx = mock(ContainerRequestContext.class);
+    var headers = new MultivaluedHashMap<String, String>();
+    headers.add("efsp-session-id", sessionId);
+    headers.add("efsp-correlation-id", corrId);
+    headers.add("efsp-request-id", reqId);
+    when(ctx.getHeaders()).thenReturn(headers);
+
+    interceptor.filter(ctx);
 
     // Request should always be present, but as long as we don't crash we're good.
     return MDC.get(MDCWrappers.REQUEST_ID) != null;


### PR DESCRIPTION
Makes the switch over to JAX-RS compliant container filters, which are better because:

* The CXF API is incomprehensible; very difficult to find the right random string to get from the message, and very little documentation in the code about what each entry contains, when it will be there. I tried implemening this change previously with the CXF API, but both the response code and path were null. idk why, and didn't want to spend ages trying to figure it out.
* we can eventually switch the HTTP server over to Spring (if desired; would clean up a bit of stuff: related to https://github.com/SuffolkLITLab/EfileProxyServer/blob/main/TODO.md).

https://stackoverflow.com/a/46726824/11416267