### PR TITLE
Notice table names that we don't handle yet

### DIFF
--- a/proxyserver/src/main/java/edu/suffolk/litlab/efsp/ecfcodes/tyler/CodeDatabase.java
+++ b/proxyserver/src/main/java/edu/suffolk/litlab/efsp/ecfcodes/tyler/CodeDatabase.java
@@ -1,6 +1,7 @@
 package edu.suffolk.litlab.efsp.ecfcodes.tyler;
 
 import edu.suffolk.litlab.efsp.ecfcodes.CodeDatabaseAPI;
+import edu.suffolk.litlab.efsp.ecfcodes.tyler.CodeTableConstants.UnsupportedTableException;
 import edu.suffolk.litlab.efsp.stdlib.SQLFunction;
 import edu.suffolk.litlab.efsp.tyler.TylerEnv;
 import jakarta.xml.bind.JAXBException;
@@ -106,10 +107,6 @@ public class CodeDatabase extends CodeDatabaseAPI {
           OptionalServiceCode.createFromOptionalServiceTable(conn);
         } else {
           String createQuery = CodeTableConstants.getCreateTable(tableName);
-          if (createQuery.isEmpty()) {
-            log.warn("Will not create table with name: {}", tableName);
-            return;
-          }
           try (Statement createSt = conn.createStatement()) {
             log.info("Full statement: {}", createQuery);
             createSt.executeUpdate(createQuery);
@@ -190,6 +187,9 @@ public class CodeDatabase extends CodeDatabaseAPI {
       update.setString(4, tylerDomain);
       update.setString(5, newVersion);
       update.executeUpdate();
+    } catch (UnsupportedTableException ex) {
+      log.error("Silently ignoring a missing table exception.", ex);
+      return;
     } catch (SQLException ex) {
       log.error("Tried to execute an insert, but failed! Exception", ex);
       log.error("Going to rollback updates to this table");

--- a/proxyserver/src/main/java/edu/suffolk/litlab/efsp/ecfcodes/tyler/CodeTableConstants.java
+++ b/proxyserver/src/main/java/edu/suffolk/litlab/efsp/ecfcodes/tyler/CodeTableConstants.java
@@ -1,5 +1,6 @@
 package edu.suffolk.litlab.efsp.ecfcodes.tyler;
 
+import java.sql.SQLException;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
@@ -451,15 +452,22 @@ public class CodeTableConstants {
     return "VACUUM ANALYZE";
   }
 
+  /** This exception is returned when a given table name isn't in the pre-approved list of names. */
+  public static class UnsupportedTableException extends SQLException {
+    public UnsupportedTableException(String message) {
+      super(message);
+    }
+  }
+
   public static boolean tableHasLocation(String tableName) {
     return tableColumns.containsKey(tableName) && tableColumns.get(tableName).needsExtraLocCol;
   }
 
-  public static String getCreateTable(String tableName) {
+  public static String getCreateTable(String tableName) throws UnsupportedTableException {
     if (createQueries.containsKey(tableName)) {
       return createQueries.get(tableName);
     }
-    return "";
+    throw new UnsupportedTableException("No create query for table " + tableName);
   }
 
   public static List<String> getCreateIndex(String tableName) {
@@ -469,23 +477,23 @@ public class CodeTableConstants {
     return tableIndices.get(tableName);
   }
   
-  public static String getInsertInto(String tableName) {
+  public static String getInsertInto(String tableName) throws UnsupportedTableException {
     if (!insertQueries.containsKey(tableName)) {
-      return "";
+      throw new UnsupportedTableException("No insert query for table " + tableName);
     }
     return insertQueries.get(tableName);
   }
   
-  public static String getDeleteFrom(String tableName) {
+  public static String getDeleteFrom(String tableName) throws UnsupportedTableException {
     if (!deleteFromQueries.containsKey(tableName)) {
-      return "";
+      throw new UnsupportedTableException("No 'delete from' query for table " + tableName);
     }
     return deleteFromQueries.get(tableName);
   }
 
-  public static String getDeleteAllCourtsFrom(String tableName) {
+  public static String getDeleteAllCourtsFrom(String tableName) throws UnsupportedTableException {
     if (!deleteAllCourtsFromQueries.containsKey(tableName)) {
-      return "";
+      throw new UnsupportedTableException("No 'delete all courts from' query for table " + tableName);
     }
     return deleteAllCourtsFromQueries.get(tableName);
   }


### PR DESCRIPTION
Adds a new exception to look for (a subclass of SQLException, so no interfaces are changed yet), and stops trying to deal with tables that we don't handle (looking at you, `repcap`).

Previously, we would skip creating them, but then would fail when trying to insert values into them. This PR fixes that issue by removing the unsupported tables from the list to update.