### PR TITLE
Don't pass nulls instead of env

### DIFF
--- a/proxyserver/src/main/java/edu/suffolk/litlab/efsp/server/EfspServer.java
+++ b/proxyserver/src/main/java/edu/suffolk/litlab/efsp/server/EfspServer.java
@@ -121,7 +121,7 @@ public class EfspServer {
    *
    * @throws InterruptedException
    */
-  private static void setupDatabases(DataSource codeDs, DataSource userDs)
+  private static void setupDatabases(DataSource codeDs, DataSource userDs, Optional<TylerEnv> env)
       throws NoSuchAlgorithmException, InterruptedException {
 
     // Update / make the latest definition of the databases if necessary
@@ -132,7 +132,7 @@ public class EfspServer {
       LoginDatabase ld = new LoginDatabase(userConn);
       @SuppressWarnings("resource")
       // Jurisdiction and env args can be null, we're just making the tables
-      CodeDatabase cd = new CodeDatabase(null, null, codeConn);
+      CodeDatabase cd = new CodeDatabase(null, env.orElse(TylerEnv.STAGE), codeConn);
       boolean brandNew = !ld.tablesExist() || !cd.tablesExist();
 
       // Now we can tell if everything is being set up fresh. If so, we'll make everything now.
@@ -193,9 +193,9 @@ public class EfspServer {
         DatabaseCreator.makeDataSource(
             dbUrl, dbPortInt, userDatabaseName, dbUser, dbPassword, 7, 100);
 
-    setupDatabases(codeDs, userDs);
-
     Optional<TylerEnv> tylerEnv = GetEnv("TYLER_ENV").map(TylerEnv::parse);
+    setupDatabases(codeDs, userDs, tylerEnv);
+
     InterviewToFilingInformationConverter daJsonConverter =
         new DocassembleToFilingInformationConverter(
             EfspServer.class.getResourceAsStream("/taxonomy.csv"), tylerEnv);


### PR DESCRIPTION
Wonderful choice by me only a few months ago to pass null instead of the TylerEnv to the CodeDatabase when starting up, just to make tables; switching to an actual object means we null pointer exeption immediately.

Not sure how no tests didn't catch this, will need to fix that.

Fixes introduced in #296 