### PR TITLE
Adding court coverage to code search endpoints

### DIFF
--- a/proxyserver/src/main/java/edu/suffolk/litlab/efsp/ecfcodes/tyler/CaseCategory.java
+++ b/proxyserver/src/main/java/edu/suffolk/litlab/efsp/ecfcodes/tyler/CaseCategory.java
@@ -105,6 +105,15 @@ public class CaseCategory {
     """;
   }
 
+  public static String courtCoverageCaseCategories() {
+    return """
+    SELECT DISTINCT location
+    FROM casecategory
+    WHERE domain=? AND name ILIKE ?
+    ORDER BY location
+    """;
+  }
+
   public static String retrieveCaseCategoryForName() {
     return """
     SELECT DISTINCT code, location

--- a/proxyserver/src/main/java/edu/suffolk/litlab/efsp/ecfcodes/tyler/CaseType.java
+++ b/proxyserver/src/main/java/edu/suffolk/litlab/efsp/ecfcodes/tyler/CaseType.java
@@ -162,6 +162,21 @@ public class CaseType {
     return st;
   }
 
+  public static PreparedStatement prepCourtCoverage(
+      Connection conn, String domain, String searchTerm) throws SQLException {
+    String search =
+        """
+        SELECT DISTINCT location
+        FROM casetype
+        WHERE domain=? AND name ILIKE ?
+        ORDER BY location
+        """;
+    PreparedStatement st = conn.prepareStatement(search);
+    st.setString(1, domain);
+    st.setString(2, searchTerm);
+    return st;
+  }
+
   public static PreparedStatement prepRetrieveQuery(
       Connection conn, String domain, String caseTypeName) throws SQLException {
     String retrieve =

--- a/proxyserver/src/main/java/edu/suffolk/litlab/efsp/ecfcodes/tyler/CodeDatabase.java
+++ b/proxyserver/src/main/java/edu/suffolk/litlab/efsp/ecfcodes/tyler/CodeDatabase.java
@@ -631,6 +631,22 @@ public class CodeDatabase extends CodeDatabaseAPI {
         });
   }
 
