### PR TITLE
Pass `CodeUpdater` a Supplier, not a CodeDatabase

### DIFF
--- a/proxyserver/src/main/java/edu/suffolk/litlab/efsp/server/setup/tyler/TylerModuleSetup.java
+++ b/proxyserver/src/main/java/edu/suffolk/litlab/efsp/server/setup/tyler/TylerModuleSetup.java
@@ -184,7 +184,7 @@ public class TylerModuleSetup implements EfmModuleSetup {
                   + tylerJurisdiction
                   + ": please wait a bit");
           CodeUpdater.executeCommand(
-              cd,
+              () -> cd,
               tylerJurisdiction,
               tylerEnv,
               List.of("replacesome", testOnlyLocation),
@@ -192,7 +192,7 @@ public class TylerModuleSetup implements EfmModuleSetup {
         } else {
           log.info("Downloading all codes for {}: please wait a bit", tylerJurisdiction);
           CodeUpdater.executeCommand(
-              cd, tylerJurisdiction, tylerEnv, List.of("replaceall"), this.x509Password);
+              () -> cd, tylerJurisdiction, tylerEnv, List.of("replaceall"), this.x509Password);
         }
       }
     } catch (SQLException e) {

--- a/proxyserver/src/main/java/edu/suffolk/litlab/efsp/server/utils/UpdateCodeVersions.java
+++ b/proxyserver/src/main/java/edu/suffolk/litlab/efsp/server/utils/UpdateCodeVersions.java
@@ -53,7 +53,8 @@ public class UpdateCodeVersions implements Job {
     try (Connection conn =
             DatabaseCreator.makeSingleConnection(pgDb, pgFullUrl, pgUser, pgPassword);
         CodeDatabase cd = new CodeDatabase(jurisdiction, env, conn)) {
-      success = CodeUpdater.executeCommand(cd, jurisdiction, env, List.of("refresh"), x509Password);
+      success =
+          CodeUpdater.executeCommand(() -> cd, jurisdiction, env, List.of("refresh"), x509Password);
     } catch (SQLException e) {
       log.error("Couldn't connect to Codes db from Job Executor: ", e);
       success = false;


### PR DESCRIPTION
Some operations (specifically `downloadIndividual` [^1]) don't need the CodeDatabase. However, the SQL data source is always created, so you need valid env vars for a SQL database, even if not used.

This patch changes it so that isn't the case; if the operation you're trying to run manually doesn't use a SQL database, the variables are not required.

[^1]: `downloadInidivdual` gets individual XML files from courts (necessary for `repcap`, an undocumented table which breaks things), and doesn't directly interact with any of the SQL tables themselves.