### PR TITLE
Use Jurisdiction, TylerEnv, and TylerDomain internally everywhere

### DIFF
--- a/EfspCommons/src/main/java/edu/suffolk/litlab/efsp/Jurisdiction.java
+++ b/EfspCommons/src/main/java/edu/suffolk/litlab/efsp/Jurisdiction.java
@@ -1,0 +1,60 @@
+package edu.suffolk.litlab.efsp;
+
+/**
+ * The jurisdictions (states) that our code works in and that we support. Even though all possible
+ * jurisdictions might be listed here, only those set to the <code>TYLER_JURISDICTIONS</code> env
+ * var are supported at runtime.
+ *
+ * <p>At the moment, each jurisdiction is uniquely mapped to a single API and Vendor of that API
+ * (i.e. ECF, and Tyler). This is for when we expand to having multiple APIs (i.e. ECF v4 and ECF
+ * v5) and multiple vendors(Tyler and SoftImage).
+ */
+public enum Jurisdiction {
+  CALIFORNIA("california", Api.ECF_4, Vendor.TYLER),
+  INDIANA("indiana", Api.ECF_4, Vendor.TYLER),
+  ILLINOIS("illinois", Api.ECF_4_Schedule, Vendor.TYLER),
+  LOUISIANA("louisiana", Api.JEFFNET, Vendor.JEFFERSON_PARISH),
+  MASSACHUSETTS("massachusetts", Api.ECF_4, Vendor.TYLER),
+  TEXAS("texas", Api.ECF_4, Vendor.TYLER),
+  VERMONT("vermont", Api.ECF_4, Vendor.TYLER);
+
+  private enum Api {
+    JEFFNET,
+    ECF_4,
+    // Illinois uses a custom Tyler ECF4 version, which includes a pre-release ECF 5
+    // version of the Court Scheduling MDE.
+    ECF_4_Schedule;
+  }
+
+  private enum Vendor {
+    JEFFERSON_PARISH,
+    TYLER;
+  }
+
+  private String name;
+  private Api api;
+  private Vendor vendor;
+
+  private Jurisdiction(String name, Api api, Vendor vendor) {
+    this.name = name;
+    this.api = api;
+    this.vendor = vendor;
+  }
+
+  public String getName() {
+    return name;
+  }
+
+  public Vendor getVendor() {
+    return vendor;
+  }
+
+  public static Jurisdiction parse(String value) {
+    for (var jurisdiction : Jurisdiction.values()) {
+      if (value.equalsIgnoreCase(jurisdiction.getName())) {
+        return jurisdiction;
+      }
+    }
+    throw new IllegalArgumentException("Can't make a `Jurisdiction` from: `" + value + "`");
+  }
+}

--- a/TylerEfmClient/src/main/java/edu/suffolk/litlab/efsp/tyler/TylerDomain.java
+++ b/TylerEfmClient/src/main/java/edu/suffolk/litlab/efsp/tyler/TylerDomain.java
@@ -1,0 +1,13 @@
+package edu.suffolk.litlab.efsp.tyler;
+
+import edu.suffolk.litlab.efsp.Jurisdiction;
+
+/**
+ * A combination of a Tyler jurisdiction and env, resulting in a specific set of servers to send
+ * requests to.
+ */
+public record TylerDomain(Jurisdiction jurisdiction, TylerEnv env) {
+  public String getName() {
+    return jurisdiction.getName() + "-" + env.getName();
+  }
+}

--- a/TylerEfmClient/src/main/java/edu/suffolk/litlab/efsp/tyler/TylerEnv.java
+++ b/TylerEfmClient/src/main/java/edu/suffolk/litlab/efsp/tyler/TylerEnv.java
@@ -13,22 +13,16 @@ public enum TylerEnv {
     this.name = name;
   }
 
-  // ** Used for when the env determines a URL / filepath. */
-  public String getPath() {
-    return name;
-  }
-
   public String getName() {
     return name;
   }
 
   public static TylerEnv parse(String value) {
-    if (value.equalsIgnoreCase(STAGE.getName())) {
-      return STAGE;
-    } else if (value.equalsIgnoreCase(PROD.getName())) {
-      return PROD;
-    } else {
-      throw new IllegalArgumentException("Can't make a `TylerEnv` from: `" + value + "`'");
+    for (var env : TylerEnv.values()) {
+      if (value.equalsIgnoreCase(env.getName())) {
+        return env;
+      }
     }
+    throw new IllegalArgumentException("Can't make a `TylerEnv` from: `" + value + "`");
   }
 }

--- a/TylerEfmClient/src/test/java/edu/suffolk/litlab/efsp/tyler/TylerClientsTest.java
+++ b/TylerEfmClient/src/test/java/edu/suffolk/litlab/efsp/tyler/TylerClientsTest.java
@@ -1,7 +1,10 @@
 package edu.suffolk.litlab.efsp.tyler;
 
+import static edu.suffolk.litlab.efsp.Jurisdiction.*;
+import static edu.suffolk.litlab.efsp.tyler.TylerEnv.*;
 import static org.assertj.core.api.Assertions.assertThat;
 
+import edu.suffolk.litlab.efsp.Jurisdiction;
 import java.io.IOException;
 import java.net.HttpURLConnection;
 import java.net.URI;
@@ -16,41 +19,41 @@ public class TylerClientsTest {
 
   @Test
   public void allFactoriesShouldNotThrow() {
-    for (String jurisdiction :
-        List.of("texas", "massachusetts", "illinois", "indiana", "california", "wales")) {
+    for (Jurisdiction jurisdiction :
+        List.of(TEXAS, MASSACHUSETTS, ILLINOIS, INDIANA, CALIFORNIA, VERMONT)) {
       for (TylerEnv env : TylerEnv.values()) {
-        assertThat(TylerClients.getEfmFirmFactory(jurisdiction, env)).isNotNull();
-        assertThat(TylerClients.getEfmUserFactory(jurisdiction, env)).isNotNull();
+        var domain = new TylerDomain(jurisdiction, env);
+        assertThat(TylerClients.getEfmFirmFactory(domain)).isNotNull();
+        assertThat(TylerClients.getEfmUserFactory(domain)).isNotNull();
       }
     }
-    assertThat(TylerClients.getEfmUserFactory("antartica", TylerEnv.STAGE)).isEmpty();
-    assertThat(TylerClients.getEfmUserFactory("massachusetts", TylerEnv.PROD)).isNotEmpty();
-    assertThat(TylerClients.getEfmUserFactory("illinois", TylerEnv.STAGE)).isNotEmpty();
+    assertThat(TylerClients.getEfmUserFactory(new TylerDomain(MASSACHUSETTS, PROD))).isNotEmpty();
+    assertThat(TylerClients.getEfmUserFactory(new TylerDomain(ILLINOIS, STAGE))).isNotEmpty();
   }
 
   @Test
   public void testJurisdictionEnvUrls() throws IOException, URISyntaxException {
     testJurisdictionEnvUrl(
         "https://texas-stage.tylertech.cloud/",
-        TylerClients.getTylerServerRootUrl("texas", TylerEnv.STAGE));
+        TylerClients.getTylerServerRootUrl(new TylerDomain(TEXAS, STAGE)));
     testJurisdictionEnvUrl(
         "https://texas.tylertech.cloud/",
-        TylerClients.getTylerServerRootUrl("texas", TylerEnv.PROD));
+        TylerClients.getTylerServerRootUrl(new TylerDomain(TEXAS, PROD)));
     testJurisdictionEnvUrl(
         "https://massachusetts-stage.tylertech.cloud/",
-        TylerClients.getTylerServerRootUrl("massachusetts", TylerEnv.STAGE));
+        TylerClients.getTylerServerRootUrl(new TylerDomain(MASSACHUSETTS, STAGE)));
     testJurisdictionEnvUrl(
         "https://massachusetts.tylertech.cloud/",
-        TylerClients.getTylerServerRootUrl("massachusetts", TylerEnv.PROD));
+        TylerClients.getTylerServerRootUrl(new TylerDomain(MASSACHUSETTS, PROD)));
     testJurisdictionEnvUrl(
         "https://illinois-stage.tylertech.cloud/",
-        TylerClients.getTylerServerRootUrl("illinois", TylerEnv.STAGE));
+        TylerClients.getTylerServerRootUrl(new TylerDomain(ILLINOIS, STAGE)));
     testJurisdictionEnvUrl(
         "https://illinois.tylertech.cloud/",
-        TylerClients.getTylerServerRootUrl("illinois", TylerEnv.PROD));
+        TylerClients.getTylerServerRootUrl(new TylerDomain(ILLINOIS, PROD)));
   }
 
