### PR TITLE
Use `TylerEnv` on all parsing boundaries

### DIFF
--- a/TylerEfmClient/src/main/java/edu/suffolk/litlab/efsp/tyler/TylerEnv.java
+++ b/TylerEfmClient/src/main/java/edu/suffolk/litlab/efsp/tyler/TylerEnv.java
@@ -7,23 +7,28 @@ public enum TylerEnv {
   /// to "deploy patches and new releases prior to introduction into" PROD
   STAGE("stage");
 
-  private String path;
+  private String name;
 
-  private TylerEnv(String path) {
-    this.path = path;
+  private TylerEnv(String name) {
+    this.name = name;
   }
 
+  // ** Used for when the env determines a URL / filepath. */
   public String getPath() {
-    return path;
+    return name;
+  }
+
+  public String getName() {
+    return name;
   }
 
   public static TylerEnv parse(String value) {
-    if (value.equalsIgnoreCase(STAGE.getPath())) {
+    if (value.equalsIgnoreCase(STAGE.getName())) {
       return STAGE;
-    } else if (value.equalsIgnoreCase(PROD.getPath())) {
+    } else if (value.equalsIgnoreCase(PROD.getName())) {
       return PROD;
     } else {
-      throw new IllegalArgumentException("Can't make a `TylerEnv` from: " + value);
+      throw new IllegalArgumentException("Can't make a `TylerEnv` from: `" + value + "`'");
     }
   }
 }

--- a/proxyserver/src/main/java/edu/suffolk/litlab/efsp/docassemble/DocassembleToFilingInformationConverter.java
+++ b/proxyserver/src/main/java/edu/suffolk/litlab/efsp/docassemble/DocassembleToFilingInformationConverter.java
@@ -5,10 +5,12 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.module.SimpleModule;
 import com.hubspot.algebra.Result;
 import edu.suffolk.litlab.efsp.model.FilingInformation;
+import edu.suffolk.litlab.efsp.tyler.TylerEnv;
 import edu.suffolk.litlab.efsp.utils.FilingError;
 import edu.suffolk.litlab.efsp.utils.InfoCollector;
 import edu.suffolk.litlab.efsp.utils.InterviewToFilingInformationConverter;
 import java.io.InputStream;
+import java.util.Optional;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -16,8 +18,12 @@ public class DocassembleToFilingInformationConverter extends InterviewToFilingIn
 
   private static Logger log =
       LoggerFactory.getLogger(DocassembleToFilingInformationConverter.class);
+  private final Optional<TylerEnv> tylerEnv;
 
-  public DocassembleToFilingInformationConverter(InputStream taxonomyCsv) {}
+  public DocassembleToFilingInformationConverter(
+      InputStream taxonomyCsv, Optional<TylerEnv> tylerEnv) {
+    this.tylerEnv = tylerEnv;
+  }
 
   @Override
   public Result<FilingInformation, FilingError> traverseInterview(
@@ -25,7 +31,8 @@ public class DocassembleToFilingInformationConverter extends InterviewToFilingIn
     SimpleModule module = new SimpleModule();
     module.addDeserializer(
         FilingInformation.class,
-        new FilingInformationDocassembleJacksonDeserializer(FilingInformation.class, collector));
+        new FilingInformationDocassembleJacksonDeserializer(
+            FilingInformation.class, collector, tylerEnv));
     ObjectMapper mapper = new ObjectMapper();
     mapper.registerModule(module);
     try {

--- a/proxyserver/src/main/java/edu/suffolk/litlab/efsp/ecfcodes/tyler/CodeDatabase.java
+++ b/proxyserver/src/main/java/edu/suffolk/litlab/efsp/ecfcodes/tyler/CodeDatabase.java
@@ -2,6 +2,7 @@ package edu.suffolk.litlab.efsp.ecfcodes.tyler;
 
 import edu.suffolk.litlab.efsp.ecfcodes.CodeDatabaseAPI;
 import edu.suffolk.litlab.efsp.stdlib.SQLFunction;
+import edu.suffolk.litlab.efsp.tyler.TylerEnv;
 import jakarta.xml.bind.JAXBException;
 import java.io.InputStream;
 import java.sql.Connection;
@@ -43,12 +44,12 @@ public class CodeDatabase extends CodeDatabaseAPI {
   /** The DNS domain (tyler jurisdiction + tyler environment, illinois-stage). */
   private final String tylerDomain;
 
-  public CodeDatabase(String jurisdiction, String env, Connection conn) {
+  public CodeDatabase(String jurisdiction, TylerEnv env, Connection conn) {
     super(conn);
-    this.tylerDomain = jurisdiction + "-" + env;
+    this.tylerDomain = jurisdiction + "-" + env.getName();
   }
 
-  public static CodeDatabase fromDS(String jurisdiction, String env, DataSource ds) {
+  public static CodeDatabase fromDS(String jurisdiction, TylerEnv env, DataSource ds) {
     try {
       CodeDatabase cd = new CodeDatabase(jurisdiction, env, ds.getConnection());
       return cd;

--- a/proxyserver/src/main/java/edu/suffolk/litlab/efsp/server/EfspServer.java
+++ b/proxyserver/src/main/java/edu/suffolk/litlab/efsp/server/EfspServer.java
@@ -28,6 +28,7 @@ import edu.suffolk.litlab.efsp.server.utils.OrgMessageSender;
 import edu.suffolk.litlab.efsp.server.utils.SendMessage;
 import edu.suffolk.litlab.efsp.server.utils.ServiceHelpers;
 import edu.suffolk.litlab.efsp.server.utils.SoapExceptionMapper;
+import edu.suffolk.litlab.efsp.tyler.TylerEnv;
 import edu.suffolk.litlab.efsp.utils.InterviewToFilingInformationConverter;
 import jakarta.ws.rs.core.MediaType;
 import java.security.NoSuchAlgorithmException;
@@ -194,9 +195,10 @@ public class EfspServer {
 
     setupDatabases(codeDs, userDs);
 
+    Optional<TylerEnv> tylerEnv = GetEnv("TYLER_ENV").map(TylerEnv::parse);
     InterviewToFilingInformationConverter daJsonConverter =
         new DocassembleToFilingInformationConverter(
-            EfspServer.class.getResourceAsStream("/taxonomy.csv"));
+            EfspServer.class.getResourceAsStream("/taxonomy.csv"), tylerEnv);
     Map<String, InterviewToFilingInformationConverter> converterMap =
         Map.of(
             "application/json", daJsonConverter,
@@ -211,7 +213,6 @@ public class EfspServer {
 
     Optional<String> tylerJurisdictions = GetEnv("TYLER_JURISDICTIONS");
     Optional<String> togaKeyStr = GetEnv("TOGA_CLIENT_KEYS");
-    Optional<String> tylerEnv = GetEnv("TYLER_ENV");
     List<String> jurisdictions = List.of(tylerJurisdictions.orElse("").split(" "));
     List<String> togaKeys = List.of(togaKeyStr.orElse("").split(" "));
     if (jurisdictions.size() > 0 && jurisdictions.size() != togaKeys.size()) {

--- a/proxyserver/src/main/java/edu/suffolk/litlab/efsp/server/auth/SecurityHub.java
+++ b/proxyserver/src/main/java/edu/suffolk/litlab/efsp/server/auth/SecurityHub.java
@@ -4,6 +4,7 @@ import com.fasterxml.jackson.databind.JsonNode;
 import edu.suffolk.litlab.efsp.db.LoginDatabase;
 import edu.suffolk.litlab.efsp.db.model.AtRest;
 import edu.suffolk.litlab.efsp.db.model.NewTokens;
+import edu.suffolk.litlab.efsp.tyler.TylerEnv;
 import java.sql.SQLException;
 import java.util.HashMap;
 import java.util.List;
@@ -41,7 +42,7 @@ public class SecurityHub {
    * @param jurisdictions a list of Tyler jurisdictions to connect to. See SoapClientChooser.
    */
   public SecurityHub(
-      Supplier<LoginDatabase> ldSupplier, Optional<String> env, List<String> jurisdictions) {
+      Supplier<LoginDatabase> ldSupplier, Optional<TylerEnv> env, List<String> jurisdictions) {
     this.ldSupplier = ldSupplier;
     if (env.isEmpty() || jurisdictions.isEmpty()) {
       this.tylerLoginObjs = List.of();

--- a/proxyserver/src/main/java/edu/suffolk/litlab/efsp/server/auth/TylerLogin.java
+++ b/proxyserver/src/main/java/edu/suffolk/litlab/efsp/server/auth/TylerLogin.java
@@ -20,10 +20,9 @@ public class TylerLogin implements LoginInterface {
   private static final String HEADER_KEY_PREFIX = "TYLER-TOKEN";
   private final String jurisdiction;
 
-  public TylerLogin(String jurisdiction, String env) {
+  public TylerLogin(String jurisdiction, TylerEnv env) {
     this.jurisdiction = jurisdiction;
-    Optional<TylerUserFactory> maybeUserFactory =
-        TylerClients.getEfmUserFactory(jurisdiction, TylerEnv.parse(env));
+    Optional<TylerUserFactory> maybeUserFactory = TylerClients.getEfmUserFactory(jurisdiction, env);
     if (maybeUserFactory.isPresent()) {
       userServiceFactory = maybeUserFactory.get();
     } else {

--- a/proxyserver/src/main/java/edu/suffolk/litlab/efsp/server/ecf4/SoapClientChooser.java
+++ b/proxyserver/src/main/java/edu/suffolk/litlab/efsp/server/ecf4/SoapClientChooser.java
@@ -1,5 +1,6 @@
 package edu.suffolk.litlab.efsp.server.ecf4;
 
+import edu.suffolk.litlab.efsp.tyler.TylerEnv;
 import https.docs_oasis_open_org.legalxml_courtfiling.ns.v5_0.wsdl.courtschedulingmde.CourtSchedulingMDE_Service;
 import java.net.URL;
 import java.util.Map;
@@ -18,6 +19,7 @@ public class SoapClientChooser {
 
   private static final Logger log = LoggerFactory.getLogger(SoapClientChooser.class);
 
+  // TODO(#284): finish this refactor to use TylerEnvs instead of strings
   static final Map<String, String> serviceMDEWsdls =
       Map.of(
           "illinois-stage", "wsdl/stage/illinois-ECF-4.0-ServiceMDEService.wsdl",
@@ -63,8 +65,8 @@ public class SoapClientChooser {
   }
 
   public static Optional<FilingReviewMDEService> getFilingReviewFactory(
-      String jurisdiction, String env) {
-    return getFilingReviewFactory(jurisdiction + "-" + env);
+      String jurisdiction, TylerEnv env) {
+    return getFilingReviewFactory(jurisdiction + "-" + env.getName());
   }
 
   public static Optional<ServiceMDEService> getServiceFactory(String wsdlDomain) {
@@ -72,8 +74,8 @@ public class SoapClientChooser {
     return url.map(u -> new ServiceMDEService(u));
   }
 
-  public static Optional<ServiceMDEService> getServiceFactory(String jurisdiction, String env) {
-    return getServiceFactory(jurisdiction + "-" + env);
+  public static Optional<ServiceMDEService> getServiceFactory(String jurisdiction, TylerEnv env) {
+    return getServiceFactory(jurisdiction + "-" + env.getName());
   }
 
   public static Optional<CourtRecordMDEService> getCourtRecordFactory(String wsdlDomain) {
@@ -82,8 +84,8 @@ public class SoapClientChooser {
   }
 
   public static Optional<CourtRecordMDEService> getCourtRecordFactory(
-      String jurisdiction, String env) {
-    return getCourtRecordFactory(jurisdiction + "-" + env);
+      String jurisdiction, TylerEnv env) {
+    return getCourtRecordFactory(jurisdiction + "-" + env.getName());
   }
 
   public static Optional<CourtSchedulingMDE_Service> getCourtSchedulingFactory(String wsdlDomain) {
@@ -92,8 +94,8 @@ public class SoapClientChooser {
   }
 
   public static Optional<CourtSchedulingMDE_Service> getCourtSchedulingFactory(
-      String jurisdiction, String env) {
-    return getCourtSchedulingFactory(jurisdiction + "-" + env);
+      String jurisdiction, TylerEnv env) {
+    return getCourtSchedulingFactory(jurisdiction + "-" + env.getName());
   }
 
   private static Optional<URL> urlFromString(String wsdlDomain, Map<String, String> domainToWsdl) {

--- a/proxyserver/src/main/java/edu/suffolk/litlab/efsp/server/services/AdminUserService.java
+++ b/proxyserver/src/main/java/edu/suffolk/litlab/efsp/server/services/AdminUserService.java
@@ -123,21 +123,19 @@ public class AdminUserService {
 
   public AdminUserService(
       String jurisdiction,
-      String env,
+      TylerEnv env,
       Supplier<LoginDatabase> ldSupplier,
       Supplier<CodeDatabase> cdSupplier,
       Function<String, Result<NullValue, String>> passwordChecker) {
     this.jurisdiction = jurisdiction;
     this.passwordChecker = passwordChecker;
-    Optional<TylerUserFactory> maybeUserFactory =
-        TylerClients.getEfmUserFactory(jurisdiction, TylerEnv.parse(env));
+    Optional<TylerUserFactory> maybeUserFactory = TylerClients.getEfmUserFactory(jurisdiction, env);
     if (maybeUserFactory.isEmpty()) {
       throw new RuntimeException(
           "Can't find " + jurisdiction + " in the SoapClientChooser for EfmUser");
     }
     this.userFactory = maybeUserFactory.get();
-    Optional<TylerFirmFactory> maybeFirmFactory =
-        TylerClients.getEfmFirmFactory(jurisdiction, TylerEnv.parse(env));
+    Optional<TylerFirmFactory> maybeFirmFactory = TylerClients.getEfmFirmFactory(jurisdiction, env);
     if (maybeFirmFactory.isEmpty()) {
       throw new RuntimeException(
           "Can't find " + jurisdiction + " in the SoapClientChooser for EfmFirm factory");

--- a/proxyserver/src/main/java/edu/suffolk/litlab/efsp/server/services/CasesService.java
+++ b/proxyserver/src/main/java/edu/suffolk/litlab/efsp/server/services/CasesService.java
@@ -16,6 +16,7 @@ import edu.suffolk.litlab.efsp.server.ecf4.SoapClientChooser;
 import edu.suffolk.litlab.efsp.server.utils.EndpointReflection;
 import edu.suffolk.litlab.efsp.server.utils.MDCWrappers;
 import edu.suffolk.litlab.efsp.server.utils.ServiceHelpers;
+import edu.suffolk.litlab.efsp.tyler.TylerEnv;
 import edu.suffolk.litlab.efsp.tyler.TylerUserNamePassword;
 import gov.niem.niem.niem_core._2.CaseType;
 import gov.niem.niem.niem_core._2.EntityType;
@@ -82,7 +83,7 @@ public class CasesService {
 
   public CasesService(
       String jurisdiction,
-      String env,
+      TylerEnv env,
       Supplier<LoginDatabase> ldSupplier,
       Supplier<CodeDatabase> cdSupplier) {
     this.jurisdiction = jurisdiction;

--- a/proxyserver/src/main/java/edu/suffolk/litlab/efsp/server/services/CourtSchedulingService.java
+++ b/proxyserver/src/main/java/edu/suffolk/litlab/efsp/server/services/CourtSchedulingService.java
@@ -25,6 +25,7 @@ import edu.suffolk.litlab.efsp.server.utils.Ecfv5XmlHelper;
 import edu.suffolk.litlab.efsp.server.utils.EndpointReflection;
 import edu.suffolk.litlab.efsp.server.utils.MDCWrappers;
 import edu.suffolk.litlab.efsp.server.utils.ServiceHelpers;
+import edu.suffolk.litlab.efsp.tyler.TylerEnv;
 import edu.suffolk.litlab.efsp.tyler.TylerUserNamePassword;
 import edu.suffolk.litlab.efsp.utils.FailFastCollector;
 import edu.suffolk.litlab.efsp.utils.FilingError;
@@ -106,7 +107,7 @@ public class CourtSchedulingService {
   public CourtSchedulingService(
       Map<String, InterviewToFilingInformationConverter> converterMap,
       String jurisdiction,
-      String env,
+      TylerEnv env,
       Supplier<LoginDatabase> ldSupplier,
       Supplier<CodeDatabase> cdSupplier) {
     this.jurisdiction = jurisdiction;

--- a/proxyserver/src/main/java/edu/suffolk/litlab/efsp/server/services/FirmAttorneyAndServiceService.java
+++ b/proxyserver/src/main/java/edu/suffolk/litlab/efsp/server/services/FirmAttorneyAndServiceService.java
@@ -85,12 +85,11 @@ public class FirmAttorneyAndServiceService {
 
   public FirmAttorneyAndServiceService(
       String jurisdiction,
-      String env,
+      TylerEnv env,
       Supplier<LoginDatabase> ldSupplier,
       Supplier<CodeDatabase> cdSupplier) {
     this.jurisdiction = jurisdiction;
-    Optional<TylerFirmFactory> maybeFirmFactory =
-        TylerClients.getEfmFirmFactory(jurisdiction, TylerEnv.parse(env));
+    Optional<TylerFirmFactory> maybeFirmFactory = TylerClients.getEfmFirmFactory(jurisdiction, env);
     if (maybeFirmFactory.isPresent()) {
       this.firmFactory = maybeFirmFactory.get();
     } else {

--- a/proxyserver/src/main/java/edu/suffolk/litlab/efsp/server/services/PaymentsService.java
+++ b/proxyserver/src/main/java/edu/suffolk/litlab/efsp/server/services/PaymentsService.java
@@ -104,7 +104,7 @@ public class PaymentsService {
 
   public PaymentsService(
       String jurisdiction,
-      String env,
+      TylerEnv env,
       String togaKey,
       String togaUrl,
       Supplier<LoginDatabase> ldSupplier,
@@ -117,7 +117,7 @@ public class PaymentsService {
     this.togaKey = togaKey;
     this.togaUrl = togaUrl;
     this.tempAccounts = new HashMap<String, TempAccount>();
-    var maybeFirmFactory = TylerClients.getEfmFirmFactory(jurisdiction, TylerEnv.parse(env));
+    var maybeFirmFactory = TylerClients.getEfmFirmFactory(jurisdiction, env);
     if (maybeFirmFactory.isPresent()) {
       this.firmFactory = maybeFirmFactory.get();
     } else {

--- a/proxyserver/src/main/java/edu/suffolk/litlab/efsp/server/setup/tyler/Ecf4Filer.java
+++ b/proxyserver/src/main/java/edu/suffolk/litlab/efsp/server/setup/tyler/Ecf4Filer.java
@@ -120,7 +120,7 @@ public class Ecf4Filer extends EfmCheckableFilingInterface {
   private static final PolicyCacher policyCacher = new PolicyCacher();
   private final String jurisdiction;
 
-  public Ecf4Filer(String jurisdiction, String env, Supplier<CodeDatabase> cdSupplier) {
+  public Ecf4Filer(String jurisdiction, TylerEnv env, Supplier<CodeDatabase> cdSupplier) {
     this.jurisdiction = jurisdiction;
     this.cdSupplier = cdSupplier;
     TylerLogin login = new TylerLogin(jurisdiction, env);
@@ -153,8 +153,7 @@ public class Ecf4Filer extends EfmCheckableFilingInterface {
       throw new RuntimeException("Cannot find " + jurisdiction + " for service mde factory");
     }
     this.serviceFactory = maybeServiceFac.get();
-    Optional<TylerFirmFactory> maybeFirmFactory =
-        TylerClients.getEfmFirmFactory(jurisdiction, TylerEnv.parse(env));
+    var maybeFirmFactory = TylerClients.getEfmFirmFactory(jurisdiction, env);
     if (maybeFirmFactory.isEmpty()) {
       throw new RuntimeException("Cannot find " + jurisdiction + " for firm mde factory");
     }

--- a/proxyserver/src/main/java/edu/suffolk/litlab/efsp/server/setup/tyler/TylerModuleSetup.java
+++ b/proxyserver/src/main/java/edu/suffolk/litlab/efsp/server/setup/tyler/TylerModuleSetup.java
@@ -25,6 +25,7 @@ import edu.suffolk.litlab.efsp.server.utils.ServiceHelpers;
 import edu.suffolk.litlab.efsp.server.utils.SoapX509CallbackHandler;
 import edu.suffolk.litlab.efsp.server.utils.UpdateCodeVersions;
 import edu.suffolk.litlab.efsp.stdlib.StdLib;
+import edu.suffolk.litlab.efsp.tyler.TylerEnv;
 import edu.suffolk.litlab.efsp.utils.InterviewToFilingInformationConverter;
 import java.sql.SQLException;
 import java.util.HashMap;
@@ -67,14 +68,14 @@ public class TylerModuleSetup implements EfmModuleSetup {
   private final String togaUrl;
   private OrgMessageSender sender;
   private Scheduler scheduler;
-  private String tylerEnv;
+  private TylerEnv tylerEnv;
 
   public static class CreationArgs {
     public String pgUrl;
     public String pgDb;
     public String pgUser;
     public String pgPassword;
-    public String tylerEnv;
+    public TylerEnv tylerEnv;
     public String x509Password;
     public String togaUrl;
   }
@@ -129,7 +130,7 @@ public class TylerModuleSetup implements EfmModuleSetup {
     CreationArgs args = new CreationArgs();
     args.x509Password = maybeX509Password.get();
 
-    Optional<String> maybeTylerEnv = GetEnv("TYLER_ENV");
+    Optional<TylerEnv> maybeTylerEnv = GetEnv("TYLER_ENV").map(TylerEnv::parse);
     if (maybeTylerEnv.isPresent()) {
       log.info("Using {} for TYLER_ENV", maybeTylerEnv.get());
       args.tylerEnv = maybeTylerEnv.get();
@@ -279,7 +280,7 @@ public class TylerModuleSetup implements EfmModuleSetup {
     var callbackMap = new HashMap<String, EfmRestCallbackInterface>();
 
     final String jurisdiction = getJurisdiction();
-    final String env = this.tylerEnv;
+    final TylerEnv env = this.tylerEnv;
 
     Supplier<CodeDatabase> cdSupplier =
         () -> {
@@ -420,7 +421,7 @@ public class TylerModuleSetup implements EfmModuleSetup {
     return JobBuilder.newJob(UpdateCodeVersions.class)
         .withIdentity(jobName, "codesdb-group")
         .usingJobData("TYLER_JURISDICTION", this.tylerJurisdiction)
-        .usingJobData("TYLER_ENV", this.tylerEnv)
+        .usingJobData("TYLER_ENV", this.tylerEnv.getName())
         .usingJobData("X509_PASSWORD", this.x509Password)
         .usingJobData("POSTGRES_URL", this.pgUrl)
         .usingJobData("POSTGRES_DB", this.pgDb)

--- a/proxyserver/src/main/java/edu/suffolk/litlab/efsp/server/utils/UpdateCodeVersions.java
+++ b/proxyserver/src/main/java/edu/suffolk/litlab/efsp/server/utils/UpdateCodeVersions.java
@@ -4,6 +4,7 @@ import edu.suffolk.litlab.efsp.db.DatabaseCreator;
 import edu.suffolk.litlab.efsp.ecfcodes.CodeUpdater;
 import edu.suffolk.litlab.efsp.ecfcodes.tyler.CodeDatabase;
 import edu.suffolk.litlab.efsp.server.logging.Monitor;
+import edu.suffolk.litlab.efsp.tyler.TylerEnv;
 import java.sql.Connection;
 import java.sql.SQLException;
 import java.time.LocalDate;
@@ -38,7 +39,7 @@ public class UpdateCodeVersions implements Job {
   public void execute(JobExecutionContext context) throws JobExecutionException {
     JobDataMap dataMap = context.getJobDetail().getJobDataMap();
     String jurisdiction = dataMap.getString("TYLER_JURISDICTION");
-    String env = dataMap.getString("TYLER_ENV");
+    TylerEnv env = TylerEnv.parse(dataMap.getString("TYLER_ENV"));
     MDC.put(MDCWrappers.OPERATION, "UpdateCodeVersions.execute");
     MDC.put(MDCWrappers.USER_ID, jurisdiction);
     String x509Password = dataMap.getString("X509_PASSWORD");

--- a/proxyserver/src/test/java/edu/suffolk/litlab/efsp/db/DatabaseVersionTest.java
+++ b/proxyserver/src/test/java/edu/suffolk/litlab/efsp/db/DatabaseVersionTest.java
@@ -6,6 +6,7 @@ import edu.suffolk.litlab.efsp.ecfcodes.tyler.CodeDatabase;
 import edu.suffolk.litlab.efsp.ecfcodes.tyler.FilingComponent;
 import edu.suffolk.litlab.efsp.ecfcodes.tyler.OptionalServiceCode;
 import edu.suffolk.litlab.efsp.ecfcodes.tyler.PartyType;
+import edu.suffolk.litlab.efsp.tyler.TylerEnv;
 import java.io.File;
 import java.io.FileInputStream;
 import java.io.FileNotFoundException;
@@ -139,7 +140,7 @@ public class DatabaseVersionTest {
       assertEquals(rs.getString(1), "illinois-stage");
     }
 
-    try (var codesDatabase = new CodeDatabase("illinois", "stage", codeConn)) {
+    try (var codesDatabase = new CodeDatabase("illinois", TylerEnv.STAGE, codeConn)) {
       List<OptionalServiceCode> opts = codesDatabase.getOptionalServices("adams", "27959");
       assertEquals(23, opts.size());
       List<PartyType> partyTypes = codesDatabase.getPartyTypeFor("adams", "27898");

--- a/proxyserver/src/test/java/edu/suffolk/litlab/efsp/docassemble/DocassembleToFilingInformationConverterTest.java
+++ b/proxyserver/src/test/java/edu/suffolk/litlab/efsp/docassemble/DocassembleToFilingInformationConverterTest.java
@@ -11,6 +11,7 @@ import com.opencsv.exceptions.CsvValidationException;
 import edu.suffolk.litlab.efsp.model.FilingDoc;
 import edu.suffolk.litlab.efsp.model.FilingInformation;
 import edu.suffolk.litlab.efsp.model.Person;
+import edu.suffolk.litlab.efsp.tyler.TylerEnv;
 import edu.suffolk.litlab.efsp.utils.FilingError;
 import edu.suffolk.litlab.efsp.utils.InterviewToFilingInformationConverter;
 import edu.suffolk.litlab.efsp.utils.InterviewVariable;
@@ -31,7 +32,7 @@ public class DocassembleToFilingInformationConverterTest {
   public void setUp() throws CsvValidationException, IOException {
     converter =
         new DocassembleToFilingInformationConverter(
-            this.getClass().getResourceAsStream("/taxonomy.csv"));
+            this.getClass().getResourceAsStream("/taxonomy.csv"), Optional.of(TylerEnv.STAGE));
   }
 
   private String getFileContents(String inFileName) throws IOException {

--- a/proxyserver/src/test/java/edu/suffolk/litlab/efsp/ecfcodes/tyler/CodeDatabaseTest.java
+++ b/proxyserver/src/test/java/edu/suffolk/litlab/efsp/ecfcodes/tyler/CodeDatabaseTest.java
@@ -8,6 +8,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 import edu.suffolk.litlab.efsp.db.DatabaseCreator;
 import edu.suffolk.litlab.efsp.db.DatabaseVersionTest;
 import edu.suffolk.litlab.efsp.ecfcodes.CodeUpdater;
+import edu.suffolk.litlab.efsp.tyler.TylerEnv;
 import java.sql.Connection;
 import java.sql.SQLException;
 import java.util.List;
@@ -42,7 +43,7 @@ public class CodeDatabaseTest {
             postgres.getJdbcUrl(),
             postgres.getUsername(),
             postgres.getPassword());
-    cd = new CodeDatabase("illinois", "stage", conn);
+    cd = new CodeDatabase("illinois", TylerEnv.STAGE, conn);
     cd.createTablesIfAbsent();
   }
 

--- a/proxyserver/src/test/java/edu/suffolk/litlab/efsp/server/auth/SecurityHubTest.java
+++ b/proxyserver/src/test/java/edu/suffolk/litlab/efsp/server/auth/SecurityHubTest.java
@@ -12,6 +12,7 @@ import edu.suffolk.litlab.efsp.db.LoginDatabase;
 import edu.suffolk.litlab.efsp.db.model.AtRest;
 import edu.suffolk.litlab.efsp.db.model.NewTokens;
 import edu.suffolk.litlab.efsp.tyler.TylerClients;
+import edu.suffolk.litlab.efsp.tyler.TylerEnv;
 import edu.suffolk.litlab.efsp.tyler.TylerUserClient;
 import edu.suffolk.litlab.efsp.tyler.TylerUserFactory;
 import java.util.List;
@@ -56,7 +57,7 @@ public class SecurityHubTest {
   @BeforeEach
   public void setup() {
     ld = mock(LoginDatabase.class);
-    hub = new SecurityHub(() -> ld, Optional.of("stage"), List.of("illinois"));
+    hub = new SecurityHub(() -> ld, Optional.of(TylerEnv.STAGE), List.of("illinois"));
   }
 
   @Test

--- a/proxyserver/src/test/java/edu/suffolk/litlab/efsp/server/ecf4/EcfCaseTypeFactoryTest.java
+++ b/proxyserver/src/test/java/edu/suffolk/litlab/efsp/server/ecf4/EcfCaseTypeFactoryTest.java
@@ -15,6 +15,7 @@ import edu.suffolk.litlab.efsp.ecfcodes.tyler.DataFieldRow;
 import edu.suffolk.litlab.efsp.model.FilingInformation;
 import edu.suffolk.litlab.efsp.model.PartyId;
 import edu.suffolk.litlab.efsp.model.Person;
+import edu.suffolk.litlab.efsp.tyler.TylerEnv;
 import edu.suffolk.litlab.efsp.utils.FailFastCollector;
 import edu.suffolk.litlab.efsp.utils.FilingError;
 import edu.suffolk.litlab.efsp.utils.InfoCollector;
@@ -114,7 +115,7 @@ public class EcfCaseTypeFactoryTest {
     // EcfCaseTypeFactory caseFactory = new EcfCaseTypeFactory(cd, "illinois");
     EcfCaseTypeFactory.getCriteria();
     InterviewToFilingInformationConverter converter =
-        new DocassembleToFilingInformationConverter(null);
+        new DocassembleToFilingInformationConverter(null, Optional.of(TylerEnv.STAGE));
     Result<FilingInformation, FilingError> infoRes = converter.extractInformation("");
     assertTrue(infoRes.isErr());
     return;

--- a/proxyserver/src/test/java/edu/suffolk/litlab/efsp/server/services/AdminUserServiceTest.java
+++ b/proxyserver/src/test/java/edu/suffolk/litlab/efsp/server/services/AdminUserServiceTest.java
@@ -13,6 +13,7 @@ import edu.suffolk.litlab.efsp.ecfcodes.tyler.CodeDatabase;
 import edu.suffolk.litlab.efsp.ecfcodes.tyler.CourtLocationInfo;
 import edu.suffolk.litlab.efsp.server.EfspServer;
 import edu.suffolk.litlab.efsp.tyler.TylerClients;
+import edu.suffolk.litlab.efsp.tyler.TylerEnv;
 import edu.suffolk.litlab.efsp.tyler.TylerFirmClient;
 import edu.suffolk.litlab.efsp.tyler.TylerFirmFactory;
 import edu.suffolk.litlab.efsp.tyler.TylerUserClient;
@@ -93,7 +94,7 @@ public class AdminUserServiceTest {
     sf.setResourceProvider(
         AdminUserService.class,
         new SingletonResourceProvider(
-            new AdminUserService("illinois", "stage", () -> ld, () -> cd, passwordChecker)));
+            new AdminUserService("illinois", TylerEnv.STAGE, () -> ld, () -> cd, passwordChecker)));
     sf.setAddress(ENDPOINT_ADDRESS);
     Map<Object, Object> extensionMappings = Map.of("json", MediaType.APPLICATION_JSON);
     sf.setExtensionMappings(extensionMappings);

--- a/proxyserver/src/test/java/edu/suffolk/litlab/efsp/server/services/CodesServiceTest.java
+++ b/proxyserver/src/test/java/edu/suffolk/litlab/efsp/server/services/CodesServiceTest.java
@@ -12,6 +12,7 @@ import edu.suffolk.litlab.efsp.db.DatabaseCreator;
 import edu.suffolk.litlab.efsp.db.DatabaseVersionTest;
 import edu.suffolk.litlab.efsp.ecfcodes.tyler.CodeDatabase;
 import edu.suffolk.litlab.efsp.server.utils.ServiceHelpers;
+import edu.suffolk.litlab.efsp.tyler.TylerEnv;
 import jakarta.ws.rs.core.MediaType;
 import jakarta.ws.rs.core.Response;
 import java.util.List;
@@ -56,7 +57,7 @@ public class CodesServiceTest {
             100);
     Supplier<CodeDatabase> cdSupplier =
         () -> {
-          return CodeDatabase.fromDS("illinois", "stage", ds);
+          return CodeDatabase.fromDS("illinois", TylerEnv.STAGE, ds);
         };
     try (CodeDatabase cd = cdSupplier.get()) {
       cd.createTablesIfAbsent();


### PR DESCRIPTION
I.e., anytime we read the env var, immediately turn it into the enum. Throws a quick `IllegalArgumentExeception` at those points, so the server should immediately stop if invalid.

 * also exposes the hack that the JSON parser depends on if Tyler's env is stage or prod. This is something that we still need to resolve elsewhere, but at least we aren't grabbing env vars deep inside that class anymore.

The only place that could have had more refactorings but didn't was `SoapClientChooser`. Could have introduced a String jurisdiction TylerEnv object to handle the mappings instead of a single string, but I would have had to retype all of the jurisdiction keys, which would have meant potential unnecessary errors.

A second attempt at #293, which got too big (had tried to include jurisdiction to fix the `SoapClientChooser` as described above, but jurisdiction has a much larger footprint, and needs to handle non-Tyler jurisdictions as well, becomes dependent on deprecating JeffNet code, etc.).

Fix #283.