### PR TITLE
Move `userCredsFromAuthorization` to TylerUserNamePassword

### DIFF
--- a/proxyserver/src/main/java/edu/suffolk/litlab/efsp/server/services/AdminUserService.java
+++ b/proxyserver/src/main/java/edu/suffolk/litlab/efsp/server/services/AdminUserService.java
@@ -751,7 +751,7 @@ public class AdminUserService {
             httpHeaders.getHeaderString(TylerLogin.getHeaderKeyFromJurisdiction(jurisdiction));
         MDC.put(MDCWrappers.USER_ID, ld.makeHash(tylerToken));
         Optional<TylerUserNamePassword> creds =
-            ServiceHelpers.userCredsFromAuthorization(tylerToken);
+            TylerUserNamePassword.userCredsFromAuthorization(tylerToken);
         if (creds.isEmpty()) {
           return Optional.empty();
         }

--- a/proxyserver/src/main/java/edu/suffolk/litlab/efsp/server/services/CasesService.java
+++ b/proxyserver/src/main/java/edu/suffolk/litlab/efsp/server/services/CasesService.java
@@ -437,7 +437,8 @@ public class CasesService {
       log.error("SQL error with record port", ex);
       return Optional.empty();
     }
-    Optional<TylerUserNamePassword> creds = ServiceHelpers.userCredsFromAuthorization(tylerToken);
+    Optional<TylerUserNamePassword> creds =
+        TylerUserNamePassword.userCredsFromAuthorization(tylerToken);
     if (creds.isEmpty()) {
       log.warn("No creds?");
       return Optional.empty();

--- a/proxyserver/src/main/java/edu/suffolk/litlab/efsp/server/services/CourtSchedulingService.java
+++ b/proxyserver/src/main/java/edu/suffolk/litlab/efsp/server/services/CourtSchedulingService.java
@@ -539,7 +539,7 @@ public class CourtSchedulingService {
       String tylerToken =
           httpHeaders.getHeaderString(TylerLogin.getHeaderKeyFromJurisdiction(jurisdiction));
       MDC.put(MDCWrappers.USER_ID, ld.makeHash(tylerToken));
-      creds = ServiceHelpers.userCredsFromAuthorization(tylerToken);
+      creds = TylerUserNamePassword.userCredsFromAuthorization(tylerToken);
     } catch (SQLException ex) {
       log.error("SQL error with Scheduling port", ex);
       return Optional.empty();
@@ -560,7 +560,8 @@ public class CourtSchedulingService {
     String tylerToken =
         httpHeaders.getHeaderString(TylerLogin.getHeaderKeyFromJurisdiction(jurisdiction));
 
-    Optional<TylerUserNamePassword> creds = ServiceHelpers.userCredsFromAuthorization(tylerToken);
+    Optional<TylerUserNamePassword> creds =
+        TylerUserNamePassword.userCredsFromAuthorization(tylerToken);
     if (creds.isEmpty()) {
       return Optional.empty();
     }

--- a/proxyserver/src/main/java/edu/suffolk/litlab/efsp/server/services/FilingReviewService.java
+++ b/proxyserver/src/main/java/edu/suffolk/litlab/efsp/server/services/FilingReviewService.java
@@ -540,6 +540,7 @@ public class FilingReviewService {
       if (orgToken == null || orgToken.isBlank()) {
         return Optional.empty();
       }
+      MDC.put(MDCWrappers.USER_ID, ld.makeHash(orgToken));
       return Optional.of(orgToken);
     } catch (SQLException ex) {
       log.error("SQL Error", ex);

--- a/proxyserver/src/main/java/edu/suffolk/litlab/efsp/server/setup/tyler/Ecf4Filer.java
+++ b/proxyserver/src/main/java/edu/suffolk/litlab/efsp/server/setup/tyler/Ecf4Filer.java
@@ -939,7 +939,8 @@ public class Ecf4Filer extends EfmCheckableFilingInterface {
   }
 
   private Optional<FilingReviewMDEPort> setupFilingPort(String apiToken) {
-    Optional<TylerUserNamePassword> creds = ServiceHelpers.userCredsFromAuthorization(apiToken);
+    Optional<TylerUserNamePassword> creds =
+        TylerUserNamePassword.userCredsFromAuthorization(apiToken);
     if (creds.isEmpty()) {
       return Optional.empty();
     }
@@ -952,7 +953,8 @@ public class Ecf4Filer extends EfmCheckableFilingInterface {
   }
 
   private Optional<ServiceMDEPort> setupServicePort(String apiToken) {
-    Optional<TylerUserNamePassword> creds = ServiceHelpers.userCredsFromAuthorization(apiToken);
+    Optional<TylerUserNamePassword> creds =
+        TylerUserNamePassword.userCredsFromAuthorization(apiToken);
     if (creds.isEmpty()) {
       return Optional.empty();
     }
@@ -965,7 +967,8 @@ public class Ecf4Filer extends EfmCheckableFilingInterface {
   }
 
   private Optional<CourtRecordMDEPort> setupRecordPort(String apiToken) {
-    Optional<TylerUserNamePassword> creds = ServiceHelpers.userCredsFromAuthorization(apiToken);
+    Optional<TylerUserNamePassword> creds =
+        TylerUserNamePassword.userCredsFromAuthorization(apiToken);
     if (creds.isEmpty()) {
       return Optional.empty();
     }

--- a/proxyserver/src/main/java/edu/suffolk/litlab/efsp/server/utils/ServiceHelpers.java
+++ b/proxyserver/src/main/java/edu/suffolk/litlab/efsp/server/utils/ServiceHelpers.java
@@ -25,7 +25,7 @@ import org.slf4j.LoggerFactory;
 import org.slf4j.MDC;
 
 public class ServiceHelpers {
-  private static Logger log = LoggerFactory.getLogger(ServiceHelpers.class);
+  private static final Logger log = LoggerFactory.getLogger(ServiceHelpers.class);
 
   /**
    * One of the ways that you can communicate over ECF. For more information, see

--- a/proxyserver/src/main/java/edu/suffolk/litlab/efsp/server/utils/ServiceHelpers.java
+++ b/proxyserver/src/main/java/edu/suffolk/litlab/efsp/server/utils/ServiceHelpers.java
@@ -73,19 +73,6 @@ public class ServiceHelpers {
     REST_CALLBACK_URL = EXTERNAL_URL + "/filingreview/jurisdictions/%s/courts/%s/filing/status";
   }
 
-  public static Optional<TylerUserNamePassword> userCredsFromAuthorization(
-      String userColonPassword) {
-    if (userColonPassword == null) {
-      return Optional.empty();
-    }
-    if (!userColonPassword.contains(":")) {
-      return Optional.empty();
-    }
-    String email = userColonPassword.split(":")[0];
-    String password = userColonPassword.split(":")[1];
-    return Optional.of(new TylerUserNamePassword(email, password));
-  }
-
   /**
    * Sets up a connection to Tyler's SOAP API WITHOUT any Auth headers, but does handle the X.509
    * certificate and signing parameters.
@@ -184,7 +171,8 @@ public class ServiceHelpers {
 
   public static Optional<TylerFirmClient> setupFirmPort(
       TylerFirmFactory firmFactory, String tylerToken) {
-    Optional<TylerUserNamePassword> creds = ServiceHelpers.userCredsFromAuthorization(tylerToken);
+    Optional<TylerUserNamePassword> creds =
+        TylerUserNamePassword.userCredsFromAuthorization(tylerToken);
     if (creds.isEmpty()) {
       log.warn("No creds from {}?", tylerToken);
       return Optional.empty();

--- a/proxyserver/src/main/java/edu/suffolk/litlab/efsp/tyler/TylerUserNamePassword.java
+++ b/proxyserver/src/main/java/edu/suffolk/litlab/efsp/tyler/TylerUserNamePassword.java
@@ -5,6 +5,7 @@ import jakarta.xml.bind.annotation.XmlElement;
 import jakarta.xml.bind.annotation.XmlRootElement;
 import java.util.Arrays;
 import java.util.List;
+import java.util.Optional;
 import javax.xml.namespace.QName;
 import org.apache.cxf.headers.Header;
 import org.apache.cxf.jaxb.JAXBDataBinding;
@@ -23,6 +24,19 @@ public class TylerUserNamePassword {
   public TylerUserNamePassword(String userName, String password) {
     this.userName = userName;
     this.password = password;
+  }
+
+  public static Optional<TylerUserNamePassword> userCredsFromAuthorization(
+      String userColonPassword) {
+    if (userColonPassword == null) {
+      return Optional.empty();
+    }
+    if (!userColonPassword.contains(":")) {
+      return Optional.empty();
+    }
+    String email = userColonPassword.split(":")[0];
+    String password = userColonPassword.split(":")[1];
+    return Optional.of(new TylerUserNamePassword(email, password));
   }
 
   public String getUserName() {


### PR DESCRIPTION
The class name is longer, but given it's just a static factory method for that class, it should go there.

Stray cleanups:

* added missing `final` to logger object.
* Added USER_ID to MDC in Filing Review Service