### PR TITLE
Bump up the number of max connections + test postgres connections

### DIFF
--- a/proxyserver/src/main/java/edu/suffolk/litlab/efsp/db/DatabaseCreator.java
+++ b/proxyserver/src/main/java/edu/suffolk/litlab/efsp/db/DatabaseCreator.java
@@ -55,6 +55,8 @@ public class DatabaseCreator {
     SharedPoolDataSource tds = new SharedPoolDataSource();
     tds.setConnectionPoolDataSource(cpds);
     tds.setDefaultAutoCommit(true);
+    tds.setDefaultTestOnBorrow(true);
+    tds.setValidationQuery("SELECT 1");
     tds.setMaxTotal(maxConnections);
     tds.setDefaultMaxWait(Duration.ofMillis(waitForConnMillis));
     try (Connection conn = tds.getConnection()) {

--- a/proxyserver/src/main/java/edu/suffolk/litlab/efsp/db/LoginDatabase.java
+++ b/proxyserver/src/main/java/edu/suffolk/litlab/efsp/db/LoginDatabase.java
@@ -192,7 +192,7 @@ public class LoginDatabase extends Database {
             System.getenv("POSTGRES_USER_DB"),
             System.getenv("POSTGRES_USER"),
             System.getenv("POSTGRES_PASSWORD"),
-            2,
+            10,
             100);
     try (LoginDatabase ld = new LoginDatabase(ds.getConnection())) {
       ld.setAutoCommit(true);

--- a/proxyserver/src/main/java/edu/suffolk/litlab/efsp/ecfcodes/CodeUpdater.java
+++ b/proxyserver/src/main/java/edu/suffolk/litlab/efsp/ecfcodes/CodeUpdater.java
@@ -671,7 +671,7 @@ public class CodeUpdater {
               System.getenv("POSTGRES_CODES_DB"),
               System.getenv("POSTGRES_USER"),
               System.getenv("POSTGRES_PASSWORD"),
-              5,
+              10,
               100);
 
       return CodeDatabase.fromDS(jurisdiction, env, ds);

--- a/proxyserver/src/main/java/edu/suffolk/litlab/efsp/server/EfspServer.java
+++ b/proxyserver/src/main/java/edu/suffolk/litlab/efsp/server/EfspServer.java
@@ -195,10 +195,10 @@ public class EfspServer {
 
     DataSource codeDs =
         DatabaseCreator.makeDataSource(
-            dbUrl, dbPortInt, codeDatabaseName, dbUser, dbPassword, 7, 100);
+            dbUrl, dbPortInt, codeDatabaseName, dbUser, dbPassword, 6, 100);
     DataSource userDs =
         DatabaseCreator.makeDataSource(
-            dbUrl, dbPortInt, userDatabaseName, dbUser, dbPassword, 7, 100);
+            dbUrl, dbPortInt, userDatabaseName, dbUser, dbPassword, 6, 100);
 
     Optional<TylerEnv> tylerEnv = GetEnv("TYLER_ENV").map(TylerEnv::parse);
     setupDatabases(codeDs, userDs, tylerEnv);


### PR DESCRIPTION
Might help issues in production regarding connections being closed?

Looks like this:

```
org.postgresql.util.PSQLException: This connection has been closed.
```

No other information, only happens on the `/authenticate` endpoint. For some reason that datasource only had 2 max connections, so maybe 2 of them are stuck somehow? Bumped that up to 10, as well as in a few other places.