### PR TITLE
Change Fly io Region

### DIFF
--- a/scripts/fly.production.toml
+++ b/scripts/fly.production.toml
@@ -4,7 +4,7 @@
 #
 
 app = 'efsp-prod'
-primary_region = 'bos'
+primary_region = 'ewr'
 kill_timeout = 60
 
 [build]

--- a/scripts/fly.toml
+++ b/scripts/fly.toml
@@ -4,7 +4,7 @@
 #
 
 app = 'efsp-staging'
-primary_region = 'bos'
+primary_region = 'ewr'
 kill_timeout = 60
 
 [build]


### PR DESCRIPTION
The Boston (bos) region in Fly is being deprecated and merged into the Secaucus, NJ region (ewr). This technically happened this morning, but seems to have resulted in some weirdness on the staging machine, hopefully re-pushing will fix that.

https://fly.io/blog/the-region-consolidation-project/