### PR TITLE
Use TylerEnv internally everywhere

### DIFF
--- a/TylerEfmClient/src/main/java/edu/suffolk/litlab/efsp/tyler/TylerClients.java
+++ b/TylerEfmClient/src/main/java/edu/suffolk/litlab/efsp/tyler/TylerClients.java
@@ -59,11 +59,11 @@ public class TylerClients {
    * @return
    */
   public static String getTylerServerRootUrl(String jurisdiction, TylerEnv envEnum) {
-    String env = envEnum.name().toLowerCase();
+    String env = envEnum.getPath();
     if (jurisdiction.equalsIgnoreCase("california")) {
       return "https://california-efm-" + env + ".tylertech.cloud/";
     }
-    if (envEnum.equals(TylerEnv.PROD)) {
+    if (envEnum == TylerEnv.PROD) {
       return "https://" + jurisdiction + ".tylertech.cloud/";
     }
     return "https://" + jurisdiction + "-" + env + ".tylertech.cloud/";

--- a/TylerEfmClient/src/main/java/edu/suffolk/litlab/efsp/tyler/TylerEnv.java
+++ b/TylerEfmClient/src/main/java/edu/suffolk/litlab/efsp/tyler/TylerEnv.java
@@ -23,7 +23,7 @@ public enum TylerEnv {
     } else if (value.equalsIgnoreCase(PROD.getPath())) {
       return PROD;
     } else {
-      throw new IllegalArgumentException("Can't make a `TylerEnv` from: " + value);
+      throw new IllegalArgumentException("Can't make a `TylerEnv` from: `" + value + "`");
     }
   }
 }

--- a/proxyserver/src/main/java/edu/suffolk/litlab/efsp/docassemble/DocassembleToFilingInformationConverter.java
+++ b/proxyserver/src/main/java/edu/suffolk/litlab/efsp/docassemble/DocassembleToFilingInformationConverter.java
@@ -5,10 +5,12 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.module.SimpleModule;
 import com.hubspot.algebra.Result;
 import edu.suffolk.litlab.efsp.model.FilingInformation;
+import edu.suffolk.litlab.efsp.tyler.TylerEnv;
 import edu.suffolk.litlab.efsp.utils.FilingError;
 import edu.suffolk.litlab.efsp.utils.InfoCollector;
 import edu.suffolk.litlab.efsp.utils.InterviewToFilingInformationConverter;
 import java.io.InputStream;
+import java.util.Optional;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -16,8 +18,12 @@ public class DocassembleToFilingInformationConverter extends InterviewToFilingIn
 
   private static Logger log =
       LoggerFactory.getLogger(DocassembleToFilingInformationConverter.class);
+  private final Optional<TylerEnv> tylerEnv;
 
-  public DocassembleToFilingInformationConverter(InputStream taxonomyCsv) {}
+  public DocassembleToFilingInformationConverter(
+      InputStream taxonomyCsv, Optional<TylerEnv> tylerEnv) {
+    this.tylerEnv = tylerEnv;
+  }
 
   @Override
   public Result<FilingInformation, FilingError> traverseInterview(
@@ -25,7 +31,8 @@ public class DocassembleToFilingInformationConverter extends InterviewToFilingIn
     SimpleModule module = new SimpleModule();
     module.addDeserializer(
         FilingInformation.class,
-        new FilingInformationDocassembleJacksonDeserializer(FilingInformation.class, collector));
+        new FilingInformationDocassembleJacksonDeserializer(
+            FilingInformation.class, collector, tylerEnv));
     ObjectMapper mapper = new ObjectMapper();
     mapper.registerModule(module);
     try {

--- a/proxyserver/src/main/java/edu/suffolk/litlab/efsp/docassemble/FilingDocDocassembleJacksonDeserializer.java
+++ b/proxyserver/src/main/java/edu/suffolk/litlab/efsp/docassemble/FilingDocDocassembleJacksonDeserializer.java
@@ -41,7 +41,7 @@ import org.slf4j.LoggerFactory;
 
 public class FilingDocDocassembleJacksonDeserializer {
   private static Logger log =
-      LoggerFactory.getLogger(FilingInformationDocassembleJacksonDeserializer.class);
+      LoggerFactory.getLogger(FilingDocDocassembleJacksonDeserializer.class);
 
   /** Parses a filing from the DA Json Object. Used by Deserializers that include filings. */
   public static Optional<FilingDoc> fromNode(

--- a/proxyserver/src/main/java/edu/suffolk/litlab/efsp/docassemble/FilingInformationDocassembleJacksonDeserializer.java
+++ b/proxyserver/src/main/java/edu/suffolk/litlab/efsp/docassemble/FilingInformationDocassembleJacksonDeserializer.java
@@ -1,7 +1,5 @@
 package edu.suffolk.litlab.efsp.docassemble;
 
-import static edu.suffolk.litlab.efsp.stdlib.StdLib.GetEnv;
-
 import com.fasterxml.jackson.core.JsonParser;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.DeserializationContext;
@@ -16,6 +14,7 @@ import edu.suffolk.litlab.efsp.model.FilingInformation;
 import edu.suffolk.litlab.efsp.model.LowerCourtInfo;
 import edu.suffolk.litlab.efsp.model.PartyId;
 import edu.suffolk.litlab.efsp.model.Person;
+import edu.suffolk.litlab.efsp.tyler.TylerEnv;
 import edu.suffolk.litlab.efsp.utils.FilingError;
 import edu.suffolk.litlab.efsp.utils.InfoCollector;
 import edu.suffolk.litlab.efsp.utils.InterviewVariable;
@@ -41,11 +40,13 @@ public class FilingInformationDocassembleJacksonDeserializer
 
   private static final long serialVersionUID = 1L;
   private final InfoCollector classCollector;
+  private final Optional<TylerEnv> tylerEnv;
 
   public FilingInformationDocassembleJacksonDeserializer(
-      Class<FilingInformation> t, InfoCollector collector) {
+      Class<FilingInformation> t, InfoCollector collector, Optional<TylerEnv> tylerEnv) {
     super(t);
     this.classCollector = collector;
+    this.tylerEnv = tylerEnv;
   }
 
   /**
@@ -92,8 +93,7 @@ public class FilingInformationDocassembleJacksonDeserializer
     return List.copyOf(people);
   }
 
-  public static FilingInformation fromNode(JsonNode node, InfoCollector collector)
-      throws FilingError {
+  public FilingInformation fromNode(JsonNode node, InfoCollector collector) throws FilingError {
     if (!node.isObject()) {
       FilingError err = FilingError.malformedInterview("interview isn't a json object");
       collector.error(err);
@@ -492,7 +492,7 @@ public class FilingInformationDocassembleJacksonDeserializer
     return maybeReturnDate;
   }
 
-  private static Optional<LowerCourtInfo> extractLowerCourt(JsonNode node, InfoCollector collector)
+  private Optional<LowerCourtInfo> extractLowerCourt(JsonNode node, InfoCollector collector)
       throws FilingError {
     if (node == null) {
       return Optional.empty();
@@ -523,8 +523,7 @@ public class FilingInformationDocassembleJacksonDeserializer
       Optional<String> maybeCodeText = Optional.empty();
       // TODO(brycew): HACK HACK HACK! Should be a better way to handle lower court codes than
       // this, but it's broken on prod
-      var tylerEnv = GetEnv("TYLER_ENV");
-      if (tylerEnv.orElse("").equalsIgnoreCase("prod")) {
+      if (tylerEnv.isPresent() && tylerEnv.get() == TylerEnv.PROD) {
         maybeCodeText =
             JsonHelpers.getStringMember(node.get("trial_court"), "tyler_prod_lower_court_code");
       } else {

--- a/proxyserver/src/main/java/edu/suffolk/litlab/efsp/ecfcodes/CodeUpdater.java
+++ b/proxyserver/src/main/java/edu/suffolk/litlab/efsp/ecfcodes/CodeUpdater.java
@@ -514,9 +514,8 @@ public class CodeUpdater {
 
   /** Sets up the WSDL connection to Tyler, used for `getPolicy` to get the URL. */
   private static FilingReviewMDEPort loginWithTyler(
-      String jurisdiction, String env, String userEmail, String userPassword) {
-    Optional<TylerUserFactory> userFactory =
-        TylerClients.getEfmUserFactory(jurisdiction, TylerEnv.parse(env));
+      String jurisdiction, TylerEnv env, String userEmail, String userPassword) {
+    Optional<TylerUserFactory> userFactory = TylerClients.getEfmUserFactory(jurisdiction, env);
     if (userFactory.isEmpty()) {
       throw new RuntimeException("Can't find " + jurisdiction + " in Soap chooser for EFMUser");
     }
@@ -541,7 +540,7 @@ public class CodeUpdater {
   }
 
   /** Downloads a single codes zip. For Debugging. */
-  public boolean downloadIndiv(List<String> args, String jurisdiction, String env) {
+  public boolean downloadIndiv(List<String> args, String jurisdiction, TylerEnv env) {
     if (args.size() < 3) {
       log.error(
           "Need to pass in args: downloadIndiv <jurisdiction> <table> <location or blank for"
@@ -557,7 +556,7 @@ public class CodeUpdater {
     String table = args.get(2);
     String location = (args.size() == 4) ? args.get(3) : "";
     HeaderSigner hs = new HeaderSigner(this.pathToKeystore, this.x509Password);
-    String endpoint = TylerClients.getTylerServerRootUrl(jurisdiction, TylerEnv.parse(env));
+    String endpoint = TylerClients.getTylerServerRootUrl(jurisdiction, env);
     return downloadAndProcessZip(
         makeCodeUrl(endpoint, table, location),
         hs.signedCurrentTime().get(),
@@ -574,12 +573,12 @@ public class CodeUpdater {
   }
 
   public static boolean executeCommand(
-      CodeDatabase cd, String jurisdiction, String env, List<String> args, String x509Password) {
+      CodeDatabase cd, String jurisdiction, TylerEnv env, List<String> args, String x509Password) {
     SoapX509CallbackHandler.setX509Password(x509Password);
     String command = args.get(0);
     try {
       cd.setAutoCommit(false);
-      String codesSite = TylerClients.getTylerServerRootUrl(jurisdiction, TylerEnv.parse(env));
+      String codesSite = TylerClients.getTylerServerRootUrl(jurisdiction, env);
       FilingReviewMDEPort filingPort =
           loginWithTyler(
               jurisdiction,
@@ -632,7 +631,7 @@ public class CodeUpdater {
             100);
 
     List<String> jurisdictions = List.of(System.getenv("TYLER_JURISDICTIONS").split(" "));
-    String env = System.getenv("TYLER_ENV");
+    TylerEnv env = TylerEnv.parse(System.getenv("TYLER_ENV"));
     for (String jurisdiction : jurisdictions) {
       try (Connection conn = ds.getConnection()) {
         executeCommand(

--- a/proxyserver/src/main/java/edu/suffolk/litlab/efsp/ecfcodes/tyler/CodeDatabase.java
+++ b/proxyserver/src/main/java/edu/suffolk/litlab/efsp/ecfcodes/tyler/CodeDatabase.java
@@ -2,6 +2,7 @@ package edu.suffolk.litlab.efsp.ecfcodes.tyler;
 
 import edu.suffolk.litlab.efsp.ecfcodes.CodeDatabaseAPI;
 import edu.suffolk.litlab.efsp.stdlib.SQLFunction;
+import edu.suffolk.litlab.efsp.tyler.TylerEnv;
 import jakarta.xml.bind.JAXBException;
 import java.io.InputStream;
 import java.sql.Connection;
@@ -43,12 +44,12 @@ public class CodeDatabase extends CodeDatabaseAPI {
   /** The DNS domain (tyler jurisdiction + tyler environment, illinois-stage). */
   private final String tylerDomain;
 
-  public CodeDatabase(String jurisdiction, String env, Connection conn) {
+  public CodeDatabase(String jurisdiction, TylerEnv env, Connection conn) {
     super(conn);
-    this.tylerDomain = jurisdiction + "-" + env;
+    this.tylerDomain = jurisdiction + "-" + env.getPath();
   }
 
-  public static CodeDatabase fromDS(String jurisdiction, String env, DataSource ds) {
+  public static CodeDatabase fromDS(String jurisdiction, TylerEnv env, DataSource ds) {
     try {
       CodeDatabase cd = new CodeDatabase(jurisdiction, env, ds.getConnection());
       return cd;

--- a/proxyserver/src/main/java/edu/suffolk/litlab/efsp/server/EfspServer.java
+++ b/proxyserver/src/main/java/edu/suffolk/litlab/efsp/server/EfspServer.java
@@ -28,6 +28,7 @@ import edu.suffolk.litlab.efsp.server.utils.OrgMessageSender;
 import edu.suffolk.litlab.efsp.server.utils.SendMessage;
 import edu.suffolk.litlab.efsp.server.utils.ServiceHelpers;
 import edu.suffolk.litlab.efsp.server.utils.SoapExceptionMapper;
+import edu.suffolk.litlab.efsp.tyler.TylerEnv;
 import edu.suffolk.litlab.efsp.utils.InterviewToFilingInformationConverter;
 import jakarta.ws.rs.core.MediaType;
 import java.security.NoSuchAlgorithmException;
@@ -194,9 +195,12 @@ public class EfspServer {
 
     setupDatabases(codeDs, userDs);
 
+    // Slight hack: this gets used early in the Docassemble converter
+    Optional<TylerEnv> tylerEnv = GetEnv("TYLER_ENV").map(TylerEnv::parse);
+
     InterviewToFilingInformationConverter daJsonConverter =
         new DocassembleToFilingInformationConverter(
-            EfspServer.class.getResourceAsStream("/taxonomy.csv"));
+            EfspServer.class.getResourceAsStream("/taxonomy.csv"), tylerEnv);
     Map<String, InterviewToFilingInformationConverter> converterMap =
         Map.of(
             "application/json", daJsonConverter,
@@ -211,7 +215,6 @@ public class EfspServer {
 
     Optional<String> tylerJurisdictions = GetEnv("TYLER_JURISDICTIONS");
     Optional<String> togaKeyStr = GetEnv("TOGA_CLIENT_KEYS");
-    Optional<String> tylerEnv = GetEnv("TYLER_ENV");
     List<String> jurisdictions = List.of(tylerJurisdictions.orElse("").split(" "));
     List<String> togaKeys = List.of(togaKeyStr.orElse("").split(" "));
     if (jurisdictions.size() > 0 && jurisdictions.size() != togaKeys.size()) {
@@ -225,7 +228,8 @@ public class EfspServer {
       if (jurisdiction.isBlank()) {
         continue;
       }
-      TylerModuleSetup.create(jurisdiction, togaKeys.get(idx), converterMap, codeDs, userDs, sender)
+      TylerModuleSetup.create(
+              jurisdiction, tylerEnv, togaKeys.get(idx), converterMap, codeDs, userDs, sender)
           .ifPresent(mod -> modules.add(mod));
     }
     JeffNetModuleSetup.create(converterMap, userDs, sender).ifPresent(mod -> modules.add(mod));

--- a/proxyserver/src/main/java/edu/suffolk/litlab/efsp/server/auth/SecurityHub.java
+++ b/proxyserver/src/main/java/edu/suffolk/litlab/efsp/server/auth/SecurityHub.java
@@ -3,6 +3,7 @@ package edu.suffolk.litlab.efsp.server.auth;
 import com.fasterxml.jackson.databind.JsonNode;
 import edu.suffolk.litlab.efsp.db.LoginDatabase;
 import edu.suffolk.litlab.efsp.db.model.NewTokens;
+import edu.suffolk.litlab.efsp.tyler.TylerEnv;
 import java.sql.SQLException;
 import java.util.List;
 import java.util.Map;
@@ -38,7 +39,7 @@ public class SecurityHub {
    * @param env the running environment, i.e. which Tyler instance to connect to, "stage" vs "prod"
    * @param jurisdictions a list of Tyler jurisdictions to connect to. See SoapClientChooser.
    */
-  public SecurityHub(DataSource userDs, Optional<String> env, List<String> jurisdictions) {
+  public SecurityHub(DataSource userDs, Optional<TylerEnv> env, List<String> jurisdictions) {
     this.userDs = userDs;
     if (env.isEmpty() || jurisdictions.isEmpty()) {
       this.tylerLoginObjs = List.of();

--- a/proxyserver/src/main/java/edu/suffolk/litlab/efsp/server/auth/TylerLogin.java
+++ b/proxyserver/src/main/java/edu/suffolk/litlab/efsp/server/auth/TylerLogin.java
@@ -20,15 +20,14 @@ public class TylerLogin implements LoginInterface {
   private static final String HEADER_KEY_PREFIX = "TYLER-TOKEN";
   private final String jurisdiction;
 
-  public TylerLogin(String jurisdiction, String env) {
+  public TylerLogin(String jurisdiction, TylerEnv env) {
     this.jurisdiction = jurisdiction;
-    Optional<TylerUserFactory> maybeUserFactory =
-        TylerClients.getEfmUserFactory(jurisdiction, TylerEnv.parse(env));
+    Optional<TylerUserFactory> maybeUserFactory = TylerClients.getEfmUserFactory(jurisdiction, env);
     if (maybeUserFactory.isPresent()) {
       userServiceFactory = maybeUserFactory.get();
     } else {
       throw new RuntimeException(
-          jurisdiction + "-" + env + " not in SoapClientChooser for EFMUser");
+          jurisdiction + "-" + env.getPath() + " not in SoapClientChooser for EFMUser");
     }
   }
 

--- a/proxyserver/src/main/java/edu/suffolk/litlab/efsp/server/ecf4/SoapClientChooser.java
+++ b/proxyserver/src/main/java/edu/suffolk/litlab/efsp/server/ecf4/SoapClientChooser.java
@@ -1,5 +1,6 @@
 package edu.suffolk.litlab.efsp.server.ecf4;
 
+import edu.suffolk.litlab.efsp.tyler.TylerEnv;
 import https.docs_oasis_open_org.legalxml_courtfiling.ns.v5_0.wsdl.courtschedulingmde.CourtSchedulingMDE_Service;
 import java.net.URL;
 import java.util.Map;
@@ -63,8 +64,8 @@ public class SoapClientChooser {
   }
 
   public static Optional<FilingReviewMDEService> getFilingReviewFactory(
-      String jurisdiction, String env) {
-    return getFilingReviewFactory(jurisdiction + "-" + env);
+      String jurisdiction, TylerEnv env) {
+    return getFilingReviewFactory(jurisdiction + "-" + env.getPath());
   }
 
   public static Optional<ServiceMDEService> getServiceFactory(String wsdlDomain) {
@@ -72,7 +73,7 @@ public class SoapClientChooser {
     return url.map(u -> new ServiceMDEService(u));
   }
 
-  public static Optional<ServiceMDEService> getServiceFactory(String jurisdiction, String env) {
+  public static Optional<ServiceMDEService> getServiceFactory(String jurisdiction, TylerEnv env) {
     return getServiceFactory(jurisdiction + "-" + env);
   }
 
@@ -82,8 +83,8 @@ public class SoapClientChooser {
   }
 
   public static Optional<CourtRecordMDEService> getCourtRecordFactory(
-      String jurisdiction, String env) {
-    return getCourtRecordFactory(jurisdiction + "-" + env);
+      String jurisdiction, TylerEnv env) {
+    return getCourtRecordFactory(jurisdiction + "-" + env.getPath());
   }
 
   public static Optional<CourtSchedulingMDE_Service> getCourtSchedulingFactory(String wsdlDomain) {
@@ -92,8 +93,8 @@ public class SoapClientChooser {
   }
 
   public static Optional<CourtSchedulingMDE_Service> getCourtSchedulingFactory(
-      String jurisdiction, String env) {
-    return getCourtSchedulingFactory(jurisdiction + "-" + env);
+      String jurisdiction, TylerEnv env) {
+    return getCourtSchedulingFactory(jurisdiction + "-" + env.getPath());
   }
 
   private static Optional<URL> urlFromString(String wsdlDomain, Map<String, String> domainToWsdl) {

--- a/proxyserver/src/main/java/edu/suffolk/litlab/efsp/server/services/AdminUserService.java
+++ b/proxyserver/src/main/java/edu/suffolk/litlab/efsp/server/services/AdminUserService.java
@@ -123,21 +123,19 @@ public class AdminUserService {
 
   public AdminUserService(
       String jurisdiction,
-      String env,
+      TylerEnv env,
       Supplier<LoginDatabase> ldSupplier,
       Supplier<CodeDatabase> cdSupplier,
       Function<String, Result<NullValue, String>> passwordChecker) {
     this.jurisdiction = jurisdiction;
     this.passwordChecker = passwordChecker;
-    Optional<TylerUserFactory> maybeUserFactory =
-        TylerClients.getEfmUserFactory(jurisdiction, TylerEnv.parse(env));
+    Optional<TylerUserFactory> maybeUserFactory = TylerClients.getEfmUserFactory(jurisdiction, env);
     if (maybeUserFactory.isEmpty()) {
       throw new RuntimeException(
           "Can't find " + jurisdiction + " in the SoapClientChooser for EfmUser");
     }
     this.userFactory = maybeUserFactory.get();
-    Optional<TylerFirmFactory> maybeFirmFactory =
-        TylerClients.getEfmFirmFactory(jurisdiction, TylerEnv.parse(env));
+    Optional<TylerFirmFactory> maybeFirmFactory = TylerClients.getEfmFirmFactory(jurisdiction, env);
     if (maybeFirmFactory.isEmpty()) {
       throw new RuntimeException(
           "Can't find " + jurisdiction + " in the SoapClientChooser for EfmFirm factory");

--- a/proxyserver/src/main/java/edu/suffolk/litlab/efsp/server/services/CasesService.java
+++ b/proxyserver/src/main/java/edu/suffolk/litlab/efsp/server/services/CasesService.java
@@ -16,6 +16,7 @@ import edu.suffolk.litlab.efsp.server.ecf4.SoapClientChooser;
 import edu.suffolk.litlab.efsp.server.utils.EndpointReflection;
 import edu.suffolk.litlab.efsp.server.utils.MDCWrappers;
 import edu.suffolk.litlab.efsp.server.utils.ServiceHelpers;
+import edu.suffolk.litlab.efsp.tyler.TylerEnv;
 import edu.suffolk.litlab.efsp.tyler.TylerUserNamePassword;
 import gov.niem.niem.niem_core._2.CaseType;
 import gov.niem.niem.niem_core._2.EntityType;
@@ -82,7 +83,7 @@ public class CasesService {
 
   public CasesService(
       String jurisdiction,
-      String env,
+      TylerEnv env,
       Supplier<LoginDatabase> ldSupplier,
       Supplier<CodeDatabase> cdSupplier) {
     this.jurisdiction = jurisdiction;

--- a/proxyserver/src/main/java/edu/suffolk/litlab/efsp/server/services/CourtSchedulingService.java
+++ b/proxyserver/src/main/java/edu/suffolk/litlab/efsp/server/services/CourtSchedulingService.java
@@ -25,6 +25,7 @@ import edu.suffolk.litlab.efsp.server.utils.Ecfv5XmlHelper;
 import edu.suffolk.litlab.efsp.server.utils.EndpointReflection;
 import edu.suffolk.litlab.efsp.server.utils.MDCWrappers;
 import edu.suffolk.litlab.efsp.server.utils.ServiceHelpers;
+import edu.suffolk.litlab.efsp.tyler.TylerEnv;
 import edu.suffolk.litlab.efsp.tyler.TylerUserNamePassword;
 import edu.suffolk.litlab.efsp.utils.FailFastCollector;
 import edu.suffolk.litlab.efsp.utils.FilingError;
@@ -106,7 +107,7 @@ public class CourtSchedulingService {
   public CourtSchedulingService(
       Map<String, InterviewToFilingInformationConverter> converterMap,
       String jurisdiction,
-      String env,
+      TylerEnv env,
       Supplier<LoginDatabase> ldSupplier,
       Supplier<CodeDatabase> cdSupplier) {
     this.jurisdiction = jurisdiction;

--- a/proxyserver/src/main/java/edu/suffolk/litlab/efsp/server/services/FirmAttorneyAndServiceService.java
+++ b/proxyserver/src/main/java/edu/suffolk/litlab/efsp/server/services/FirmAttorneyAndServiceService.java
@@ -85,12 +85,11 @@ public class FirmAttorneyAndServiceService {
 
   public FirmAttorneyAndServiceService(
       String jurisdiction,
-      String env,
+      TylerEnv env,
       Supplier<LoginDatabase> ldSupplier,
       Supplier<CodeDatabase> cdSupplier) {
     this.jurisdiction = jurisdiction;
-    Optional<TylerFirmFactory> maybeFirmFactory =
-        TylerClients.getEfmFirmFactory(jurisdiction, TylerEnv.parse(env));
+    Optional<TylerFirmFactory> maybeFirmFactory = TylerClients.getEfmFirmFactory(jurisdiction, env);
     if (maybeFirmFactory.isPresent()) {
       this.firmFactory = maybeFirmFactory.get();
     } else {

--- a/proxyserver/src/main/java/edu/suffolk/litlab/efsp/server/services/PaymentsService.java
+++ b/proxyserver/src/main/java/edu/suffolk/litlab/efsp/server/services/PaymentsService.java
@@ -104,7 +104,7 @@ public class PaymentsService {
 
   public PaymentsService(
       String jurisdiction,
-      String env,
+      TylerEnv env,
       String togaKey,
       String togaUrl,
       Supplier<LoginDatabase> ldSupplier,
@@ -117,7 +117,7 @@ public class PaymentsService {
     this.togaKey = togaKey;
     this.togaUrl = togaUrl;
     this.tempAccounts = new HashMap<String, TempAccount>();
-    var maybeFirmFactory = TylerClients.getEfmFirmFactory(jurisdiction, TylerEnv.parse(env));
+    var maybeFirmFactory = TylerClients.getEfmFirmFactory(jurisdiction, env);
     if (maybeFirmFactory.isPresent()) {
       this.firmFactory = maybeFirmFactory.get();
     } else {

--- a/proxyserver/src/main/java/edu/suffolk/litlab/efsp/server/setup/tyler/Ecf4Filer.java
+++ b/proxyserver/src/main/java/edu/suffolk/litlab/efsp/server/setup/tyler/Ecf4Filer.java
@@ -120,7 +120,7 @@ public class Ecf4Filer extends EfmCheckableFilingInterface {
   private static final PolicyCacher policyCacher = new PolicyCacher();
   private final String jurisdiction;
 
-  public Ecf4Filer(String jurisdiction, String env, Supplier<CodeDatabase> cdSupplier) {
+  public Ecf4Filer(String jurisdiction, TylerEnv env, Supplier<CodeDatabase> cdSupplier) {
     this.jurisdiction = jurisdiction;
     this.cdSupplier = cdSupplier;
     TylerLogin login = new TylerLogin(jurisdiction, env);
@@ -153,8 +153,7 @@ public class Ecf4Filer extends EfmCheckableFilingInterface {
       throw new RuntimeException("Cannot find " + jurisdiction + " for service mde factory");
     }
     this.serviceFactory = maybeServiceFac.get();
-    Optional<TylerFirmFactory> maybeFirmFactory =
-        TylerClients.getEfmFirmFactory(jurisdiction, TylerEnv.parse(env));
+    Optional<TylerFirmFactory> maybeFirmFactory = TylerClients.getEfmFirmFactory(jurisdiction, env);
     if (maybeFirmFactory.isEmpty()) {
       throw new RuntimeException("Cannot find " + jurisdiction + " for firm mde factory");
     }

--- a/proxyserver/src/main/java/edu/suffolk/litlab/efsp/server/setup/tyler/TylerModuleSetup.java
+++ b/proxyserver/src/main/java/edu/suffolk/litlab/efsp/server/setup/tyler/TylerModuleSetup.java
@@ -25,6 +25,7 @@ import edu.suffolk.litlab.efsp.server.utils.ServiceHelpers;
 import edu.suffolk.litlab.efsp.server.utils.SoapX509CallbackHandler;
 import edu.suffolk.litlab.efsp.server.utils.UpdateCodeVersions;
 import edu.suffolk.litlab.efsp.stdlib.StdLib;
+import edu.suffolk.litlab.efsp.tyler.TylerEnv;
 import edu.suffolk.litlab.efsp.utils.InterviewToFilingInformationConverter;
 import java.sql.SQLException;
 import java.util.HashMap;
@@ -67,14 +68,14 @@ public class TylerModuleSetup implements EfmModuleSetup {
   private final String togaUrl;
   private OrgMessageSender sender;
   private Scheduler scheduler;
-  private String tylerEnv;
+  private TylerEnv tylerEnv;
 
   public static class CreationArgs {
     public String pgUrl;
     public String pgDb;
     public String pgUser;
     public String pgPassword;
-    public String tylerEnv;
+    public TylerEnv tylerEnv;
     public String x509Password;
     public String togaUrl;
   }
@@ -82,12 +83,13 @@ public class TylerModuleSetup implements EfmModuleSetup {
   /** Use this factory method instead of the class constructor. */
   public static Optional<TylerModuleSetup> create(
       String jurisdiction,
+      Optional<TylerEnv> env,
       String togaKey,
       Map<String, InterviewToFilingInformationConverter> converterMap,
       DataSource codeDs,
       DataSource userDs,
       OrgMessageSender sender) {
-    Optional<CreationArgs> args = createFromEnvVars();
+    Optional<CreationArgs> args = createFromEnvVars(env);
     if (args.isEmpty()) {
       return Optional.empty();
     }
@@ -120,7 +122,7 @@ public class TylerModuleSetup implements EfmModuleSetup {
     this.sender = sender;
   }
 
-  private static Optional<CreationArgs> createFromEnvVars() {
+  private static Optional<CreationArgs> createFromEnvVars(Optional<TylerEnv> maybeTylerEnv) {
     Optional<String> maybeX509Password = GetEnv("X509_PASSWORD");
     if (maybeX509Password.isEmpty() || maybeX509Password.orElse("").isBlank()) {
       log.warn("If using Tyler, X509_PASSWORD can't be null. Did you forget to source .env?");
@@ -129,12 +131,11 @@ public class TylerModuleSetup implements EfmModuleSetup {
     CreationArgs args = new CreationArgs();
     args.x509Password = maybeX509Password.get();
 
-    Optional<String> maybeTylerEnv = GetEnv("TYLER_ENV");
     if (maybeTylerEnv.isPresent()) {
       log.info("Using {} for TYLER_ENV", maybeTylerEnv.get());
       args.tylerEnv = maybeTylerEnv.get();
     } else {
-      log.info("Not using any TYLER_ENV, maybe prod?");
+      log.error("Not using any TYLER_ENV. Something definitely going to break later");
     }
 
     args.pgUser = GetEnv("POSTGRES_USER").orElse("postgres");
@@ -171,7 +172,12 @@ public class TylerModuleSetup implements EfmModuleSetup {
       cd.createTablesIfAbsent();
       List<String> locations = cd.getAllLocations();
       log.info(
-          "All locations for " + this.tylerJurisdiction + "-" + this.tylerEnv + ": " + locations);
+          "All locations for "
+              + this.tylerJurisdiction
+              + "-"
+              + this.tylerEnv.getPath()
+              + ": "
+              + locations);
       boolean downloadAll = (cd.getAllLocations().size() == 0);
       if (downloadAll) {
         String testOnlyLocation = StdLib.GetEnv("_TEST_ONLY_LOCATION").orElse("");
@@ -279,7 +285,7 @@ public class TylerModuleSetup implements EfmModuleSetup {
     var callbackMap = new HashMap<String, EfmRestCallbackInterface>();
 
     final String jurisdiction = getJurisdiction();
-    final String env = this.tylerEnv;
+    final TylerEnv env = this.tylerEnv;
 
     Supplier<CodeDatabase> cdSupplier =
         () -> {
@@ -420,7 +426,7 @@ public class TylerModuleSetup implements EfmModuleSetup {
     return JobBuilder.newJob(UpdateCodeVersions.class)
         .withIdentity(jobName, "codesdb-group")
         .usingJobData("TYLER_JURISDICTION", this.tylerJurisdiction)
-        .usingJobData("TYLER_ENV", this.tylerEnv)
+        .usingJobData("TYLER_ENV", this.tylerEnv.getPath())
         .usingJobData("X509_PASSWORD", this.x509Password)
         .usingJobData("POSTGRES_URL", this.pgUrl)
         .usingJobData("POSTGRES_DB", this.pgDb)

--- a/proxyserver/src/main/java/edu/suffolk/litlab/efsp/server/utils/UpdateCodeVersions.java
+++ b/proxyserver/src/main/java/edu/suffolk/litlab/efsp/server/utils/UpdateCodeVersions.java
@@ -4,6 +4,7 @@ import edu.suffolk.litlab.efsp.db.DatabaseCreator;
 import edu.suffolk.litlab.efsp.ecfcodes.CodeUpdater;
 import edu.suffolk.litlab.efsp.ecfcodes.tyler.CodeDatabase;
 import edu.suffolk.litlab.efsp.server.logging.Monitor;
+import edu.suffolk.litlab.efsp.tyler.TylerEnv;
 import java.sql.Connection;
 import java.sql.SQLException;
 import java.time.LocalDate;
@@ -38,7 +39,7 @@ public class UpdateCodeVersions implements Job {
   public void execute(JobExecutionContext context) throws JobExecutionException {
     JobDataMap dataMap = context.getJobDetail().getJobDataMap();
     String jurisdiction = dataMap.getString("TYLER_JURISDICTION");
-    String env = dataMap.getString("TYLER_ENV");
+    TylerEnv env = TylerEnv.parse(dataMap.getString("TYLER_ENV"));
     MDC.put(MDCWrappers.OPERATION, "UpdateCodeVersions.execute");
     MDC.put(MDCWrappers.USER_ID, jurisdiction);
     String x509Password = dataMap.getString("X509_PASSWORD");
@@ -67,7 +68,7 @@ public class UpdateCodeVersions implements Job {
               "jurisdiction",
               jurisdiction,
               "env",
-              env,
+              env.getPath(),
               "error_timestamp",
               LocalDate.now().toString()));
     }

--- a/proxyserver/src/test/java/edu/suffolk/litlab/efsp/db/DatabaseVersionTest.java
+++ b/proxyserver/src/test/java/edu/suffolk/litlab/efsp/db/DatabaseVersionTest.java
@@ -6,6 +6,7 @@ import edu.suffolk.litlab.efsp.ecfcodes.tyler.CodeDatabase;
 import edu.suffolk.litlab.efsp.ecfcodes.tyler.FilingComponent;
 import edu.suffolk.litlab.efsp.ecfcodes.tyler.OptionalServiceCode;
 import edu.suffolk.litlab.efsp.ecfcodes.tyler.PartyType;
+import edu.suffolk.litlab.efsp.tyler.TylerEnv;
 import java.io.File;
 import java.io.FileInputStream;
 import java.io.FileNotFoundException;
@@ -139,7 +140,7 @@ public class DatabaseVersionTest {
       assertEquals(rs.getString(1), "illinois-stage");
     }
 
-    try (var codesDatabase = new CodeDatabase("illinois", "stage", codeConn)) {
+    try (var codesDatabase = new CodeDatabase("illinois", TylerEnv.STAGE, codeConn)) {
       List<OptionalServiceCode> opts = codesDatabase.getOptionalServices("adams", "27959");
       assertEquals(23, opts.size());
       List<PartyType> partyTypes = codesDatabase.getPartyTypeFor("adams", "27898");

--- a/proxyserver/src/test/java/edu/suffolk/litlab/efsp/docassemble/DocassembleToFilingInformationConverterTest.java
+++ b/proxyserver/src/test/java/edu/suffolk/litlab/efsp/docassemble/DocassembleToFilingInformationConverterTest.java
@@ -31,7 +31,7 @@ public class DocassembleToFilingInformationConverterTest {
   public void setUp() throws CsvValidationException, IOException {
     converter =
         new DocassembleToFilingInformationConverter(
-            this.getClass().getResourceAsStream("/taxonomy.csv"));
+            this.getClass().getResourceAsStream("/taxonomy.csv"), Optional.empty());
   }
 
   private String getFileContents(String inFileName) throws IOException {

--- a/proxyserver/src/test/java/edu/suffolk/litlab/efsp/ecfcodes/tyler/CodeDatabaseTest.java
+++ b/proxyserver/src/test/java/edu/suffolk/litlab/efsp/ecfcodes/tyler/CodeDatabaseTest.java
@@ -8,6 +8,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 import edu.suffolk.litlab.efsp.db.DatabaseCreator;
 import edu.suffolk.litlab.efsp.db.DatabaseVersionTest;
 import edu.suffolk.litlab.efsp.ecfcodes.CodeUpdater;
+import edu.suffolk.litlab.efsp.tyler.TylerEnv;
 import java.sql.Connection;
 import java.sql.SQLException;
 import java.util.List;
@@ -42,7 +43,7 @@ public class CodeDatabaseTest {
             postgres.getJdbcUrl(),
             postgres.getUsername(),
             postgres.getPassword());
-    cd = new CodeDatabase("illinois", "stage", conn);
+    cd = new CodeDatabase("illinois", TylerEnv.STAGE, conn);
     cd.createTablesIfAbsent();
   }
 

--- a/proxyserver/src/test/java/edu/suffolk/litlab/efsp/server/ecf4/EcfCaseTypeFactoryTest.java
+++ b/proxyserver/src/test/java/edu/suffolk/litlab/efsp/server/ecf4/EcfCaseTypeFactoryTest.java
@@ -114,7 +114,7 @@ public class EcfCaseTypeFactoryTest {
     // EcfCaseTypeFactory caseFactory = new EcfCaseTypeFactory(cd, "illinois");
     EcfCaseTypeFactory.getCriteria();
     InterviewToFilingInformationConverter converter =
-        new DocassembleToFilingInformationConverter(null);
+        new DocassembleToFilingInformationConverter(null, Optional.empty());
     Result<FilingInformation, FilingError> infoRes = converter.extractInformation("");
     assertTrue(infoRes.isErr());
     return;

--- a/proxyserver/src/test/java/edu/suffolk/litlab/efsp/server/services/AdminUserServiceTest.java
+++ b/proxyserver/src/test/java/edu/suffolk/litlab/efsp/server/services/AdminUserServiceTest.java
@@ -13,6 +13,7 @@ import edu.suffolk.litlab.efsp.ecfcodes.tyler.CodeDatabase;
 import edu.suffolk.litlab.efsp.ecfcodes.tyler.CourtLocationInfo;
 import edu.suffolk.litlab.efsp.server.EfspServer;
 import edu.suffolk.litlab.efsp.tyler.TylerClients;
+import edu.suffolk.litlab.efsp.tyler.TylerEnv;
 import edu.suffolk.litlab.efsp.tyler.TylerFirmClient;
 import edu.suffolk.litlab.efsp.tyler.TylerFirmFactory;
 import edu.suffolk.litlab.efsp.tyler.TylerUserClient;
@@ -92,7 +93,7 @@ public class AdminUserServiceTest {
     sf.setResourceProvider(
         AdminUserService.class,
         new SingletonResourceProvider(
-            new AdminUserService("illinois", "stage", () -> ld, () -> cd, passwordChecker)));
+            new AdminUserService("illinois", TylerEnv.STAGE, () -> ld, () -> cd, passwordChecker)));
     sf.setAddress(ENDPOINT_ADDRESS);
     Map<Object, Object> extensionMappings = Map.of("json", MediaType.APPLICATION_JSON);
     sf.setExtensionMappings(extensionMappings);

--- a/proxyserver/src/test/java/edu/suffolk/litlab/efsp/server/services/CodesServiceTest.java
+++ b/proxyserver/src/test/java/edu/suffolk/litlab/efsp/server/services/CodesServiceTest.java
@@ -12,6 +12,7 @@ import edu.suffolk.litlab.efsp.db.DatabaseCreator;
 import edu.suffolk.litlab.efsp.db.DatabaseVersionTest;
 import edu.suffolk.litlab.efsp.ecfcodes.tyler.CodeDatabase;
 import edu.suffolk.litlab.efsp.server.utils.ServiceHelpers;
+import edu.suffolk.litlab.efsp.tyler.TylerEnv;
 import jakarta.ws.rs.core.MediaType;
 import jakarta.ws.rs.core.Response;
 import java.util.List;
@@ -56,7 +57,7 @@ public class CodesServiceTest {
             100);
     Supplier<CodeDatabase> cdSupplier =
         () -> {
-          return CodeDatabase.fromDS("illinois", "stage", ds);
+          return CodeDatabase.fromDS("illinois", TylerEnv.STAGE, ds);
         };
     try (CodeDatabase cd = cdSupplier.get()) {
       cd.createTablesIfAbsent();


### PR DESCRIPTION
Instead of a string, which could be accidentally switched with the Jurisdiction. Shouldn't change any external behavior (i.e. the `TYLER_ENV` var behavior should still be the same, we just parse it into an enum immediately).

Needs to happen before I can refactor to a better config, since we'll be using the tyler env to determine which config to load and use.

Fix #283