### PR TITLE
Try building the docker file in CI

### DIFF
--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -16,3 +16,11 @@ jobs:
           cache: 'maven'
       - name: Build with Maven
         run: mvn --batch-mode -Preproducible verify javadoc:javadoc
+
+  dockerimage:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+      - name: Build whole Dockerfile
+        run: docker build --target release --tag test-efspjava-image .


### PR DESCRIPTION
Had we been doing this, we could have prevented the need for #291 and caught it CI.

Uses a different build because the docker build is completely separate from the local java build