### PR TITLE
Better JsonExtractException stacktraces

### DIFF
--- a/proxyserver/src/main/java/edu/suffolk/litlab/efsp/docassemble/JsonExtractException.java
+++ b/proxyserver/src/main/java/edu/suffolk/litlab/efsp/docassemble/JsonExtractException.java
@@ -10,7 +10,7 @@ public class JsonExtractException extends JsonParseException {
   private static final long serialVersionUID = 1L;
 
   public JsonExtractException(JsonParser p, FilingError err) {
-    super(p, err.toString());
+    super(p, err.toString(), err);
     this.err = err;
   }
 


### PR DESCRIPTION
Just needed to pass the throwable to the parent class.