+  public List<String> courtCoverageFilingType(String searchTerm) {
+    String finalSearchTerm = likeWildcard(searchTerm);
+    return safetyWrap(
+        () -> {
+          try (PreparedStatement st =
+              FilingCode.prepCourtCoverageQuery(conn, tylerDomain, finalSearchTerm)) {
+            List<String> types = new ArrayList<>();
+            ResultSet rs = st.executeQuery();
+            while (rs.next()) {
+              types.add(rs.getString(1));
+            }
+            return types;
+          }
+        });
+  }
+
   /**
    * Get the code and court locations of the filing types that match the given name exactly.
    *

--- a/proxyserver/src/main/java/edu/suffolk/litlab/efsp/ecfcodes/tyler/FilingCode.java
+++ b/proxyserver/src/main/java/edu/suffolk/litlab/efsp/ecfcodes/tyler/FilingCode.java
@@ -91,6 +91,19 @@ public class FilingCode {
     st.setString(2, searchTerm);
     return st;
   }
+
+  public static PreparedStatement prepCourtCoverageQuery(Connection conn, String domain, String searchTerm) throws SQLException {
+    final String search = """
+        SELECT DISTINCT location
+        FROM filing
+        WHERE domain=? AND casecategory='' AND casetypeid='' AND name ILIKE ?
+        ORDER BY location
+        """;
+    PreparedStatement st = conn.prepareStatement(search);
+    st.setString(1, domain);
+    st.setString(2, searchTerm);
+    return st;
+  }
   
   public static PreparedStatement prepRetrieveQuery(Connection conn, String domain, String filingName) throws SQLException {
     String retrieve = """

--- a/proxyserver/src/main/java/edu/suffolk/litlab/efsp/ecfcodes/tyler/OptionalServiceCode.java
+++ b/proxyserver/src/main/java/edu/suffolk/litlab/efsp/ecfcodes/tyler/OptionalServiceCode.java
@@ -109,6 +109,21 @@ public class OptionalServiceCode {
     return st;
   }
 
+  public static PreparedStatement prepCourtCoverage(
+      Connection conn, String domain, String searchTerm) throws SQLException {
+    final String search =
+        """
+        SELECT DISTINCT location
+        FROM optionalservices as os
+        WHERE os.domain=? AND os.name ILIKE ?
+        ORDER BY location
+        """;
+    PreparedStatement st = conn.prepareStatement(search);
+    st.setString(1, domain);
+    st.setString(2, searchTerm);
+    return st;
+  }
+
   public static PreparedStatement prepRetrieve(Connection conn, String domain, String optServName)
       throws SQLException {
     final String retrieve =

--- a/proxyserver/src/main/java/edu/suffolk/litlab/efsp/ecfcodes/tyler/PartyType.java
+++ b/proxyserver/src/main/java/edu/suffolk/litlab/efsp/ecfcodes/tyler/PartyType.java
@@ -80,6 +80,15 @@ public class PartyType {
     """;
   }
 
+  public static String courtCoveragePartyType() {
+    return """
+    SELECT DISTINCT location
+    FROM partytype
+    WHERE domain=? and name ILIKE ?
+    ORDER BY location
+    """;
+  }
+
   public static String retrievePartyTypeFromName() {
     return """
     SELECT DISTINCT code, location

--- a/proxyserver/src/main/java/edu/suffolk/litlab/efsp/server/EfspServer.java
+++ b/proxyserver/src/main/java/edu/suffolk/litlab/efsp/server/EfspServer.java
@@ -21,6 +21,7 @@ import edu.suffolk.litlab.efsp.server.setup.EfmModuleSetup;
 import edu.suffolk.litlab.efsp.server.setup.EfmRestCallbackInterface;
 import edu.suffolk.litlab.efsp.server.setup.jeffnet.JeffNetModuleSetup;
 import edu.suffolk.litlab.efsp.server.setup.tyler.TylerModuleSetup;
+import edu.suffolk.litlab.efsp.server.utils.EnumExceptionMapper;
 import edu.suffolk.litlab.efsp.server.utils.JsonExceptionMapper;
 import edu.suffolk.litlab.efsp.server.utils.ObservabilityHeadersInterceptor;
 import edu.suffolk.litlab.efsp.server.utils.ObservabilityResetInterceptor;
@@ -174,6 +175,7 @@ public class EfspServer {
         new JacksonJsonProvider(), // TODO(brycew): JAXBJSon?
         new SoapExceptionMapper(),
         new JsonExceptionMapper(),
+        new EnumExceptionMapper(),
         new ObservabilityHeadersInterceptor(),
         new ObservabilityResetInterceptor());
   }

--- a/proxyserver/src/main/java/edu/suffolk/litlab/efsp/server/services/EcfCodesService.java
+++ b/proxyserver/src/main/java/edu/suffolk/litlab/efsp/server/services/EcfCodesService.java
@@ -226,11 +226,25 @@ public class EcfCodesService extends CodesService {
     }
   }
 
+  public enum DesiredResult {
+    NAMES,
+    COURT_COVERAGE;
+  }
+
   @GET
   @Path("/filing_types")
-  public Response searchFilingTypes(@QueryParam("search") String searchTerm) throws SQLException {
+  public Response searchFilingTypes(
+      @QueryParam("search") String searchTerm, @QueryParam("result") DesiredResult desiredResult)
+      throws SQLException {
+    if (desiredResult == null) {
+      desiredResult = DesiredResult.NAMES;
+    }
     try (CodeDatabase cd = cdSupplier.get()) {
-      return cors(Response.ok(cd.searchFilingType(searchTerm)));
+      return switch (desiredResult) {
+        case DesiredResult.NAMES -> cors(Response.ok(cd.searchFilingType(searchTerm)));
+        case DesiredResult.COURT_COVERAGE ->
+            cors(Response.ok(cd.courtCoverageFilingType(searchTerm)));
+      };
     }
   }
 

--- a/proxyserver/src/main/java/edu/suffolk/litlab/efsp/server/services/EcfCodesService.java
+++ b/proxyserver/src/main/java/edu/suffolk/litlab/efsp/server/services/EcfCodesService.java
@@ -255,11 +255,9 @@ public class EcfCodesService extends CodesService {
   @GET
   @Path("/case_types")
   public Response searchCaseTypes(
-      @QueryParam("search") String searchTerm, @QueryParam("result") DesiredResult desiredResult)
+      @QueryParam("search") String searchTerm, @QueryParam("result") String resultStr)
       throws SQLException {
-    if (desiredResult == null) {
-      desiredResult = DesiredResult.NAMES;
-    }
+    DesiredResult desiredResult = DesiredResult.parse(resultStr);
     try (CodeDatabase cd = cdSupplier.get()) {
       return switch (desiredResult) {
         case DesiredResult.NAMES -> cors(Response.ok(cd.searchCaseType(searchTerm)));

--- a/proxyserver/src/main/java/edu/suffolk/litlab/efsp/server/services/EcfCodesService.java
+++ b/proxyserver/src/main/java/edu/suffolk/litlab/efsp/server/services/EcfCodesService.java
@@ -192,6 +192,20 @@ public class EcfCodesService extends CodesService {
 
   //////////////  Search endpoints (i.e. info gathering across courts) //////////////////
 
+  /** Enum that's used across the search endpoints. */
+  public enum DesiredResult {
+    NAMES,
+    COURT_COVERAGE;
+
+    public static DesiredResult parse(String resultStr) {
+      if (resultStr == null || resultStr.isBlank()) {
+        // Default to Names, as that was originally you could only search for names.
+        return NAMES;
+      }
+      return DesiredResult.valueOf(resultStr.toUpperCase());
+    }
+  }
+
   @GET
   @Path("/categories")
   public Response searchCategories(@QueryParam("search") String searchTerm) throws SQLException {
@@ -226,19 +240,12 @@ public class EcfCodesService extends CodesService {
     }
   }
 