-  public void testJurisdictionEnvUrl(String urlExpected, String urlGenerated)
+  private void testJurisdictionEnvUrl(String urlExpected, String urlGenerated)
       throws IOException, URISyntaxException {
     assertThat(urlGenerated).isEqualTo(urlExpected);
     URL url = (new URI(urlGenerated)).toURL();

--- a/proxyserver/src/main/java/edu/suffolk/litlab/efsp/ecfcodes/CodeDatabaseAPI.java
+++ b/proxyserver/src/main/java/edu/suffolk/litlab/efsp/ecfcodes/CodeDatabaseAPI.java
@@ -1,6 +1,7 @@
 package edu.suffolk.litlab.efsp.ecfcodes;
 
 import edu.suffolk.litlab.efsp.db.Database;
+import edu.suffolk.litlab.efsp.tyler.TylerDomain;
 import jakarta.xml.bind.JAXBContext;
 import jakarta.xml.bind.JAXBException;
 import jakarta.xml.bind.Unmarshaller;
@@ -34,7 +35,7 @@ public abstract class CodeDatabaseAPI extends Database {
    * The domain (the juristiction + environment, e.g. illinois-stage) that this database is working
    * over.
    */
-  public abstract String getDomain();
+  public abstract TylerDomain getDomain();
 
   /**
    * Gets all court location identifiers (CLI) stored in the database.

--- a/proxyserver/src/main/java/edu/suffolk/litlab/efsp/ecfcodes/tyler/CodeDatabase.java
+++ b/proxyserver/src/main/java/edu/suffolk/litlab/efsp/ecfcodes/tyler/CodeDatabase.java
@@ -4,7 +4,7 @@ import edu.suffolk.litlab.efsp.ecfcodes.CodeDatabaseAPI;
 import edu.suffolk.litlab.efsp.ecfcodes.tyler.CodeTableConstants.UnsupportedTableException;
 import edu.suffolk.litlab.efsp.stdlib.SQLFunction;
 import edu.suffolk.litlab.efsp.stdlib.SQLGetter;
-import edu.suffolk.litlab.efsp.tyler.TylerEnv;
+import edu.suffolk.litlab.efsp.tyler.TylerDomain;
 import jakarta.xml.bind.JAXBException;
 import java.io.InputStream;
 import java.sql.Connection;
@@ -40,17 +40,17 @@ import org.slf4j.LoggerFactory;
 public class CodeDatabase extends CodeDatabaseAPI {
   private static final Logger log = LoggerFactory.getLogger(CodeDatabase.class);
 
-  /** The DNS domain (tyler jurisdiction + tyler environment, illinois-stage). */
-  private final String tylerDomain;
+  /** The tyler jurisdiction + tyler environment, i.e. illinois-stage. */
+  private final TylerDomain tylerDomain;
 
-  public CodeDatabase(String jurisdiction, TylerEnv env, Connection conn) {
+  public CodeDatabase(TylerDomain domain, Connection conn) {
     super(conn);
-    this.tylerDomain = jurisdiction + "-" + env.getName();
+    this.tylerDomain = domain;
   }
 
-  public static CodeDatabase fromDS(String jurisdiction, TylerEnv env, DataSource ds) {
+  public static CodeDatabase fromDS(TylerDomain domain, DataSource ds) {
     try {
-      CodeDatabase cd = new CodeDatabase(jurisdiction, env, ds.getConnection());
+      CodeDatabase cd = new CodeDatabase(domain, ds.getConnection());
       return cd;
     } catch (SQLException e) {
       log.error("In CodeDatabase constructor, can't get connection: ", e);
@@ -81,8 +81,13 @@ public class CodeDatabase extends CodeDatabaseAPI {
     createTableIfAbsent("installedversion");
   }
 
-  public String getDomain() {
+  @Override
+  public TylerDomain getDomain() {
     return tylerDomain;
+  }
+
+  private String domainStr() {
+    return tylerDomain.getName();
   }
 
   public void createTableIfAbsent(String tableName) throws SQLException {
@@ -174,8 +179,7 @@ public class CodeDatabase extends CodeDatabaseAPI {
     String versionUpdate = CodeTableConstants.updateVersion();
     try (PreparedStatement update = conn.prepareStatement(versionUpdate)) {
       if (tableName.equals("optionalservices")) {
-        OptionalServiceCode.updateOptionalServiceTable(
-            courtName, this.tylerDomain, rows, this.conn);
+        OptionalServiceCode.updateOptionalServiceTable(courtName, domainStr(), rows, this.conn);
       } else {
         updateTableInner(tableName, courtName, rows);
       }
@@ -185,7 +189,7 @@ public class CodeDatabase extends CodeDatabaseAPI {
       update.setString(1, courtName);
       update.setString(2, zipName);
       update.setString(3, newVersion);
-      update.setString(4, tylerDomain);
+      update.setString(4, domainStr());
       update.setString(5, newVersion);
       update.executeUpdate();
     } catch (UnsupportedTableException ex) {
@@ -247,7 +251,7 @@ public class CodeDatabase extends CodeDatabaseAPI {
       stmt.setString(idx, courtName);
       idx += 1;
     }
-    stmt.setString(idx, this.tylerDomain);
+    stmt.setString(idx, domainStr());
     return stmt;
   }
 
@@ -277,7 +281,7 @@ public class CodeDatabase extends CodeDatabaseAPI {
         (term) -> {
           String query = CaseCategory.searchCaseCategories();
           PreparedStatement st = conn.prepareStatement(query);
-          st.setString(1, tylerDomain);
+          st.setString(1, domainStr());
           st.setString(2, term);
           return st;
         });
@@ -289,7 +293,7 @@ public class CodeDatabase extends CodeDatabaseAPI {
         (term) -> {
           String query = CaseCategory.courtCoverageCaseCategories();
           PreparedStatement st = conn.prepareStatement(query);
-          st.setString(1, tylerDomain);
+          st.setString(1, domainStr());
           st.setString(2, term);
           return st;
         });
@@ -307,7 +311,7 @@ public class CodeDatabase extends CodeDatabaseAPI {
           String query = CaseCategory.retrieveCaseCategoryForName();
           List<CodeAndLocation> cats = new ArrayList<>();
           try (PreparedStatement st = conn.prepareStatement(query)) {
-            st.setString(1, tylerDomain);
+            st.setString(1, domainStr());
             st.setString(2, categoryName);
             ResultSet rs = st.executeQuery();
             while (rs.next()) {
@@ -324,7 +328,7 @@ public class CodeDatabase extends CodeDatabaseAPI {
           String query = CaseCategory.getCaseCategoriesForLoc();
           List<CaseCategory> cats = new ArrayList<>();
           try (PreparedStatement st = conn.prepareStatement(query)) {
-            st.setString(1, tylerDomain);
+            st.setString(1, domainStr());
             st.setString(2, courtLocationId);
             ResultSet rs = st.executeQuery();
             while (rs.next()) {
@@ -343,9 +347,9 @@ public class CodeDatabase extends CodeDatabaseAPI {
           if (initial.isPresent()) {
             st =
                 CaseCategory.prepFilableQueryTiming(
-                    conn, this.tylerDomain, courtLocationId, initial.get());
+                    conn, domainStr(), courtLocationId, initial.get());
           } else {
-            st = CaseCategory.prepFileableQuery(conn, this.tylerDomain, courtLocationId);
+            st = CaseCategory.prepFileableQuery(conn, domainStr(), courtLocationId);
           }
           ResultSet rs = st.executeQuery();
           List<CaseCategory> cats = new ArrayList<>();
@@ -363,7 +367,7 @@ public class CodeDatabase extends CodeDatabaseAPI {
         () -> {
           String query = CaseCategory.getCaseCategoryWithCode();
           try (PreparedStatement st = conn.prepareStatement(query)) {
-            st.setString(1, tylerDomain);
+            st.setString(1, domainStr());
             st.setString(2, courtLocationId);
             st.setString(3, caseCatCode);
             ResultSet rs = st.executeQuery();
@@ -385,11 +389,11 @@ public class CodeDatabase extends CodeDatabaseAPI {
    * @return
    */
   public List<String> searchCaseType(String searchTerm) {
-    return genericSearch(searchTerm, (term) -> CaseType.prepSearchQuery(conn, tylerDomain, term));
+    return genericSearch(searchTerm, (term) -> CaseType.prepSearchQuery(conn, domainStr(), term));
   }
 
   public List<String> courtCoverageCaseType(String searchTerm) {
-    return genericSearch(searchTerm, (term) -> CaseType.prepCourtCoverage(conn, tylerDomain, term));
+    return genericSearch(searchTerm, (term) -> CaseType.prepCourtCoverage(conn, domainStr(), term));
   }
 
   /**
@@ -401,7 +405,7 @@ public class CodeDatabase extends CodeDatabaseAPI {
   public List<CodeAndLocation> retrieveCaseTypeByName(String caseTypeName) {
     return safetyWrap(
         () -> {
-          try (PreparedStatement st = CaseType.prepRetrieveQuery(conn, tylerDomain, caseTypeName)) {
+          try (PreparedStatement st = CaseType.prepRetrieveQuery(conn, domainStr(), caseTypeName)) {
             List<CodeAndLocation> types = new ArrayList<>();
             ResultSet rs = st.executeQuery();
             while (rs.next()) {
@@ -420,9 +424,9 @@ public class CodeDatabase extends CodeDatabaseAPI {
           if (initial.isPresent()) {
             st =
                 CaseType.prepQueryTiming(
-                    conn, tylerDomain, courtLocationId, caseCategoryCode, initial);
+                    conn, domainStr(), courtLocationId, caseCategoryCode, initial);
           } else {
-            st = CaseType.prepQueryBroad(conn, tylerDomain, courtLocationId, caseCategoryCode);
+            st = CaseType.prepQueryBroad(conn, domainStr(), courtLocationId, caseCategoryCode);
           }
           ResultSet rs = st.executeQuery();
           List<CaseType> types = new ArrayList<>();
@@ -438,7 +442,7 @@ public class CodeDatabase extends CodeDatabaseAPI {
     return safetyWrapOpt(
         () -> {
           try (PreparedStatement st =
-              CaseType.prepQueryWithCode(conn, tylerDomain, courtLocationId, caseTypeCode)) {
+              CaseType.prepQueryWithCode(conn, domainStr(), courtLocationId, caseTypeCode)) {
             ResultSet rs = st.executeQuery();
             if (rs.next()) {
               return Optional.of(new CaseType(rs));
@@ -455,7 +459,7 @@ public class CodeDatabase extends CodeDatabaseAPI {
           String query = CodeTableConstants.getCaseSubtypesFor();
           List<NameAndCode> subtypes = new ArrayList<NameAndCode>();
           try (PreparedStatement st = conn.prepareStatement(query)) {
-            st.setString(1, tylerDomain);
+            st.setString(1, domainStr());
             st.setString(2, courtLocationId);
             st.setString(3, caseType);
             ResultSet rs = st.executeQuery();
@@ -478,7 +482,7 @@ public class CodeDatabase extends CodeDatabaseAPI {
       String query = DataFieldRow.getAllFromDataFieldConfigForLoc();
       for (String currentCourt : parentList) {
         try (PreparedStatement st = conn.prepareStatement(query)) {
-          st.setString(1, tylerDomain);
+          st.setString(1, domainStr());
           st.setString(2, currentCourt);
           st.setString(3, dataName);
           ResultSet rs = st.executeQuery();
@@ -522,7 +526,7 @@ public class CodeDatabase extends CodeDatabaseAPI {
       Set<String> codesInList = new HashSet<>();
       for (String currentCourt : parentList) {
         try (PreparedStatement st = conn.prepareStatement(query)) {
-          st.setString(1, tylerDomain);
+          st.setString(1, domainStr());
           st.setString(2, currentCourt);
           ResultSet rs = st.executeQuery();
           while (rs.next()) {
@@ -554,7 +558,7 @@ public class CodeDatabase extends CodeDatabaseAPI {
       List<Map<String, DataFieldRow>> allDataFields = new ArrayList<>();
       for (String currentCourt : parentList) {
         try (PreparedStatement st = conn.prepareStatement(query)) {
-          st.setString(1, tylerDomain);
+          st.setString(1, domainStr());
           st.setString(2, currentCourt);
           ResultSet rs = st.executeQuery();
           var dataFieldMap = new HashMap<String, DataFieldRow>();
@@ -593,7 +597,7 @@ public class CodeDatabase extends CodeDatabaseAPI {
 
     String query = CodeTableConstants.getProcedureOrRemedy();
     try (PreparedStatement st = conn.prepareStatement(query)) {
-      st.setString(1, tylerDomain);
+      st.setString(1, domainStr());
       st.setString(2, courtLocationId);
       st.setString(3, caseCategory);
       ResultSet rs = st.executeQuery();
@@ -615,7 +619,7 @@ public class CodeDatabase extends CodeDatabaseAPI {
    * @return
    */
   public List<String> searchFilingType(String searchTerm) {
-    return genericSearch(searchTerm, (term) -> FilingCode.prepSearchQuery(conn, tylerDomain, term));
+    return genericSearch(searchTerm, (term) -> FilingCode.prepSearchQuery(conn, domainStr(), term));
   }
 
   /**
@@ -626,7 +630,7 @@ public class CodeDatabase extends CodeDatabaseAPI {
    */
   public List<String> courtCoverageFilingType(String searchTerm) {
     return genericSearch(
-        searchTerm, (term) -> FilingCode.prepCourtCoverageQuery(conn, tylerDomain, term));
+        searchTerm, (term) -> FilingCode.prepCourtCoverageQuery(conn, domainStr(), term));
   }
 
   /** Runs all of the logic for search queries (both name searches and court coverage searches). */
@@ -656,7 +660,7 @@ public class CodeDatabase extends CodeDatabaseAPI {
     return safetyWrap(
         () -> {
           try (PreparedStatement st =
-              FilingCode.prepRetrieveQuery(conn, tylerDomain, caseTypeName)) {
+              FilingCode.prepRetrieveQuery(conn, domainStr(), caseTypeName)) {
             List<CodeAndLocation> types = new ArrayList<>();
             ResultSet rs = st.executeQuery();
             while (rs.next()) {
@@ -674,7 +678,7 @@ public class CodeDatabase extends CodeDatabaseAPI {
           List<FilingCode> filingTypes = new ArrayList<>();
           try (PreparedStatement specificSt =
               FilingCode.prepQueryWithCaseInfo(
-                  conn, initial, tylerDomain, courtLocationId, categoryCode, typeCode)) {
+                  conn, initial, domainStr(), courtLocationId, categoryCode, typeCode)) {
             ResultSet rs = specificSt.executeQuery();
             while (rs.next()) {
               filingTypes.add(new FilingCode(rs));
@@ -683,7 +687,7 @@ public class CodeDatabase extends CodeDatabaseAPI {
             // categories or types
             if (filingTypes.isEmpty()) {
               try (PreparedStatement broadSt =
-                  FilingCode.prepQueryNoCaseInfo(conn, initial, tylerDomain, courtLocationId)) {
+                  FilingCode.prepQueryNoCaseInfo(conn, initial, domainStr(), courtLocationId)) {
                 ResultSet broadRs = broadSt.executeQuery();
                 while (broadRs.next()) {
                   filingTypes.add(new FilingCode(broadRs));
@@ -699,7 +703,7 @@ public class CodeDatabase extends CodeDatabaseAPI {
     return safetyWrapOpt(
         () -> {
           try (PreparedStatement st =
-              FilingCode.prepQueryWithCode(conn, tylerDomain, courtLocationId, filingCode)) {
+              FilingCode.prepQueryWithCode(conn, domainStr(), courtLocationId, filingCode)) {
             ResultSet rs = st.executeQuery();
             if (rs.next()) {
               return Optional.of(new FilingCode(rs));
@@ -728,7 +732,7 @@ public class CodeDatabase extends CodeDatabaseAPI {
           String query = CodeTableConstants.getDamageAmount();
           List<NameAndCode> amounts = new ArrayList<>();
           try (PreparedStatement st = conn.prepareStatement(query)) {
-            st.setString(1, tylerDomain);
+            st.setString(1, domainStr());
             st.setString(2, courtLocationId);
             st.setString(3, caseCategory);
             try (ResultSet rs = st.executeQuery()) {
@@ -753,7 +757,7 @@ public class CodeDatabase extends CodeDatabaseAPI {
         (term) -> {
           String query = PartyType.searchPartyType();
           PreparedStatement st = conn.prepareStatement(query);
-          st.setString(1, tylerDomain);
+          st.setString(1, domainStr());
           st.setString(2, term);
           return st;
         });
@@ -765,7 +769,7 @@ public class CodeDatabase extends CodeDatabaseAPI {
         (term) -> {
           String query = PartyType.courtCoveragePartyType();
           PreparedStatement st = conn.prepareStatement(query);
-          st.setString(1, tylerDomain);
+          st.setString(1, domainStr());
           st.setString(2, term);
           return st;
         });
@@ -777,7 +781,7 @@ public class CodeDatabase extends CodeDatabaseAPI {
           String query = PartyType.retrievePartyTypeFromName();
           List<CodeAndLocation> types = new ArrayList<>();
           try (PreparedStatement st = conn.prepareStatement(query)) {
-            st.setString(1, tylerDomain);
+            st.setString(1, domainStr());
             st.setString(2, partyTypeName);
             ResultSet rs = st.executeQuery();
             while (rs.next()) {
@@ -802,7 +806,7 @@ public class CodeDatabase extends CodeDatabaseAPI {
           String query = PartyType.getPartyTypeFromCaseType();
           List<PartyType> partyTypes = new ArrayList<>();
           try (PreparedStatement caseSt = conn.prepareStatement(query)) {
-            caseSt.setString(1, tylerDomain);
+            caseSt.setString(1, domainStr());
             caseSt.setString(2, courtLocationId);
             if (caseTypeCode != null) {
               caseSt.setString(3, caseTypeCode);
@@ -815,7 +819,7 @@ public class CodeDatabase extends CodeDatabaseAPI {
             if (partyTypes.isEmpty()) {
               String broadQuery = PartyType.getPartyTypeNoCaseType();
               try (PreparedStatement broadSt = conn.prepareStatement(broadQuery)) {
-                broadSt.setString(1, tylerDomain);
+                broadSt.setString(1, domainStr());
                 broadSt.setString(2, courtLocationId);
                 try (ResultSet broadRs = broadSt.executeQuery()) {
                   while (broadRs.next()) {
@@ -835,7 +839,7 @@ public class CodeDatabase extends CodeDatabaseAPI {
           String query = PartyType.retrievePartyTypeFromName();
           List<PartyType> types = new ArrayList<>();
           try (PreparedStatement st = conn.prepareStatement(query)) {
-            st.setString(1, tylerDomain);
+            st.setString(1, domainStr());
             st.setString(2, courtLocationId);
             st.setString(3, partyTypeCode);
             ResultSet rs = st.executeQuery();
@@ -851,7 +855,7 @@ public class CodeDatabase extends CodeDatabaseAPI {
     return safetyWrap(
         () -> {
           try (PreparedStatement st = conn.prepareStatement(CrossReference.query())) {
-            st.setString(1, tylerDomain);
+            st.setString(1, domainStr());
             st.setString(2, courtLocationId);
             st.setString(3, caseTypeId);
             ResultSet rs = st.executeQuery();
@@ -870,7 +874,7 @@ public class CodeDatabase extends CodeDatabaseAPI {
           String query = ServiceCodeType.query();
           List<ServiceCodeType> types = new ArrayList<>();
           try (PreparedStatement st = conn.prepareStatement(query)) {
-            st.setString(1, tylerDomain);
+            st.setString(1, domainStr());
             st.setString(2, courtLocationId);
             ResultSet rs = st.executeQuery();
             while (rs.next()) {
@@ -889,7 +893,7 @@ public class CodeDatabase extends CodeDatabaseAPI {
 
     String specificQuery = DocumentTypeTableRow.getDocumentTypeWithFilingCode();
     try (PreparedStatement specificSt = conn.prepareStatement(specificQuery)) {
-      specificSt.setString(1, tylerDomain);
+      specificSt.setString(1, domainStr());
       specificSt.setString(2, courtLocationId);
       specificSt.setString(3, filingCodeId);
       ResultSet spefRs = specificSt.executeQuery();
@@ -900,7 +904,7 @@ public class CodeDatabase extends CodeDatabaseAPI {
       if (docTypes.isEmpty()) {
         String broadQuery = DocumentTypeTableRow.getDocumentTypeNoFiling();
         try (PreparedStatement broadSt = conn.prepareStatement(broadQuery)) {
-          broadSt.setString(1, tylerDomain);
+          broadSt.setString(1, domainStr());
           broadSt.setString(2, courtLocationId);
           ResultSet broadRs = broadSt.executeQuery();
           while (broadRs.next()) {
@@ -923,7 +927,7 @@ public class CodeDatabase extends CodeDatabaseAPI {
 
     String query = CodeTableConstants.getMotionTypes();
     try (PreparedStatement st = conn.prepareStatement(query)) {
-      st.setString(1, tylerDomain);
+      st.setString(1, domainStr());
       st.setString(2, courtLocationId);
       st.setString(3, filingCodeId);
       ResultSet rs = st.executeQuery();
@@ -946,7 +950,7 @@ public class CodeDatabase extends CodeDatabaseAPI {
 
     String query = CodeTableConstants.getNameSuffixes();
     try (PreparedStatement st = conn.prepareStatement(query)) {
-      st.setString(1, tylerDomain);
+      st.setString(1, domainStr());
       st.setString(2, courtLocationId);
       ResultSet rs = st.executeQuery();
       var motions = new ArrayList<NameAndCode>();
@@ -968,7 +972,7 @@ public class CodeDatabase extends CodeDatabaseAPI {
 
     String query = FilingComponent.getFilingComponents();
     try (PreparedStatement st = conn.prepareStatement(query)) {
-      st.setString(1, tylerDomain);
+      st.setString(1, domainStr());
       st.setString(2, courtLocationId);
       st.setString(3, filingCodeId);
       ResultSet rs = st.executeQuery();
@@ -992,7 +996,7 @@ public class CodeDatabase extends CodeDatabaseAPI {
     String query = CodeTableConstants.getSpecificStatesForCountryForLoc();
     try (PreparedStatement st = conn.prepareStatement(query)) {
       // TODO(brycew-later): Tyler docs say state is a system table, but there's one per court?
-      st.setString(1, tylerDomain);
+      st.setString(1, domainStr());
       st.setString(2, courtId);
       st.setString(3, country);
       ResultSet rs = st.executeQuery();
@@ -1022,7 +1026,7 @@ public class CodeDatabase extends CodeDatabaseAPI {
         () -> {
           String query = FileType.fileTypeQueries();
           try (PreparedStatement st = conn.prepareStatement(query)) {
-            st.setString(1, tylerDomain);
+            st.setString(1, domainStr());
             st.setString(2, courtId);
             ResultSet rs = st.executeQuery();
             List<FileType> types = new ArrayList<>();
@@ -1039,7 +1043,7 @@ public class CodeDatabase extends CodeDatabaseAPI {
         () -> {
           String query = FilerType.query();
           try (PreparedStatement st = conn.prepareStatement(query)) {
-            st.setString(1, tylerDomain);
+            st.setString(1, domainStr());
             st.setString(2, courtId);
             ResultSet rs = st.executeQuery();
             List<FilerType> types = new ArrayList<>();
@@ -1059,7 +1063,7 @@ public class CodeDatabase extends CodeDatabaseAPI {
 
     String query = CodeTableConstants.getFilingStatuses();
     try (PreparedStatement st = conn.prepareStatement(query)) {
-      st.setString(1, tylerDomain);
+      st.setString(1, domainStr());
       st.setString(2, courtId);
       ResultSet rs = st.executeQuery();
       List<NameAndCode> names = new ArrayList<>();
@@ -1075,19 +1079,19 @@ public class CodeDatabase extends CodeDatabaseAPI {
 
   public List<String> searchOptionalServices(String searchTerm) {
     return genericSearch(
-        searchTerm, (term) -> OptionalServiceCode.prepSearch(conn, tylerDomain, term));
+        searchTerm, (term) -> OptionalServiceCode.prepSearch(conn, domainStr(), term));
   }
 
   public List<String> courtCoverageOptionalServices(String searchTerm) {
     return genericSearch(
-        searchTerm, (term) -> OptionalServiceCode.prepCourtCoverage(conn, tylerDomain, term));
+        searchTerm, (term) -> OptionalServiceCode.prepCourtCoverage(conn, domainStr(), term));
   }
 
   public List<CodeAndLocation> retrieveOptionalServices(String optServName) {
     return safetyWrap(
         () -> {
           try (PreparedStatement st =
-              OptionalServiceCode.prepRetrieve(conn, tylerDomain, optServName)) {
+              OptionalServiceCode.prepRetrieve(conn, domainStr(), optServName)) {
             List<CodeAndLocation> optServs = new ArrayList<>();
             ResultSet rs = st.executeQuery();
             while (rs.next()) {
@@ -1102,7 +1106,7 @@ public class CodeDatabase extends CodeDatabaseAPI {
     return safetyWrap(
         () -> {
           try (PreparedStatement st =
-              OptionalServiceCode.prepQueryWithCode(conn, tylerDomain, courtId, optServCode)) {
+              OptionalServiceCode.prepQueryWithCode(conn, domainStr(), courtId, optServCode)) {
             List<OptionalServiceCode> optServs = new ArrayList<>();
             ResultSet rs = st.executeQuery();
             while (rs.next()) {
@@ -1117,7 +1121,7 @@ public class CodeDatabase extends CodeDatabaseAPI {
     return safetyWrap(
         () -> {
           try (PreparedStatement st =
-              OptionalServiceCode.prepQuery(conn, tylerDomain, courtId, filingCode)) {
+              OptionalServiceCode.prepQuery(conn, domainStr(), courtId, filingCode)) {
             ResultSet rs = st.executeQuery();
             List<OptionalServiceCode> services = new ArrayList<>();
             while (rs.next()) {
@@ -1133,7 +1137,7 @@ public class CodeDatabase extends CodeDatabaseAPI {
         () -> {
           String query = CodeTableConstants.getLanguages();
           try (PreparedStatement st = conn.prepareStatement(query)) {
-            st.setString(1, tylerDomain);
+            st.setString(1, domainStr());
             st.setString(2, courtLocationId);
             ResultSet rs = st.executeQuery();
             List<String> languages = new ArrayList<>();
@@ -1150,7 +1154,7 @@ public class CodeDatabase extends CodeDatabaseAPI {
         () -> {
           String query = CodeTableConstants.getLanguages();
           try (PreparedStatement st = conn.prepareStatement(query)) {
-            st.setString(1, tylerDomain);
+            st.setString(1, domainStr());
             st.setString(2, courtLocationId);
             ResultSet rs = st.executeQuery();
             List<NameAndCode> languages = new ArrayList<>();
@@ -1170,7 +1174,7 @@ public class CodeDatabase extends CodeDatabaseAPI {
     String query = CodeTableConstants.needToUpdateVersion();
     Map<String, List<String>> courtTables = new HashMap<>();
     try (PreparedStatement st = conn.prepareStatement(query)) {
-      st.setString(1, this.tylerDomain);
+      st.setString(1, this.domainStr());
       ResultSet rs = st.executeQuery();
       log.info("Query was {}", st);
       while (rs.next()) {
@@ -1198,12 +1202,12 @@ public class CodeDatabase extends CodeDatabaseAPI {
       throw new SQLException();
     }
     if (tableName.equals("optionalservices")) {
-      OptionalServiceCode.deleteFromOptionalServiceTable(null, tylerDomain, conn);
+      OptionalServiceCode.deleteFromOptionalServiceTable(null, domainStr(), conn);
     } else {
       final String deleteFromTable = CodeTableConstants.getDeleteAllCourtsFrom(tableName);
       // TODO(brycew): make variant that deletes everything with a specific jurisdiction
       try (PreparedStatement st = conn.prepareStatement(deleteFromTable)) {
-        st.setString(1, tylerDomain);
+        st.setString(1, domainStr());
         log.debug(st.toString());
         st.executeUpdate();
       }
@@ -1220,7 +1224,7 @@ public class CodeDatabase extends CodeDatabaseAPI {
       return false;
     }
     if (tableName.equals("optionalservices")) {
-      OptionalServiceCode.deleteFromOptionalServiceTable(courtLocation, tylerDomain, conn);
+      OptionalServiceCode.deleteFromOptionalServiceTable(courtLocation, domainStr(), conn);
       return true;
     }
     // TODO(brycew): make variant that deletes everything with a specific jurisdiction
@@ -1234,7 +1238,7 @@ public class CodeDatabase extends CodeDatabaseAPI {
       return false;
     }
     try (PreparedStatement st = conn.prepareStatement(deleteFromTableStr)) {
-      st.setString(1, tylerDomain);
+      st.setString(1, domainStr());
       st.setString(2, courtLocation);
       st.executeUpdate();
     }
@@ -1253,7 +1257,7 @@ public class CodeDatabase extends CodeDatabaseAPI {
       return List.of();
     }
     try (PreparedStatement st = conn.prepareStatement(CourtLocationInfo.allOrderedQuery())) {
-      st.setString(1, tylerDomain);
+      st.setString(1, domainStr());
       ResultSet rs = st.executeQuery();
       var locs = new ArrayList<String>();
       while (rs.next()) {
@@ -1271,7 +1275,7 @@ public class CodeDatabase extends CodeDatabaseAPI {
     return safetyWrap(
         () -> {
           try (PreparedStatement st = conn.prepareStatement(CourtLocationInfo.allNames())) {
-            st.setString(1, tylerDomain);
+            st.setString(1, domainStr());
             ResultSet rs = st.executeQuery();
             var names = new ArrayList<NameAndCode>();
             while (rs.next()) {
@@ -1286,7 +1290,7 @@ public class CodeDatabase extends CodeDatabaseAPI {
     return safetyWrap(
         () -> {
           try (PreparedStatement st = conn.prepareStatement(CourtLocationInfo.fileableQuery())) {
-            st.setString(1, tylerDomain);
+            st.setString(1, domainStr());
             ResultSet rs = st.executeQuery();
             var codes = new ArrayList<String>();
             while (rs.next()) {
@@ -1301,7 +1305,7 @@ public class CodeDatabase extends CodeDatabaseAPI {
     return safetyWrap(
         () -> {
           try (PreparedStatement st = conn.prepareStatement(CourtLocationInfo.fileableQuery())) {
-            st.setString(1, tylerDomain);
+            st.setString(1, domainStr());
             ResultSet rs = st.executeQuery();
             var codes = new ArrayList<NameAndCode>();
             while (rs.next()) {
@@ -1316,7 +1320,7 @@ public class CodeDatabase extends CodeDatabaseAPI {
     return safetyWrapOpt(
         () -> {
           try (PreparedStatement st = conn.prepareStatement(CourtLocationInfo.fullSingleQuery())) {
-            st.setString(1, tylerDomain);
+            st.setString(1, domainStr());
             st.setString(2, courtId);
             ResultSet rs = st.executeQuery();
             if (rs.next()) {
@@ -1340,7 +1344,7 @@ public class CodeDatabase extends CodeDatabaseAPI {
     while (!currentCourt.isBlank()) {
       parentList.add(currentCourt);
       try (PreparedStatement st = conn.prepareStatement(CourtLocationInfo.parentQuery())) {
-        st.setString(1, tylerDomain);
+        st.setString(1, domainStr());
         st.setString(2, currentCourt);
         ResultSet rs = st.executeQuery();
         if (rs.next()) {
@@ -1362,7 +1366,7 @@ public class CodeDatabase extends CodeDatabaseAPI {
         () -> {
           String query = Disclaimer.getDisclaimerRequirements();
           try (PreparedStatement st = conn.prepareStatement(query)) {
-            st.setString(1, tylerDomain);
+            st.setString(1, domainStr());
             st.setString(2, courtLocation);
             ResultSet rs = st.executeQuery();
             List<Disclaimer> disclaimers = new ArrayList<>();

--- a/proxyserver/src/main/java/edu/suffolk/litlab/efsp/server/auth/SecurityHub.java
+++ b/proxyserver/src/main/java/edu/suffolk/litlab/efsp/server/auth/SecurityHub.java
@@ -1,9 +1,11 @@
 package edu.suffolk.litlab.efsp.server.auth;
 
 import com.fasterxml.jackson.databind.JsonNode;
+import edu.suffolk.litlab.efsp.Jurisdiction;
 import edu.suffolk.litlab.efsp.db.LoginDatabase;
 import edu.suffolk.litlab.efsp.db.model.AtRest;
 import edu.suffolk.litlab.efsp.db.model.NewTokens;
+import edu.suffolk.litlab.efsp.tyler.TylerDomain;
 import edu.suffolk.litlab.efsp.tyler.TylerEnv;
 import java.sql.SQLException;
 import java.util.HashMap;
@@ -42,14 +44,16 @@ public class SecurityHub {
    * @param jurisdictions a list of Tyler jurisdictions to connect to. See SoapClientChooser.
    */
   public SecurityHub(
-      Supplier<LoginDatabase> ldSupplier, Optional<TylerEnv> env, List<String> jurisdictions) {
+      Supplier<LoginDatabase> ldSupplier,
+      Optional<TylerEnv> env,
+      List<Jurisdiction> jurisdictions) {
     this.ldSupplier = ldSupplier;
     if (env.isEmpty() || jurisdictions.isEmpty()) {
       this.tylerLoginObjs = List.of();
     } else {
       this.tylerLoginObjs =
           jurisdictions.stream()
-              .map(j -> new TylerLogin(j, env.get()))
+              .map(j -> new TylerLogin(new TylerDomain(j, env.get())))
               .collect(Collectors.toList());
     }
     this.jeffNetLoginObj = new JeffNetLogin();

--- a/proxyserver/src/main/java/edu/suffolk/litlab/efsp/server/auth/TylerLogin.java
+++ b/proxyserver/src/main/java/edu/suffolk/litlab/efsp/server/auth/TylerLogin.java
@@ -1,9 +1,10 @@
 package edu.suffolk.litlab.efsp.server.auth;
 
 import com.fasterxml.jackson.databind.JsonNode;
+import edu.suffolk.litlab.efsp.Jurisdiction;
 import edu.suffolk.litlab.efsp.server.utils.ServiceHelpers;
 import edu.suffolk.litlab.efsp.tyler.TylerClients;
-import edu.suffolk.litlab.efsp.tyler.TylerEnv;
+import edu.suffolk.litlab.efsp.tyler.TylerDomain;
 import edu.suffolk.litlab.efsp.tyler.TylerUserClient;
 import edu.suffolk.litlab.efsp.tyler.TylerUserFactory;
 import java.util.Map;
@@ -18,21 +19,20 @@ public class TylerLogin implements LoginInterface {
 
   private final TylerUserFactory userServiceFactory;
   private static final String HEADER_KEY_PREFIX = "TYLER-TOKEN";
-  private final String jurisdiction;
+  private final Jurisdiction jurisdiction;
 
-  public TylerLogin(String jurisdiction, TylerEnv env) {
-    this.jurisdiction = jurisdiction;
-    Optional<TylerUserFactory> maybeUserFactory = TylerClients.getEfmUserFactory(jurisdiction, env);
+  public TylerLogin(TylerDomain domain) {
+    this.jurisdiction = domain.jurisdiction();
+    Optional<TylerUserFactory> maybeUserFactory = TylerClients.getEfmUserFactory(domain);
     if (maybeUserFactory.isPresent()) {
       userServiceFactory = maybeUserFactory.get();
     } else {
-      throw new RuntimeException(
-          jurisdiction + "-" + env + " not in SoapClientChooser for EFMUser");
+      throw new RuntimeException(domain + " not in SoapClientChooser for EFMUser");
     }
   }
 
-  public static String getHeaderKeyFromJurisdiction(String jurisdiction) {
-    return HEADER_KEY_PREFIX + "-" + jurisdiction.toUpperCase();
+  public static String getHeaderKeyFromJurisdiction(Jurisdiction jurisdiction) {
+    return HEADER_KEY_PREFIX + "-" + jurisdiction.getName().toUpperCase();
   }
 
   @Override
@@ -82,10 +82,10 @@ public class TylerLogin implements LoginInterface {
 
   @Override
   public String getLoginName() {
-    return "tyler-" + this.jurisdiction;
+    return "tyler-" + this.jurisdiction.getName();
   }
 
-  public static String getHeaderId(String jurisdiction) {
-    return "TYLER-ID-" + jurisdiction;
+  public static String getHeaderId(Jurisdiction jurisdiction) {
+    return "TYLER-ID-" + jurisdiction.getName().toUpperCase();
   }
 }

--- a/proxyserver/src/main/java/edu/suffolk/litlab/efsp/server/ecf4/EcfCaseTypeFactory.java
+++ b/proxyserver/src/main/java/edu/suffolk/litlab/efsp/server/ecf4/EcfCaseTypeFactory.java
@@ -1,6 +1,7 @@
 package edu.suffolk.litlab.efsp.server.ecf4;
 
 import com.fasterxml.jackson.databind.JsonNode;
+import edu.suffolk.litlab.efsp.Jurisdiction;
 import edu.suffolk.litlab.efsp.ecfcodes.tyler.CaseCategory;
 import edu.suffolk.litlab.efsp.ecfcodes.tyler.CodeDatabase;
 import edu.suffolk.litlab.efsp.ecfcodes.tyler.ComboCaseCodes;
@@ -64,9 +65,9 @@ public class EcfCaseTypeFactory {
       ecfCommonObjFac;
   private final gov.niem.niem.niem_core._2.ObjectFactory of;
   private final gov.niem.niem.structures._2.ObjectFactory structObjFac;
-  private final String jurisdiction;
+  private final Jurisdiction jurisdiction;
 
-  public EcfCaseTypeFactory(CodeDatabase cd, String jurisdiction) {
+  public EcfCaseTypeFactory(CodeDatabase cd, Jurisdiction jurisdiction) {
     this.cd = cd;
     this.tylerObjFac = new tyler.ecf.extensions.common.ObjectFactory();
     this.ecfCommonObjFac =

--- a/proxyserver/src/main/java/edu/suffolk/litlab/efsp/server/ecf4/PaymentFactory.java
+++ b/proxyserver/src/main/java/edu/suffolk/litlab/efsp/server/ecf4/PaymentFactory.java
@@ -1,5 +1,6 @@
 package edu.suffolk.litlab.efsp.server.ecf4;
 
+import edu.suffolk.litlab.efsp.Jurisdiction;
 import java.math.BigDecimal;
 import oasis.names.specification.ubl.schema.xsd.commonaggregatecomponents_2.AllowanceChargeType;
 import oasis.names.specification.ubl.schema.xsd.commonaggregatecomponents_2.PaymentMeansType;
@@ -13,7 +14,7 @@ import oasis.names.tc.legalxml_courtfiling.schema.xsd.paymentmessage_4.PaymentMe
 import tyler.ecf.extensions.common.ProviderChargeType;
 
 public class PaymentFactory {
-  public static PaymentMessageType makePaymentMessage(String paymentId, String jurisdiction) {
+  public static PaymentMessageType makePaymentMessage(String paymentId, Jurisdiction jurisdiction) {
     var ecfObjFac =
         new oasis.names.tc.legalxml_courtfiling.schema.xsd.paymentmessage_4.ObjectFactory();
     PaymentMessageType pmt = ecfObjFac.createPaymentMessageType();
@@ -29,7 +30,8 @@ public class PaymentFactory {
     return pmt;
   }
 
-  public static ProviderChargeType makeProviderChargeType(String paymentId, String jurisdiction) {
+  public static ProviderChargeType makeProviderChargeType(
+      String paymentId, Jurisdiction jurisdiction) {
     tyler.ecf.extensions.common.ObjectFactory tylerObjFac =
         new tyler.ecf.extensions.common.ObjectFactory();
     ProviderChargeType pct = tylerObjFac.createProviderChargeType();
@@ -38,7 +40,7 @@ public class PaymentFactory {
   }
 
   private static AllowanceChargeType makeAllowanceChargeType(
-      String paymentId, String jurisdiction) {
+      String paymentId, Jurisdiction jurisdiction) {
     var cacObjFac =
         new oasis.names.specification.ubl.schema.xsd.commonaggregatecomponents_2.ObjectFactory();
     var cbcObjFac =

--- a/proxyserver/src/main/java/edu/suffolk/litlab/efsp/server/ecf4/SoapClientChooser.java
+++ b/proxyserver/src/main/java/edu/suffolk/litlab/efsp/server/ecf4/SoapClientChooser.java
@@ -1,6 +1,9 @@
 package edu.suffolk.litlab.efsp.server.ecf4;
 
-import edu.suffolk.litlab.efsp.tyler.TylerEnv;
+import static edu.suffolk.litlab.efsp.Jurisdiction.*;
+import static edu.suffolk.litlab.efsp.tyler.TylerEnv.*;
+
+import edu.suffolk.litlab.efsp.tyler.TylerDomain;
 import https.docs_oasis_open_org.legalxml_courtfiling.ns.v5_0.wsdl.courtschedulingmde.CourtSchedulingMDE_Service;
 import java.net.URL;
 import java.util.Map;
@@ -19,53 +22,67 @@ public class SoapClientChooser {
 
   private static final Logger log = LoggerFactory.getLogger(SoapClientChooser.class);
 
-  // TODO(#284): finish this refactor to use TylerEnvs instead of strings
-  private static final Map<String, URL> serviceMDEWsdls =
+  private static final Map<TylerDomain, URL> serviceMDEWsdls =
       Map.of(
-          "illinois-stage", getRes("wsdl/stage/illinois-ECF-4.0-ServiceMDEService.wsdl"),
-          "illinois-test", getRes("wsdl/test/illinois-ECF-4.0-ServiceMDEService.wsdl"),
-          "illinois-prod", getRes("wsdl/prod/illinois-ECF-4.0-ServiceMDEService.wsdl"),
-          "massachusetts-stage", getRes("wsdl/stage/massachusetts-ECF-4.0-ServiceMDEService.wsdl"),
-          "massachusetts-prod", getRes("wsdl/prod/massachusetts-ECF-4.0-ServiceMDEService.wsdl"),
-          "california-stage", getRes("wsdl/stage/california-ECF-4.0-ServiceMDEService.wsdl"),
-          "texas-stage", getRes("wsdl/stage/texas-ECF-4.0-ServiceMDEService.wsdl"),
-          "indiana-stage", getRes("wsdl/stage/indiana-ECF-4.0-ServiceMDEService.wsdl"),
-          "vermont-stage", getRes("wsdl/stage/vermont-ECF-4.0-ServiceMDEService.wsdl"));
+          new TylerDomain(ILLINOIS, STAGE),
+              getRes("wsdl/stage/illinois-ECF-4.0-ServiceMDEService.wsdl"),
+          new TylerDomain(ILLINOIS, PROD),
+              getRes("wsdl/prod/illinois-ECF-4.0-ServiceMDEService.wsdl"),
+          new TylerDomain(MASSACHUSETTS, STAGE),
+              getRes("wsdl/stage/massachusetts-ECF-4.0-ServiceMDEService.wsdl"),
+          new TylerDomain(MASSACHUSETTS, PROD),
+              getRes("wsdl/prod/massachusetts-ECF-4.0-ServiceMDEService.wsdl"),
+          new TylerDomain(CALIFORNIA, STAGE),
+              getRes("wsdl/stage/california-ECF-4.0-ServiceMDEService.wsdl"),
+          new TylerDomain(TEXAS, STAGE), getRes("wsdl/stage/texas-ECF-4.0-ServiceMDEService.wsdl"),
+          new TylerDomain(INDIANA, STAGE),
+              getRes("wsdl/stage/indiana-ECF-4.0-ServiceMDEService.wsdl"),
+          new TylerDomain(VERMONT, STAGE),
+              getRes("wsdl/stage/vermont-ECF-4.0-ServiceMDEService.wsdl"));
 
-  private static final Map<String, URL> filingReviewMDEWsdls =
+  private static final Map<TylerDomain, URL> filingReviewMDEWsdls =
       Map.of(
-          "illinois-stage", getRes("wsdl/stage/illinois-ECF-4.0-FilingReviewMDEService.wsdl"),
-          "illinois-test", getRes("wsdl/test/illinois-ECF-4.0-FilingReviewMDEService.wsdl"),
-          "illinois-prod", getRes("wsdl/prod/illinois-ECF-4.0-FilingReviewMDEService.wsdl"),
-          "massachusetts-stage",
+          new TylerDomain(ILLINOIS, STAGE),
+              getRes("wsdl/stage/illinois-ECF-4.0-FilingReviewMDEService.wsdl"),
+          new TylerDomain(ILLINOIS, PROD),
+              getRes("wsdl/prod/illinois-ECF-4.0-FilingReviewMDEService.wsdl"),
+          new TylerDomain(MASSACHUSETTS, STAGE),
               getRes("wsdl/stage/massachusetts-ECF-4.0-FilingReviewMDEService.wsdl"),
-          "massachusetts-prod",
+          new TylerDomain(MASSACHUSETTS, PROD),
               getRes("wsdl/prod/massachusetts-ECF-4.0-FilingReviewMDEService.wsdl"),
-          "california-stage", getRes("wsdl/stage/california-ECF-4.0-FilingReviewMDEService.wsdl"),
-          "texas-stage", getRes("wsdl/stage/texas-ECF-4.0-FilingReviewMDEService.wsdl"),
-          "indiana-stage", getRes("wsdl/stage/indiana-ECF-4.0-FilingReviewMDEService.wsdl"),
-          "vermont-stage", getRes("wsdl/stage/vermont-ECF-4.0-FilingReviewMDEService.wsdl"));
+          new TylerDomain(CALIFORNIA, STAGE),
+              getRes("wsdl/stage/california-ECF-4.0-FilingReviewMDEService.wsdl"),
+          new TylerDomain(TEXAS, STAGE),
+              getRes("wsdl/stage/texas-ECF-4.0-FilingReviewMDEService.wsdl"),
+          new TylerDomain(INDIANA, STAGE),
+              getRes("wsdl/stage/indiana-ECF-4.0-FilingReviewMDEService.wsdl"),
+          new TylerDomain(VERMONT, STAGE),
+              getRes("wsdl/stage/vermont-ECF-4.0-FilingReviewMDEService.wsdl"));
 
-  private static final Map<String, URL> courtRecordMDEWsdls =
+  private static final Map<TylerDomain, URL> courtRecordMDEWsdls =
       Map.of(
-          "illinois-stage", getRes("wsdl/stage/illinois-ECF-4.0-CourtRecordMDEService.wsdl"),
-          "illinois-test", getRes("wsdl/test/illinois-ECF-4.0-CourtRecordMDEService.wsdl"),
-          "illinois-prod", getRes("wsdl/prod/illinois-ECF-4.0-CourtRecordMDEService.wsdl"),
-          "massachusetts-stage",
+          new TylerDomain(ILLINOIS, STAGE),
+              getRes("wsdl/stage/illinois-ECF-4.0-CourtRecordMDEService.wsdl"),
+          new TylerDomain(ILLINOIS, PROD),
+              getRes("wsdl/prod/illinois-ECF-4.0-CourtRecordMDEService.wsdl"),
+          new TylerDomain(MASSACHUSETTS, STAGE),
               getRes("wsdl/stage/massachusetts-ECF-4.0-CourtRecordMDEService.wsdl"),
-          "massachusetts-prod",
+          new TylerDomain(MASSACHUSETTS, PROD),
               getRes("wsdl/prod/massachusetts-ECF-4.0-CourtRecordMDEService.wsdl"),
-          "california-stage", getRes("wsdl/stage/california-ECF-4.0-CourtRecordMDEService.wsdl"),
-          "texas-stage", getRes("wsdl/stage/texas-ECF-4.0-CourtRecordMDEService.wsdl"),
-          "indiana-stage", getRes("wsdl/stage/indiana-ECF-4.0-CourtRecordMDEService.wsdl"),
-          "vermont-stage", getRes("wsdl/stage/vermont-ECF-4.0-CourtRecordMDEService.wsdl"));
+          new TylerDomain(CALIFORNIA, STAGE),
+              getRes("wsdl/stage/california-ECF-4.0-CourtRecordMDEService.wsdl"),
+          new TylerDomain(TEXAS, STAGE),
+              getRes("wsdl/stage/texas-ECF-4.0-CourtRecordMDEService.wsdl"),
+          new TylerDomain(INDIANA, STAGE),
+              getRes("wsdl/stage/indiana-ECF-4.0-CourtRecordMDEService.wsdl"),
+          new TylerDomain(VERMONT, STAGE),
+              getRes("wsdl/stage/vermont-ECF-4.0-CourtRecordMDEService.wsdl"));
 
-  private static final Map<String, URL> courtSchedulingMDEWsdls =
+  private static final Map<TylerDomain, URL> courtSchedulingMDEWsdls =
       Map.of(
-          "illinois-stage",
-          getRes("wsdl/stage/illinois-v5-CourtSchedulingMDE.wsdl"),
-          "illinois-prod",
-          getRes("wsdl/prod/illinois-v5-CourtSchedulingMDE.wsdl"));
+          new TylerDomain(ILLINOIS, STAGE),
+              getRes("wsdl/stage/illinois-v5-CourtSchedulingMDE.wsdl"),
+          new TylerDomain(ILLINOIS, PROD), getRes("wsdl/prod/illinois-v5-CourtSchedulingMDE.wsdl"));
 
   private static URL getRes(String wsdlPath) {
     URL url = SoapClientChooser.class.getClassLoader().getResource(wsdlPath);
@@ -76,46 +93,28 @@ public class SoapClientChooser {
     return url;
   }
 
-  public static Optional<FilingReviewMDEService> getFilingReviewFactory(String wsdlDomain) {
-    Optional<URL> url = urlFromString(wsdlDomain, filingReviewMDEWsdls);
+  public static Optional<FilingReviewMDEService> getFilingReviewFactory(TylerDomain wsdlDomain) {
+    Optional<URL> url = urlFrom(wsdlDomain, filingReviewMDEWsdls);
     return url.map(u -> new FilingReviewMDEService(u));
   }
 
-  public static Optional<FilingReviewMDEService> getFilingReviewFactory(
-      String jurisdiction, TylerEnv env) {
-    return getFilingReviewFactory(jurisdiction + "-" + env.getName());
-  }
-
-  public static Optional<ServiceMDEService> getServiceFactory(String wsdlDomain) {
-    Optional<URL> url = urlFromString(wsdlDomain, serviceMDEWsdls);
+  public static Optional<ServiceMDEService> getServiceFactory(TylerDomain wsdlDomain) {
+    Optional<URL> url = urlFrom(wsdlDomain, serviceMDEWsdls);
     return url.map(u -> new ServiceMDEService(u));
   }
 
-  public static Optional<ServiceMDEService> getServiceFactory(String jurisdiction, TylerEnv env) {
-    return getServiceFactory(jurisdiction + "-" + env.getName());
-  }
-
-  public static Optional<CourtRecordMDEService> getCourtRecordFactory(String wsdlDomain) {
-    Optional<URL> url = urlFromString(wsdlDomain, courtRecordMDEWsdls);
+  public static Optional<CourtRecordMDEService> getCourtRecordFactory(TylerDomain wsdlDomain) {
+    Optional<URL> url = urlFrom(wsdlDomain, courtRecordMDEWsdls);
     return url.map(u -> new CourtRecordMDEService(u));
   }
 
-  public static Optional<CourtRecordMDEService> getCourtRecordFactory(
-      String jurisdiction, TylerEnv env) {
-    return getCourtRecordFactory(jurisdiction + "-" + env.getName());
-  }
-
-  public static Optional<CourtSchedulingMDE_Service> getCourtSchedulingFactory(String wsdlDomain) {
-    Optional<URL> url = urlFromString(wsdlDomain, courtSchedulingMDEWsdls);
+  public static Optional<CourtSchedulingMDE_Service> getCourtSchedulingFactory(
+      TylerDomain wsdlDomain) {
+    Optional<URL> url = urlFrom(wsdlDomain, courtSchedulingMDEWsdls);
     return url.map(u -> new CourtSchedulingMDE_Service(u));
   }
 
-  public static Optional<CourtSchedulingMDE_Service> getCourtSchedulingFactory(
-      String jurisdiction, TylerEnv env) {
-    return getCourtSchedulingFactory(jurisdiction + "-" + env.getName());
-  }
-
-  private static Optional<URL> urlFromString(String wsdlDomain, Map<String, URL> domainToWsdl) {
+  private static Optional<URL> urlFrom(TylerDomain wsdlDomain, Map<TylerDomain, URL> domainToWsdl) {
     if (!domainToWsdl.containsKey(wsdlDomain)) {
       return Optional.empty();
     }

--- a/proxyserver/src/main/java/edu/suffolk/litlab/efsp/server/ecf4/TylerConstants.java
+++ b/proxyserver/src/main/java/edu/suffolk/litlab/efsp/server/ecf4/TylerConstants.java
@@ -1,5 +1,6 @@
 package edu.suffolk.litlab.efsp.server.ecf4;
 
+import edu.suffolk.litlab.efsp.Jurisdiction;
 import java.math.BigDecimal;
 import java.util.Map;
 
@@ -7,9 +8,9 @@ public class TylerConstants {
   // This is the amount that we take as a cut.
   public static BigDecimal ourCut = new BigDecimal("0.00");
 
-  public static Map<String, BigDecimal> jurisdictionToTax =
+  public static Map<Jurisdiction, BigDecimal> jurisdictionToTax =
       Map.of(
-          "illinois", new BigDecimal("0.0625"),
-          "massachusetts", new BigDecimal("0.0625"),
-          "texas", new BigDecimal("0.0825"));
+          Jurisdiction.ILLINOIS, new BigDecimal("0.0625"),
+          Jurisdiction.MASSACHUSETTS, new BigDecimal("0.0625"),
+          Jurisdiction.TEXAS, new BigDecimal("0.0825"));
 }

--- a/proxyserver/src/main/java/edu/suffolk/litlab/efsp/server/services/CasesService.java
+++ b/proxyserver/src/main/java/edu/suffolk/litlab/efsp/server/services/CasesService.java
@@ -3,6 +3,7 @@ package edu.suffolk.litlab.efsp.server.services;
 import static edu.suffolk.litlab.efsp.server.utils.EndpointReflection.replacePathParam;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
+import edu.suffolk.litlab.efsp.Jurisdiction;
 import edu.suffolk.litlab.efsp.db.LoginDatabase;
 import edu.suffolk.litlab.efsp.db.model.AtRest;
 import edu.suffolk.litlab.efsp.ecfcodes.tyler.CodeDatabase;
@@ -16,7 +17,7 @@ import edu.suffolk.litlab.efsp.server.ecf4.SoapClientChooser;
 import edu.suffolk.litlab.efsp.server.utils.EndpointReflection;
 import edu.suffolk.litlab.efsp.server.utils.MDCWrappers;
 import edu.suffolk.litlab.efsp.server.utils.ServiceHelpers;
-import edu.suffolk.litlab.efsp.tyler.TylerEnv;
+import edu.suffolk.litlab.efsp.tyler.TylerDomain;
 import edu.suffolk.litlab.efsp.tyler.TylerUserNamePassword;
 import edu.suffolk.litlab.efsp.utils.Hasher;
 import gov.niem.niem.niem_core._2.CaseType;
@@ -78,24 +79,20 @@ public class CasesService {
       new oasis.names.tc.legalxml_courtfiling.schema.xsd.commontypes_4.ObjectFactory();
   private final Supplier<LoginDatabase> ldSupplier;
   private final Supplier<CodeDatabase> cdSupplier;
-  private final String jurisdiction;
+  private final Jurisdiction jurisdiction;
   private final EndpointReflection ef;
 
   public CasesService(
-      String jurisdiction,
-      TylerEnv env,
-      Supplier<LoginDatabase> ldSupplier,
-      Supplier<CodeDatabase> cdSupplier) {
-    this.jurisdiction = jurisdiction;
-    Optional<CourtRecordMDEService> maybeRecords =
-        SoapClientChooser.getCourtRecordFactory(jurisdiction, env);
+      TylerDomain domain, Supplier<LoginDatabase> ldSupplier, Supplier<CodeDatabase> cdSupplier) {
+    this.jurisdiction = domain.jurisdiction();
+    Optional<CourtRecordMDEService> maybeRecords = SoapClientChooser.getCourtRecordFactory(domain);
     if (maybeRecords.isEmpty()) {
-      throw new RuntimeException("Can't find " + jurisdiction + " for court record factory");
+      throw new RuntimeException("Can't find " + domain + " for court record factory");
     }
     this.recordFactory = maybeRecords.get();
     this.cdSupplier = cdSupplier;
     this.ldSupplier = ldSupplier;
-    this.ef = new EndpointReflection("/jurisdictions/" + jurisdiction + "/cases");
+    this.ef = new EndpointReflection("/jurisdictions/" + jurisdiction.getName() + "/cases");
   }
 
   @GET

--- a/proxyserver/src/main/java/edu/suffolk/litlab/efsp/server/services/CourtSchedulingService.java
+++ b/proxyserver/src/main/java/edu/suffolk/litlab/efsp/server/services/CourtSchedulingService.java
@@ -7,6 +7,7 @@ import com.fasterxml.jackson.databind.JsonMappingException;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.json.JsonMapper;
 import com.hubspot.algebra.Result;
+import edu.suffolk.litlab.efsp.Jurisdiction;
 import edu.suffolk.litlab.efsp.db.LoginDatabase;
 import edu.suffolk.litlab.efsp.db.model.AtRest;
 import edu.suffolk.litlab.efsp.ecfcodes.tyler.CodeDatabase;
@@ -25,7 +26,7 @@ import edu.suffolk.litlab.efsp.server.utils.Ecfv5XmlHelper;
 import edu.suffolk.litlab.efsp.server.utils.EndpointReflection;
 import edu.suffolk.litlab.efsp.server.utils.MDCWrappers;
 import edu.suffolk.litlab.efsp.server.utils.ServiceHelpers;
-import edu.suffolk.litlab.efsp.tyler.TylerEnv;
+import edu.suffolk.litlab.efsp.tyler.TylerDomain;
 import edu.suffolk.litlab.efsp.tyler.TylerUserNamePassword;
 import edu.suffolk.litlab.efsp.utils.FailFastCollector;
 import edu.suffolk.litlab.efsp.utils.FilingError;
@@ -100,24 +101,23 @@ public class CourtSchedulingService {
   private final gov.niem.release.niem.proxy.xsd._4.ObjectFactory proxyObjFac;
   private final Map<String, InterviewToFilingInformationConverter> converterMap;
   private final CourtRecordMDEService recordFactory;
-  private final String jurisdiction;
+  private final Jurisdiction jurisdiction;
 
   private final Supplier<CodeDatabase> cdSupplier;
   private final Supplier<LoginDatabase> ldSupplier;
 
   public CourtSchedulingService(
       Map<String, InterviewToFilingInformationConverter> converterMap,
-      String jurisdiction,
-      TylerEnv env,
+      TylerDomain domain,
       Supplier<LoginDatabase> ldSupplier,
       Supplier<CodeDatabase> cdSupplier) {
-    this.jurisdiction = jurisdiction;
+    this.jurisdiction = domain.jurisdiction();
     this.cdSupplier = cdSupplier;
     this.ldSupplier = ldSupplier;
-    var maybeSchedFactory = SoapClientChooser.getCourtSchedulingFactory(jurisdiction, env);
+    var maybeSchedFactory = SoapClientChooser.getCourtSchedulingFactory(domain);
     if (maybeSchedFactory.isEmpty()) {
       throw new RuntimeException(
-          "Can't find " + jurisdiction + " in the SoapClientChooser for CourtScheduler");
+          "Can't find " + domain + " in the SoapClientChooser for CourtScheduler");
     }
     this.schedFactory = maybeSchedFactory.get();
     this.converterMap = converterMap;
@@ -127,10 +127,9 @@ public class CourtSchedulingService {
         new https.docs_oasis_open_org.legalxml_courtfiling.ns.v5_0.reservedate.ObjectFactory();
     this.niemObjFac = new gov.niem.release.niem.niem_core._4.ObjectFactory();
     this.proxyObjFac = new gov.niem.release.niem.proxy.xsd._4.ObjectFactory();
-    Optional<CourtRecordMDEService> maybeCourt =
-        SoapClientChooser.getCourtRecordFactory(jurisdiction, env);
+    Optional<CourtRecordMDEService> maybeCourt = SoapClientChooser.getCourtRecordFactory(domain);
     if (maybeCourt.isEmpty()) {
-      throw new RuntimeException("Cannot find " + jurisdiction + " for court record factory");
+      throw new RuntimeException("Cannot find " + domain + " for court record factory");
     }
     this.recordFactory = maybeCourt.get();
   }

--- a/proxyserver/src/main/java/edu/suffolk/litlab/efsp/server/services/CourtsOnlyCodesService.java
+++ b/proxyserver/src/main/java/edu/suffolk/litlab/efsp/server/services/CourtsOnlyCodesService.java
@@ -2,6 +2,7 @@ package edu.suffolk.litlab.efsp.server.services;
 
 import static edu.suffolk.litlab.efsp.server.utils.EndpointReflection.replacePathParam;
 
+import edu.suffolk.litlab.efsp.Jurisdiction;
 import edu.suffolk.litlab.efsp.ecfcodes.tyler.NameAndCode;
 import edu.suffolk.litlab.efsp.server.utils.EndpointReflection;
 import jakarta.ws.rs.core.HttpHeaders;
@@ -21,11 +22,11 @@ public class CourtsOnlyCodesService extends CodesService {
 
   private final Map<String, String> courts; // map court code names to full names
   private final EndpointReflection ef;
-  private final String jurisdiction;
+  private final Jurisdiction jurisdiction;
 
-  public CourtsOnlyCodesService(String jurisdiction, Map<String, String> courts) {
+  public CourtsOnlyCodesService(Jurisdiction jurisdiction, Map<String, String> courts) {
     this.jurisdiction = jurisdiction;
-    this.ef = new EndpointReflection("/jurisdictions/" + jurisdiction + "/codes");
+    this.ef = new EndpointReflection("/jurisdictions/" + jurisdiction.getName() + "/codes");
     this.courts = courts;
   }
 

--- a/proxyserver/src/main/java/edu/suffolk/litlab/efsp/server/services/EcfCodesService.java
+++ b/proxyserver/src/main/java/edu/suffolk/litlab/efsp/server/services/EcfCodesService.java
@@ -2,6 +2,7 @@ package edu.suffolk.litlab.efsp.server.services;
 
 import static edu.suffolk.litlab.efsp.server.utils.EndpointReflection.replacePathParam;
 
+import edu.suffolk.litlab.efsp.Jurisdiction;
 import edu.suffolk.litlab.efsp.ecfcodes.tyler.CaseCategory;
 import edu.suffolk.litlab.efsp.ecfcodes.tyler.CaseType;
 import edu.suffolk.litlab.efsp.ecfcodes.tyler.CodeDatabase;
@@ -77,9 +78,9 @@ public class EcfCodesService extends CodesService {
   private final Supplier<CodeDatabase> cdSupplier;
   private final EndpointReflection ef;
 
-  public EcfCodesService(String jurisdiction, Supplier<CodeDatabase> cdSupplier) {
+  public EcfCodesService(Jurisdiction jurisdiction, Supplier<CodeDatabase> cdSupplier) {
     this.cdSupplier = cdSupplier;
-    this.ef = new EndpointReflection("/jurisdictions/" + jurisdiction + "/codes");
+    this.ef = new EndpointReflection("/jurisdictions/" + jurisdiction.getName() + "/codes");
   }
 
   @Override

--- a/proxyserver/src/main/java/edu/suffolk/litlab/efsp/server/services/FilingReviewService.java
+++ b/proxyserver/src/main/java/edu/suffolk/litlab/efsp/server/services/FilingReviewService.java
@@ -6,6 +6,7 @@ import static edu.suffolk.litlab.efsp.utils.JsonHelpers.getStringDefault;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.hubspot.algebra.NullValue;
 import com.hubspot.algebra.Result;
+import edu.suffolk.litlab.efsp.Jurisdiction;
 import edu.suffolk.litlab.efsp.db.LoginDatabase;
 import edu.suffolk.litlab.efsp.db.UserDatabase;
 import edu.suffolk.litlab.efsp.db.model.AtRest;
@@ -68,7 +69,7 @@ public class FilingReviewService {
   private final EndpointReflection ef;
 
   public FilingReviewService(
-      String jurisdiction,
+      Jurisdiction jurisdiction,
       Supplier<LoginDatabase> ldSupplier,
       Supplier<UserDatabase> udSupplier,
       Map<String, InterviewToFilingInformationConverter> converterMap,
@@ -81,7 +82,7 @@ public class FilingReviewService {
     this.ldSupplier = ldSupplier;
     this.udSupplier = udSupplier;
     this.msgSender = msgSender;
-    this.ef = new EndpointReflection("/jurisdictions/" + jurisdiction + "/filingreview");
+    this.ef = new EndpointReflection("/jurisdictions/" + jurisdiction.getName() + "/filingreview");
   }
 
   @GET

--- a/proxyserver/src/main/java/edu/suffolk/litlab/efsp/server/services/JurisdictionServiceHandle.java
+++ b/proxyserver/src/main/java/edu/suffolk/litlab/efsp/server/services/JurisdictionServiceHandle.java
@@ -1,5 +1,6 @@
 package edu.suffolk.litlab.efsp.server.services;
 
+import edu.suffolk.litlab.efsp.Jurisdiction;
 import edu.suffolk.litlab.efsp.server.utils.EndpointReflection;
 import jakarta.ws.rs.GET;
 import jakarta.ws.rs.Path;
@@ -22,10 +23,10 @@ public class JurisdictionServiceHandle {
   private final FilingReviewService filingReview;
   private final Optional<FirmAttorneyAndServiceService> firmAttorneyAndService;
   private final Optional<PaymentsService> payments;
-  private final String jurisdiction;
+  private final Jurisdiction jurisdiction;
 
   public JurisdictionServiceHandle(
-      String jurisdiction,
+      Jurisdiction jurisdiction,
       AdminUserService au,
       CasesService c,
       CodesService codes,
@@ -45,7 +46,7 @@ public class JurisdictionServiceHandle {
   }
 
   public JurisdictionServiceHandle(
-      String jurisdiction,
+      Jurisdiction jurisdiction,
       AdminUserService au,
       CasesService c,
       CodesService codes,
@@ -65,7 +66,7 @@ public class JurisdictionServiceHandle {
   }
 
   public JurisdictionServiceHandle(
-      String jurisdiction, FilingReviewService filingReview, CodesService codes) {
+      Jurisdiction jurisdiction, FilingReviewService filingReview, CodesService codes) {
     this(
         jurisdiction,
         Optional.empty(),
@@ -77,7 +78,7 @@ public class JurisdictionServiceHandle {
         Optional.empty());
   }
 
-  public JurisdictionServiceHandle(String jurisdiction, FilingReviewService filingReview) {
+  public JurisdictionServiceHandle(Jurisdiction jurisdiction, FilingReviewService filingReview) {
     this(
         jurisdiction,
         Optional.empty(),
@@ -90,7 +91,7 @@ public class JurisdictionServiceHandle {
   }
 
   private JurisdictionServiceHandle(
-      String jurisdiction,
+      Jurisdiction jurisdiction,
       Optional<AdminUserService> adminUser,
       Optional<CasesService> cases,
       Optional<CodesService> codes,
@@ -112,7 +113,7 @@ public class JurisdictionServiceHandle {
   @Path("/")
   @Produces(MediaType.APPLICATION_JSON)
   public Response getAll() {
-    EndpointReflection ef = new EndpointReflection("/jurisdictions/" + jurisdiction);
+    EndpointReflection ef = new EndpointReflection("/jurisdictions/" + jurisdiction.getName());
     var endpoints = ef.findRESTEndpoints(List.of(JurisdictionServiceHandle.class));
     log.info("All endpoints for servicehandle: {}", endpoints);
     var map = ef.endPointsToMap(endpoints);

--- a/proxyserver/src/main/java/edu/suffolk/litlab/efsp/server/services/JurisdictionSwitch.java
+++ b/proxyserver/src/main/java/edu/suffolk/litlab/efsp/server/services/JurisdictionSwitch.java
@@ -1,5 +1,6 @@
 package edu.suffolk.litlab.efsp.server.services;
 
+import edu.suffolk.litlab.efsp.Jurisdiction;
 import edu.suffolk.litlab.efsp.server.utils.EndpointReflection;
 import jakarta.ws.rs.GET;
 import jakarta.ws.rs.Path;
@@ -12,9 +13,9 @@ import java.util.Map;
 @Path("/jurisdictions")
 public class JurisdictionSwitch {
 
-  private final Map<String, JurisdictionServiceHandle> jurisdictions;
+  private final Map<Jurisdiction, JurisdictionServiceHandle> jurisdictions;
 
-  public JurisdictionSwitch(Map<String, JurisdictionServiceHandle> jurisdictions) {
+  public JurisdictionSwitch(Map<Jurisdiction, JurisdictionServiceHandle> jurisdictions) {
     this.jurisdictions = jurisdictions;
   }
 
@@ -23,7 +24,9 @@ public class JurisdictionSwitch {
   @Produces(MediaType.APPLICATION_JSON)
   public Response getAll() {
     EndpointReflection ef = new EndpointReflection("/jurisdictions");
-    return Response.ok(ef.pathParamsToMap(jurisdictions.keySet().stream())).build();
+    return Response.ok(
+            ef.pathParamsToMap(jurisdictions.keySet().stream().map(Jurisdiction::getName)))
+        .build();
   }
 
   /**
@@ -37,6 +40,7 @@ public class JurisdictionSwitch {
   @Path("{jurisdiction_id}")
   public JurisdictionServiceHandle getJurisdictionService(
       @PathParam("jurisdiction_id") String jurisdictionId) {
-    return jurisdictions.get(jurisdictionId);
+    Jurisdiction jurisdiction = Jurisdiction.parse(jurisdictionId);
+    return jurisdictions.get(jurisdiction);
   }
 }

--- a/proxyserver/src/main/java/edu/suffolk/litlab/efsp/server/services/PaymentsService.java
+++ b/proxyserver/src/main/java/edu/suffolk/litlab/efsp/server/services/PaymentsService.java
@@ -9,6 +9,7 @@ import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.webcohesion.enunciate.metadata.rs.ResponseCode;
 import com.webcohesion.enunciate.metadata.rs.StatusCodes;
+import edu.suffolk.litlab.efsp.Jurisdiction;
 import edu.suffolk.litlab.efsp.db.LoginDatabase;
 import edu.suffolk.litlab.efsp.ecfcodes.tyler.CodeDatabase;
 import edu.suffolk.litlab.efsp.server.utils.EndpointReflection;
@@ -16,7 +17,7 @@ import edu.suffolk.litlab.efsp.server.utils.MDCWrappers;
 import edu.suffolk.litlab.efsp.server.utils.ServiceHelpers;
 import edu.suffolk.litlab.efsp.stdlib.RandomString;
 import edu.suffolk.litlab.efsp.tyler.TylerClients;
-import edu.suffolk.litlab.efsp.tyler.TylerEnv;
+import edu.suffolk.litlab.efsp.tyler.TylerDomain;
 import edu.suffolk.litlab.efsp.tyler.TylerErrorCodes;
 import edu.suffolk.litlab.efsp.tyler.TylerFirmClient;
 import edu.suffolk.litlab.efsp.tyler.TylerFirmFactory;
@@ -79,8 +80,8 @@ import tyler.efm.latest.services.schema.updatepaymentaccountresponse.UpdatePayme
  */
 @Produces(MediaType.APPLICATION_JSON)
 public class PaymentsService {
-  private static Logger log = LoggerFactory.getLogger(PaymentsService.class);
-  private static tyler.efm.latest.services.schema.common.ObjectFactory tylerCommonObjFac =
+  private static final Logger log = LoggerFactory.getLogger(PaymentsService.class);
+  private static final tyler.efm.latest.services.schema.common.ObjectFactory tylerCommonObjFac =
       new tyler.efm.latest.services.schema.common.ObjectFactory();
   private final String callbackToUsUrl;
   private static final String paymentsErrorHtml =
@@ -101,29 +102,30 @@ public class PaymentsService {
   private final TylerFirmFactory firmFactory;
   private final Supplier<CodeDatabase> cdSupplier;
   private final Supplier<LoginDatabase> ldSupplier;
-  private final String jurisdiction;
+  private final Jurisdiction jurisdiction;
 
   public PaymentsService(
-      String jurisdiction,
-      TylerEnv env,
+      TylerDomain domain,
       String togaKey,
       String togaUrl,
       Supplier<LoginDatabase> ldSupplier,
       Supplier<CodeDatabase> cdSupplier) {
+    this.jurisdiction = domain.jurisdiction();
     this.callbackToUsUrl =
-        ServiceHelpers.EXTERNAL_URL + "/jurisdictions/" + jurisdiction + "/payments/toga-account";
-    this.jurisdiction = jurisdiction;
+        ServiceHelpers.EXTERNAL_URL
+            + "/jurisdictions/"
+            + jurisdiction.getName()
+            + "/payments/toga-account";
     // Will generated 21 character long transaction ids, the max length.
     this.transactionIdGen = new RandomString(21);
     this.togaKey = togaKey;
     this.togaUrl = togaUrl;
     this.tempAccounts = new HashMap<String, TempAccount>();
-    var maybeFirmFactory = TylerClients.getEfmFirmFactory(jurisdiction, env);
+    var maybeFirmFactory = TylerClients.getEfmFirmFactory(domain);
     if (maybeFirmFactory.isPresent()) {
       this.firmFactory = maybeFirmFactory.get();
     } else {
-      throw new RuntimeException(
-          jurisdiction + "-" + env + " not in SoapClientChooser for EFMFirm");
+      throw new RuntimeException(domain + " not in SoapClientChooser for EFMFirm");
     }
     this.cdSupplier = cdSupplier;
     this.ldSupplier = ldSupplier;
@@ -132,7 +134,8 @@ public class PaymentsService {
   @GET
   @Path("/")
   public Response getAll() {
-    EndpointReflection ef = new EndpointReflection("/jurisdictions/" + jurisdiction + "/payments");
+    EndpointReflection ef =
+        new EndpointReflection("/jurisdictions/" + jurisdiction.getName() + "/payments");
     return Response.ok(ef.endPointsToMap(ef.findRESTEndpoints(List.of(PaymentsService.class))))
         .build();
   }

--- a/proxyserver/src/main/java/edu/suffolk/litlab/efsp/server/setup/EfmModuleSetup.java
+++ b/proxyserver/src/main/java/edu/suffolk/litlab/efsp/server/setup/EfmModuleSetup.java
@@ -1,5 +1,6 @@
 package edu.suffolk.litlab.efsp.server.setup;
 
+import edu.suffolk.litlab.efsp.Jurisdiction;
 import edu.suffolk.litlab.efsp.server.services.JurisdictionServiceHandle;
 import edu.suffolk.litlab.efsp.stdlib.StdLib;
 import java.util.List;
@@ -22,7 +23,7 @@ public interface EfmModuleSetup {
 
   Optional<EfmRestCallbackInterface> getCallback();
 
-  String getJurisdiction();
+  Jurisdiction getJurisdiction();
 
   void setupGlobals();
 

--- a/proxyserver/src/main/java/edu/suffolk/litlab/efsp/server/setup/jeffnet/JeffNetModuleSetup.java
+++ b/proxyserver/src/main/java/edu/suffolk/litlab/efsp/server/setup/jeffnet/JeffNetModuleSetup.java
@@ -1,6 +1,7 @@
 package edu.suffolk.litlab.efsp.server.setup.jeffnet;
 
 import com.opencsv.exceptions.CsvValidationException;
+import edu.suffolk.litlab.efsp.Jurisdiction;
 import edu.suffolk.litlab.efsp.db.LoginDatabase;
 import edu.suffolk.litlab.efsp.db.UserDatabase;
 import edu.suffolk.litlab.efsp.server.EfspServer;
@@ -79,8 +80,8 @@ public class JeffNetModuleSetup implements EfmModuleSetup {
   }
 
   @Override
-  public String getJurisdiction() {
-    return "louisiana";
+  public Jurisdiction getJurisdiction() {
+    return Jurisdiction.LOUISIANA;
   }
 
   public Set<String> getCourts() {

--- a/proxyserver/src/main/java/edu/suffolk/litlab/efsp/server/setup/tyler/TylerModuleSetup.java
+++ b/proxyserver/src/main/java/edu/suffolk/litlab/efsp/server/setup/tyler/TylerModuleSetup.java
@@ -4,6 +4,7 @@ import static edu.suffolk.litlab.efsp.stdlib.StdLib.GetEnv;
 
 import com.hubspot.algebra.NullValue;
 import com.hubspot.algebra.Result;
+import edu.suffolk.litlab.efsp.Jurisdiction;
 import edu.suffolk.litlab.efsp.db.LoginDatabase;
 import edu.suffolk.litlab.efsp.db.UserDatabase;
 import edu.suffolk.litlab.efsp.ecfcodes.CodeUpdater;
@@ -25,6 +26,7 @@ import edu.suffolk.litlab.efsp.server.utils.ServiceHelpers;
 import edu.suffolk.litlab.efsp.server.utils.SoapX509CallbackHandler;
 import edu.suffolk.litlab.efsp.server.utils.UpdateCodeVersions;
 import edu.suffolk.litlab.efsp.stdlib.StdLib;
+import edu.suffolk.litlab.efsp.tyler.TylerDomain;
 import edu.suffolk.litlab.efsp.tyler.TylerEnv;
 import edu.suffolk.litlab.efsp.utils.InterviewToFilingInformationConverter;
 import java.sql.SQLException;
@@ -58,12 +60,11 @@ public class TylerModuleSetup implements EfmModuleSetup {
   private final String pgDb;
   private final String pgUser;
   private final String pgPassword;
-  private final String tylerJurisdiction;
+  private final TylerDomain tylerDomain;
   private final String x509Password;
   private final DataSource codeDs;
   private final DataSource userDs;
   private final Map<String, InterviewToFilingInformationConverter> converterMap;
-  private final TylerEnv tylerEnv;
   private final LocalTime codesDbUpdateTime;
 
   // Payments Stuff
@@ -84,14 +85,15 @@ public class TylerModuleSetup implements EfmModuleSetup {
 
   /** Use this factory method instead of the class constructor. */
   public static Optional<TylerModuleSetup> create(
-      String jurisdiction,
+      Jurisdiction jurisdiction,
+      Optional<TylerEnv> env,
       String togaKey,
       LocalTime codesDbUpdateTime,
       Map<String, InterviewToFilingInformationConverter> converterMap,
       DataSource codeDs,
       DataSource userDs,
       OrgMessageSender sender) {
-    Optional<CreationArgs> args = createFromEnvVars();
+    Optional<CreationArgs> args = createFromEnvVars(env);
     if (args.isEmpty()) {
       return Optional.empty();
     }
@@ -110,7 +112,7 @@ public class TylerModuleSetup implements EfmModuleSetup {
 
   private TylerModuleSetup(
       CreationArgs args,
-      String jurisdiction,
+      Jurisdiction jurisdiction,
       String togaKey,
       LocalTime codesDbUpdateTime,
       Map<String, InterviewToFilingInformationConverter> converterMap,
@@ -124,8 +126,7 @@ public class TylerModuleSetup implements EfmModuleSetup {
     this.pgDb = args.pgDb;
     this.pgUser = args.pgUser;
     this.pgPassword = args.pgPassword;
-    this.tylerJurisdiction = jurisdiction;
-    this.tylerEnv = args.tylerEnv;
+    this.tylerDomain = new TylerDomain(jurisdiction, args.tylerEnv);
     this.x509Password = args.x509Password;
     this.togaKey = togaKey;
     this.togaUrl = args.togaUrl;
@@ -133,7 +134,7 @@ public class TylerModuleSetup implements EfmModuleSetup {
     this.codesDbUpdateTime = codesDbUpdateTime;
   }
 
-  private static Optional<CreationArgs> createFromEnvVars() {
+  private static Optional<CreationArgs> createFromEnvVars(Optional<TylerEnv> maybeTylerEnv) {
     Optional<String> maybeX509Password = GetEnv("X509_PASSWORD");
     if (maybeX509Password.isEmpty() || maybeX509Password.orElse("").isBlank()) {
       log.warn("If using Tyler, X509_PASSWORD can't be null. Did you forget to source .env?");
@@ -142,12 +143,12 @@ public class TylerModuleSetup implements EfmModuleSetup {
     CreationArgs args = new CreationArgs();
     args.x509Password = maybeX509Password.get();
 
-    Optional<TylerEnv> maybeTylerEnv = GetEnv("TYLER_ENV").map(TylerEnv::parse);
     if (maybeTylerEnv.isPresent()) {
       log.info("Using {} for TYLER_ENV", maybeTylerEnv.get());
       args.tylerEnv = maybeTylerEnv.get();
     } else {
-      log.info("Not using any TYLER_ENV, maybe prod?");
+      log.error("Not using any TYLER_ENV, so not creating the TylerModule.");
+      return Optional.empty();
     }
 
     args.pgUser = GetEnv("POSTGRES_USER").orElse("postgres");
@@ -180,31 +181,24 @@ public class TylerModuleSetup implements EfmModuleSetup {
     SoapX509CallbackHandler.setX509Password(x509Password);
 
     log.info("Checking table if absent");
-    try (CodeDatabase cd = new CodeDatabase(tylerJurisdiction, tylerEnv, codeDs.getConnection())) {
+    try (CodeDatabase cd = new CodeDatabase(tylerDomain, codeDs.getConnection())) {
       cd.createTablesIfAbsent();
       List<String> locations = cd.getAllLocations();
-      log.info(
-          "All locations for " + this.tylerJurisdiction + "-" + this.tylerEnv + ": " + locations);
+      log.info("All locations for {}: {}", tylerDomain, locations);
       boolean downloadAll = (cd.getAllLocations().size() == 0);
       if (downloadAll) {
         String testOnlyLocation = StdLib.GetEnv("_TEST_ONLY_LOCATION").orElse("");
         if (!testOnlyLocation.isBlank()) {
           log.info(
-              "Downloading just codes for "
-                  + testOnlyLocation
-                  + " in "
-                  + tylerJurisdiction
-                  + ": please wait a bit");
+              "Downloading just codes for {} in {}: please wait a bit",
+              testOnlyLocation,
+              tylerDomain);
           CodeUpdater.executeCommand(
-              () -> cd,
-              tylerJurisdiction,
-              tylerEnv,
-              List.of("replacesome", testOnlyLocation),
-              this.x509Password);
+              () -> cd, tylerDomain, List.of("replacesome", testOnlyLocation), this.x509Password);
         } else {
-          log.info("Downloading all codes for {}: please wait a bit", tylerJurisdiction);
+          log.info("Downloading all codes for {}: please wait a bit", tylerDomain);
           CodeUpdater.executeCommand(
-              () -> cd, tylerJurisdiction, tylerEnv, List.of("replaceall"), this.x509Password);
+              () -> cd, tylerDomain, List.of("replaceall"), this.x509Password);
         }
       }
     } catch (SQLException e) {
@@ -230,7 +224,7 @@ public class TylerModuleSetup implements EfmModuleSetup {
       int hour = codesDbUpdateTime.getHour();
       int min = codesDbUpdateTime.getMinute();
       var r = new Random();
-      String triggerName = "trigger-" + this.tylerJurisdiction + "-" + this.tylerEnv;
+      String triggerName = "trigger-" + tylerDomain.getName();
       Trigger trigger =
           TriggerBuilder.newTrigger()
               .withIdentity(triggerName, "codesdb-group")
@@ -239,8 +233,7 @@ public class TylerModuleSetup implements EfmModuleSetup {
               .build();
 
       log.info("Scheduling daily Tyler EFM code update job around {}", codesDbUpdateTime);
-      scheduler.scheduleJob(
-          buildJob("job-" + this.tylerJurisdiction + "-" + this.tylerEnv), trigger);
+      scheduler.scheduleJob(buildJob("job-" + tylerDomain.getName()), trigger);
 
       if (scheduleImmediately) {
         // Schedule immediate codes update.
@@ -249,16 +242,12 @@ public class TylerModuleSetup implements EfmModuleSetup {
         // by external cron
         Trigger immediateTrigger =
             TriggerBuilder.newTrigger()
-                .withIdentity(
-                    "trigger-immediate-" + this.tylerJurisdiction + "-" + this.tylerEnv,
-                    "codesdb-group")
+                .withIdentity("trigger-immediate-" + tylerDomain.getName(), "codesdb-group")
                 .startNow()
                 .withSchedule(SimpleScheduleBuilder.simpleSchedule().withIntervalInSeconds(20))
                 .build();
         log.info("Scheduling immediate Tyler EFM code update job.");
-        scheduler.scheduleJob(
-            buildJob("job-immediate-" + this.tylerJurisdiction + "-" + this.tylerEnv),
-            immediateTrigger);
+        scheduler.scheduleJob(buildJob("job-immediate-" + tylerDomain.getName()), immediateTrigger);
       }
     } catch (SchedulerException se) {
       log.error("Scheduler Exception: ", se);
@@ -267,12 +256,12 @@ public class TylerModuleSetup implements EfmModuleSetup {
   }
 
   @Override
-  public String getJurisdiction() {
-    return tylerJurisdiction;
+  public Jurisdiction getJurisdiction() {
+    return tylerDomain.jurisdiction();
   }
 
   public Set<String> getCourts() {
-    try (CodeDatabase cd = new CodeDatabase(tylerJurisdiction, tylerEnv, codeDs.getConnection())) {
+    try (CodeDatabase cd = new CodeDatabase(tylerDomain, codeDs.getConnection())) {
       Set<String> allCourts = new HashSet<String>(cd.getAllLocations());
       // 0 and 1 are special "system" courts that have defaults for all courts.
       // They aren't available for filing
@@ -293,15 +282,12 @@ public class TylerModuleSetup implements EfmModuleSetup {
     var filingMap = new HashMap<String, EfmFilingInterface>();
     var callbackMap = new HashMap<String, EfmRestCallbackInterface>();
 
-    final String jurisdiction = getJurisdiction();
-    final TylerEnv env = this.tylerEnv;
-
     Supplier<CodeDatabase> cdSupplier =
         () -> {
-          return CodeDatabase.fromDS(jurisdiction, env, this.codeDs);
+          return CodeDatabase.fromDS(tylerDomain, this.codeDs);
         };
 
-    EfmFilingInterface filer = new Ecf4Filer(jurisdiction, env, cdSupplier);
+    EfmFilingInterface filer = new Ecf4Filer(tylerDomain, cdSupplier);
     for (String court : getCourts()) {
       filingMap.put(court, filer);
       getCallback().ifPresent(call -> callbackMap.put(court, call));
@@ -334,15 +320,14 @@ public class TylerModuleSetup implements EfmModuleSetup {
     Supplier<LoginDatabase> ldSupplier = () -> LoginDatabase.fromDS(this.userDs);
     Supplier<UserDatabase> udSupplier = () -> UserDatabase.fromDS(this.userDs);
 
-    var adminUser =
-        new AdminUserService(jurisdiction, env, ldSupplier, cdSupplier, passwordChecker);
-    var cases = new CasesService(jurisdiction, env, ldSupplier, cdSupplier);
-    var codes = new EcfCodesService(jurisdiction, cdSupplier);
+    var adminUser = new AdminUserService(tylerDomain, ldSupplier, cdSupplier, passwordChecker);
+    var cases = new CasesService(tylerDomain, ldSupplier, cdSupplier);
+    var codes = new EcfCodesService(tylerDomain.jurisdiction(), cdSupplier);
     Optional<CourtSchedulingService> courtScheduler = Optional.empty();
-    if (jurisdiction.equals("illinois")) {
+    if (tylerDomain.jurisdiction() == Jurisdiction.ILLINOIS) {
       courtScheduler =
           Optional.of(
-              new CourtSchedulingService(converterMap, jurisdiction, env, ldSupplier, cdSupplier));
+              new CourtSchedulingService(converterMap, tylerDomain, ldSupplier, cdSupplier));
     }
     var filingReview =
         new FilingReviewService(
@@ -353,9 +338,9 @@ public class TylerModuleSetup implements EfmModuleSetup {
             filingMap,
             callbackMap,
             this.sender);
-    var firmAttorney = new FirmAttorneyAndServiceService(jurisdiction, env, ldSupplier, cdSupplier);
+    var firmAttorney = new FirmAttorneyAndServiceService(tylerDomain, ldSupplier, cdSupplier);
     var payments =
-        new PaymentsService(jurisdiction, env, this.togaKey, this.togaUrl, ldSupplier, cdSupplier);
+        new PaymentsService(tylerDomain, this.togaKey, this.togaUrl, ldSupplier, cdSupplier);
     JurisdictionServiceHandle handle =
         new JurisdictionServiceHandle(
             getJurisdiction(),
@@ -376,12 +361,15 @@ public class TylerModuleSetup implements EfmModuleSetup {
 
   @Override
   public void setupGlobals() {
-    Supplier<CodeDatabase> makeCD = () -> CodeDatabase.fromDS(tylerJurisdiction, tylerEnv, codeDs);
+    Supplier<CodeDatabase> makeCD = () -> CodeDatabase.fromDS(tylerDomain, codeDs);
     Supplier<UserDatabase> makeUD = () -> UserDatabase.fromDS(userDs);
     OasisEcfWsCallback implementor = new OasisEcfWsCallback(makeCD, makeUD, sender);
     String baseLocalUrl = ServiceHelpers.BASE_LOCAL_URL;
     String address =
-        baseLocalUrl + "/jurisdictions/" + tylerJurisdiction + ServiceHelpers.ASSEMBLY_PORT;
+        baseLocalUrl
+            + "/jurisdictions/"
+            + tylerDomain.jurisdiction().getName()
+            + ServiceHelpers.ASSEMBLY_PORT;
     log.info("Starting NFRC callback server at {}", address);
     EndpointImpl jaxWsEndpoint =
         (EndpointImpl) jakarta.xml.ws.Endpoint.publish(address, implementor);
@@ -390,7 +378,10 @@ public class TylerModuleSetup implements EfmModuleSetup {
 
     OasisEcfv5WsCallback impl2 = new OasisEcfv5WsCallback(makeCD, makeUD, sender);
     String v5Address =
-        baseLocalUrl + "/jurisdictions/" + tylerJurisdiction + ServiceHelpers.ASSEMBLY_PORT_V5;
+        baseLocalUrl
+            + "/jurisdictions/"
+            + tylerDomain.jurisdiction().getName()
+            + ServiceHelpers.ASSEMBLY_PORT_V5;
     EndpointImpl jaxWsV5Endpoint = (EndpointImpl) jakarta.xml.ws.Endpoint.publish(v5Address, impl2);
     log.info("V5 Address : {}", jaxWsV5Endpoint.getAddress());
     log.info("V5 Bean name: {}", jaxWsV5Endpoint.getBeanName());
@@ -428,14 +419,14 @@ public class TylerModuleSetup implements EfmModuleSetup {
 
   @Override
   public String toString() {
-    return "TylerModuleSetup[jurisdiction=" + tylerJurisdiction + ",env=" + tylerEnv + "]";
+    return "TylerModuleSetup[domain=" + tylerDomain + "]";
   }
 
   private JobDetail buildJob(final String jobName) {
     return JobBuilder.newJob(UpdateCodeVersions.class)
         .withIdentity(jobName, "codesdb-group")
-        .usingJobData("TYLER_JURISDICTION", this.tylerJurisdiction)
-        .usingJobData("TYLER_ENV", this.tylerEnv.getName())
+        .usingJobData("TYLER_JURISDICTION", this.tylerDomain.jurisdiction().getName())
+        .usingJobData("TYLER_ENV", this.tylerDomain.env().getName())
         .usingJobData("X509_PASSWORD", this.x509Password)
         .usingJobData("POSTGRES_URL", this.pgUrl)
         .usingJobData("POSTGRES_DB", this.pgDb)

--- a/proxyserver/src/main/java/edu/suffolk/litlab/efsp/server/utils/ServiceHelpers.java
+++ b/proxyserver/src/main/java/edu/suffolk/litlab/efsp/server/utils/ServiceHelpers.java
@@ -2,6 +2,7 @@ package edu.suffolk.litlab.efsp.server.utils;
 
 import static edu.suffolk.litlab.efsp.stdlib.StdLib.GetEnv;
 
+import edu.suffolk.litlab.efsp.Jurisdiction;
 import edu.suffolk.litlab.efsp.db.LoginDatabase;
 import edu.suffolk.litlab.efsp.db.model.AtRest;
 import edu.suffolk.litlab.efsp.ecfcodes.tyler.CodeDatabase;
@@ -123,7 +124,7 @@ public class ServiceHelpers {
       TylerFirmFactory firmFactory,
       HttpHeaders httpHeaders,
       Supplier<LoginDatabase> ldSupplier,
-      String jurisdiction) {
+      Jurisdiction jurisdiction) {
     return setupFirmPort(firmFactory, httpHeaders, ldSupplier, true, jurisdiction);
   }
 
@@ -133,7 +134,7 @@ public class ServiceHelpers {
       HttpHeaders httpHeaders,
       Supplier<LoginDatabase> ldSupplier,
       boolean needsSoapHeader,
-      String jurisdiction) {
+      Jurisdiction jurisdiction) {
     String activeToken = httpHeaders.getHeaderString("X-API-KEY");
     try (LoginDatabase ld = ldSupplier.get()) {
       Optional<AtRest> atRest = ld.getAtRestInfo(activeToken);

--- a/proxyserver/src/main/java/edu/suffolk/litlab/efsp/server/utils/UpdateCodeVersions.java
+++ b/proxyserver/src/main/java/edu/suffolk/litlab/efsp/server/utils/UpdateCodeVersions.java
@@ -1,9 +1,11 @@
 package edu.suffolk.litlab.efsp.server.utils;
 
+import edu.suffolk.litlab.efsp.Jurisdiction;
 import edu.suffolk.litlab.efsp.db.DatabaseCreator;
 import edu.suffolk.litlab.efsp.ecfcodes.CodeUpdater;
 import edu.suffolk.litlab.efsp.ecfcodes.tyler.CodeDatabase;
 import edu.suffolk.litlab.efsp.server.logging.Monitor;
+import edu.suffolk.litlab.efsp.tyler.TylerDomain;
 import edu.suffolk.litlab.efsp.tyler.TylerEnv;
 import java.sql.Connection;
 import java.sql.SQLException;
@@ -38,10 +40,11 @@ public class UpdateCodeVersions implements Job {
    */
   public void execute(JobExecutionContext context) throws JobExecutionException {
     JobDataMap dataMap = context.getJobDetail().getJobDataMap();
-    String jurisdiction = dataMap.getString("TYLER_JURISDICTION");
-    TylerEnv env = TylerEnv.parse(dataMap.getString("TYLER_ENV"));
+    var jurisdiction = Jurisdiction.parse(dataMap.getString("TYLER_JURISDICTION"));
+    var env = TylerEnv.parse(dataMap.getString("TYLER_ENV"));
+    TylerDomain domain = new TylerDomain(jurisdiction, env);
     MDC.put(MDCWrappers.OPERATION, "UpdateCodeVersions.execute");
-    MDC.put(MDCWrappers.USER_ID, jurisdiction);
+    MDC.put(MDCWrappers.USER_ID, jurisdiction.getName());
     String x509Password = dataMap.getString("X509_PASSWORD");
 
     String pgFullUrl = dataMap.getString("POSTGRES_URL");
@@ -52,9 +55,8 @@ public class UpdateCodeVersions implements Job {
     boolean success = true;
     try (Connection conn =
             DatabaseCreator.makeSingleConnection(pgDb, pgFullUrl, pgUser, pgPassword);
-        CodeDatabase cd = new CodeDatabase(jurisdiction, env, conn)) {
-      success =
-          CodeUpdater.executeCommand(() -> cd, jurisdiction, env, List.of("refresh"), x509Password);
+        CodeDatabase cd = new CodeDatabase(domain, conn)) {
+      success = CodeUpdater.executeCommand(() -> cd, domain, List.of("refresh"), x509Password);
     } catch (SQLException e) {
       log.error("Couldn't connect to Codes db from Job Executor: ", e);
       success = false;
@@ -70,7 +72,7 @@ public class UpdateCodeVersions implements Job {
               "jurisdiction",
               jurisdiction,
               "env",
-              env,
+              env.getName(),
               "error_timestamp",
               LocalDate.now().toString()));
     }

--- a/proxyserver/src/test/java/edu/suffolk/litlab/efsp/db/DatabaseVersionTest.java
+++ b/proxyserver/src/test/java/edu/suffolk/litlab/efsp/db/DatabaseVersionTest.java
@@ -2,10 +2,12 @@ package edu.suffolk.litlab.efsp.db;
 
 import static org.junit.Assert.assertEquals;
 
+import edu.suffolk.litlab.efsp.Jurisdiction;
 import edu.suffolk.litlab.efsp.ecfcodes.tyler.CodeDatabase;
 import edu.suffolk.litlab.efsp.ecfcodes.tyler.FilingComponent;
 import edu.suffolk.litlab.efsp.ecfcodes.tyler.OptionalServiceCode;
 import edu.suffolk.litlab.efsp.ecfcodes.tyler.PartyType;
+import edu.suffolk.litlab.efsp.tyler.TylerDomain;
 import edu.suffolk.litlab.efsp.tyler.TylerEnv;
 import edu.suffolk.litlab.efsp.utils.Hasher;
 import java.io.File;
@@ -146,7 +148,8 @@ public class DatabaseVersionTest {
       assertEquals(rs.getString(1), "illinois-stage");
     }
 
-    try (var codesDatabase = new CodeDatabase("illinois", TylerEnv.STAGE, codeConn)) {
+    try (var codesDatabase =
+        new CodeDatabase(new TylerDomain(Jurisdiction.ILLINOIS, TylerEnv.STAGE), codeConn)) {
       List<OptionalServiceCode> opts = codesDatabase.getOptionalServices("adams", "27959");
       assertEquals(23, opts.size());
       List<PartyType> partyTypes = codesDatabase.getPartyTypeFor("adams", "27898");

--- a/proxyserver/src/test/java/edu/suffolk/litlab/efsp/ecfcodes/tyler/CodeDatabaseTest.java
+++ b/proxyserver/src/test/java/edu/suffolk/litlab/efsp/ecfcodes/tyler/CodeDatabaseTest.java
@@ -5,9 +5,11 @@ import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
+import edu.suffolk.litlab.efsp.Jurisdiction;
 import edu.suffolk.litlab.efsp.db.DatabaseCreator;
 import edu.suffolk.litlab.efsp.db.DatabaseVersionTest;
 import edu.suffolk.litlab.efsp.ecfcodes.CodeUpdater;
+import edu.suffolk.litlab.efsp.tyler.TylerDomain;
 import edu.suffolk.litlab.efsp.tyler.TylerEnv;
 import java.sql.Connection;
 import java.sql.SQLException;
@@ -43,7 +45,7 @@ public class CodeDatabaseTest {
             postgres.getJdbcUrl(),
             postgres.getUsername(),
             postgres.getPassword());
-    cd = new CodeDatabase("illinois", TylerEnv.STAGE, conn);
+    cd = new CodeDatabase(new TylerDomain(Jurisdiction.ILLINOIS, TylerEnv.STAGE), conn);
     cd.createTablesIfAbsent();
   }
 

--- a/proxyserver/src/test/java/edu/suffolk/litlab/efsp/server/auth/SecurityHubTest.java
+++ b/proxyserver/src/test/java/edu/suffolk/litlab/efsp/server/auth/SecurityHubTest.java
@@ -8,6 +8,7 @@ import static org.mockito.Mockito.when;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.node.ObjectNode;
+import edu.suffolk.litlab.efsp.Jurisdiction;
 import edu.suffolk.litlab.efsp.db.LoginDatabase;
 import edu.suffolk.litlab.efsp.db.model.AtRest;
 import edu.suffolk.litlab.efsp.db.model.NewTokens;
@@ -46,7 +47,7 @@ public class SecurityHubTest {
     when(userFactory.makeUserClient(any())).thenReturn(tylerUserClient);
 
     mockClients = Mockito.mockStatic(TylerClients.class);
-    when(TylerClients.getEfmUserFactory(any(), any())).thenReturn(Optional.of(userFactory));
+    when(TylerClients.getEfmUserFactory(any())).thenReturn(Optional.of(userFactory));
   }
 
   @AfterAll
@@ -57,7 +58,7 @@ public class SecurityHubTest {
   @BeforeEach
   public void setup() {
     ld = mock(LoginDatabase.class);
-    hub = new SecurityHub(() -> ld, Optional.of(TylerEnv.STAGE), List.of("illinois"));
+    hub = new SecurityHub(() -> ld, Optional.of(TylerEnv.STAGE), List.of(Jurisdiction.ILLINOIS));
   }
 
   @Test

--- a/proxyserver/src/test/java/edu/suffolk/litlab/efsp/server/services/AdminUserServiceTest.java
+++ b/proxyserver/src/test/java/edu/suffolk/litlab/efsp/server/services/AdminUserServiceTest.java
@@ -8,12 +8,14 @@ import static org.mockito.Mockito.when;
 
 import com.hubspot.algebra.NullValue;
 import com.hubspot.algebra.Result;
+import edu.suffolk.litlab.efsp.Jurisdiction;
 import edu.suffolk.litlab.efsp.db.LoginDatabase;
 import edu.suffolk.litlab.efsp.db.model.AtRest;
 import edu.suffolk.litlab.efsp.ecfcodes.tyler.CodeDatabase;
 import edu.suffolk.litlab.efsp.ecfcodes.tyler.CourtLocationInfo;
 import edu.suffolk.litlab.efsp.server.EfspServer;
 import edu.suffolk.litlab.efsp.tyler.TylerClients;
+import edu.suffolk.litlab.efsp.tyler.TylerDomain;
 import edu.suffolk.litlab.efsp.tyler.TylerEnv;
 import edu.suffolk.litlab.efsp.tyler.TylerFirmClient;
 import edu.suffolk.litlab.efsp.tyler.TylerFirmFactory;
@@ -69,8 +71,8 @@ public class AdminUserServiceTest {
     when(userFactory.makeUserClient(any())).thenReturn(tylerUserClient);
 
     mockClients = Mockito.mockStatic(TylerClients.class);
-    when(TylerClients.getEfmFirmFactory(any(), any())).thenReturn(Optional.of(firmFactory));
-    when(TylerClients.getEfmUserFactory(any(), any())).thenReturn(Optional.of(userFactory));
+    when(TylerClients.getEfmFirmFactory(any())).thenReturn(Optional.of(firmFactory));
+    when(TylerClients.getEfmUserFactory(any())).thenReturn(Optional.of(userFactory));
   }
 
   private void startServer() {
@@ -98,7 +100,11 @@ public class AdminUserServiceTest {
     sf.setResourceProvider(
         AdminUserService.class,
         new SingletonResourceProvider(
-            new AdminUserService("illinois", TylerEnv.STAGE, () -> ld, () -> cd, passwordChecker)));
+            new AdminUserService(
+                new TylerDomain(Jurisdiction.ILLINOIS, TylerEnv.STAGE),
+                () -> ld,
+                () -> cd,
+                passwordChecker)));
     sf.setAddress(ENDPOINT_ADDRESS);
     Map<Object, Object> extensionMappings = Map.of("json", MediaType.APPLICATION_JSON);
     sf.setExtensionMappings(extensionMappings);

--- a/proxyserver/src/test/java/edu/suffolk/litlab/efsp/server/services/CodesServiceTest.java
+++ b/proxyserver/src/test/java/edu/suffolk/litlab/efsp/server/services/CodesServiceTest.java
@@ -7,11 +7,13 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import edu.suffolk.litlab.efsp.Jurisdiction;
 import edu.suffolk.litlab.efsp.db.DatabaseCreator;
 import edu.suffolk.litlab.efsp.db.DatabaseVersionTest;
 import edu.suffolk.litlab.efsp.ecfcodes.tyler.CodeDatabase;
 import edu.suffolk.litlab.efsp.server.EfspServer;
 import edu.suffolk.litlab.efsp.server.utils.ServiceHelpers;
+import edu.suffolk.litlab.efsp.tyler.TylerDomain;
 import edu.suffolk.litlab.efsp.tyler.TylerEnv;
 import jakarta.ws.rs.core.MediaType;
 import jakarta.ws.rs.core.Response;
@@ -56,7 +58,7 @@ public class CodesServiceTest {
             100);
     Supplier<CodeDatabase> cdSupplier =
         () -> {
-          return CodeDatabase.fromDS("illinois", TylerEnv.STAGE, ds);
+          return CodeDatabase.fromDS(new TylerDomain(Jurisdiction.ILLINOIS, TylerEnv.STAGE), ds);
         };
     try (CodeDatabase cd = cdSupplier.get()) {
       cd.createTablesIfAbsent();
@@ -81,7 +83,7 @@ public class CodesServiceTest {
     sf.setResourceClasses(EcfCodesService.class);
     sf.setResourceProvider(
         EcfCodesService.class,
-        new SingletonResourceProvider(new EcfCodesService("illinois", cdSupplier)));
+        new SingletonResourceProvider(new EcfCodesService(Jurisdiction.ILLINOIS, cdSupplier)));
     sf.setAddress(ENDPOINT_ADDRESS);
     Map<Object, Object> extensionMappings =
         Map.of(


### PR DESCRIPTION
Jurisdiction is vendor agnostic, and also contains info about API type (will be helpful with ECF5 changes).

Instead of strings, which could be accidentally switched, or not verified. Yay more solid typings!

TylerDomains get used mostly everywhere.

Will help with a better config, since we'll be using the Env to determine which config to load and use.

Fix #283, #284