-  public enum DesiredResult {
-    NAMES,
-    COURT_COVERAGE;
-  }
-
   @GET
   @Path("/filing_types")
   public Response searchFilingTypes(
-      @QueryParam("search") String searchTerm, @QueryParam("result") DesiredResult desiredResult)
+      @QueryParam("search") String searchTerm, @QueryParam("result") String resultStr)
       throws SQLException {
-    if (desiredResult == null) {
-      desiredResult = DesiredResult.NAMES;
-    }
+    DesiredResult desiredResult = DesiredResult.parse(resultStr);
     try (CodeDatabase cd = cdSupplier.get()) {
       return switch (desiredResult) {
         case DesiredResult.NAMES -> cors(Response.ok(cd.searchFilingType(searchTerm)));

--- a/proxyserver/src/main/java/edu/suffolk/litlab/efsp/server/utils/EnumExceptionMapper.java
+++ b/proxyserver/src/main/java/edu/suffolk/litlab/efsp/server/utils/EnumExceptionMapper.java
@@ -1,0 +1,23 @@
+package edu.suffolk.litlab.efsp.server.utils;
+
+import jakarta.ws.rs.core.Response;
+import jakarta.ws.rs.ext.ExceptionMapper;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class EnumExceptionMapper implements ExceptionMapper<IllegalArgumentException> {
+  public Logger log = LoggerFactory.getLogger(EnumExceptionMapper.class);
+
+  @Override
+  public Response toResponse(IllegalArgumentException exception) {
+    if (exception
+        .getMessage()
+        .contains(" edu.suffolk.litlab.efsp.server.services.EcfCodesService.DesiredResult")) {
+      return Response.status(400)
+          .entity("Unknown value for `result` parameter: should be 'NAMES', or 'COURT_COVERAGE'")
+          .build();
+    }
+    log.error("Catching non user-facing IllegalArgumentException", exception);
+    return Response.status(500).build();
+  }
+}

--- a/proxyserver/src/main/java/edu/suffolk/litlab/efsp/stdlib/SQLGetter.java
+++ b/proxyserver/src/main/java/edu/suffolk/litlab/efsp/stdlib/SQLGetter.java
@@ -3,6 +3,6 @@ package edu.suffolk.litlab.efsp.stdlib;
 import java.sql.SQLException;
 
 @FunctionalInterface
-public interface SQLFunction<T, R> {
-  R apply(T input) throws SQLException;
+public interface SQLGetter<R> {
+  R get() throws SQLException;
 }


### PR DESCRIPTION
Would allow a new param to let you either get all of the search results for a string, or would let you get courts that a particular search query would be sufficient for partial matches with.

Turns a custom python script that takes 150 seconds to run into a single query that can be added to the codes interview to give detailed information about a particular search string. That query will be added once this is in stage.