### PR TITLE
Create a new SHA-256 hasher on each call to `makeHash`

### DIFF
--- a/proxyserver/src/main/java/edu/suffolk/litlab/efsp/utils/Hasher.java
+++ b/proxyserver/src/main/java/edu/suffolk/litlab/efsp/utils/Hasher.java
@@ -7,16 +7,6 @@ import org.bouncycastle.util.encoders.Hex;
 
 public class Hasher {
 
-  private static final MessageDigest digest;
-
-  static {
-    try {
-      digest = MessageDigest.getInstance("SHA-256");
-    } catch (NoSuchAlgorithmException ex) {
-      throw new AssertionError(ex);
-    }
-  }
-
   /**
    * Returns a hash of the given input string. Used to hash user IDs and API keys (neither of which
    * need salt, as they're already random).
@@ -25,6 +15,12 @@ public class Hasher {
     if (input == null) {
       return "";
     }
-    return new String(Hex.encode(digest.digest(input.getBytes(StandardCharsets.UTF_8))));
+
+    try {
+      var shaHasher = MessageDigest.getInstance("SHA-256");
+      return new String(Hex.encode(shaHasher.digest(input.getBytes(StandardCharsets.UTF_8))));
+    } catch (NoSuchAlgorithmException ex) {
+      throw new AssertionError(ex);
+    }
   }
 }


### PR DESCRIPTION
MessageDigest does not seem to be thread safe, and when making multiple calls in quick succession (like LiteFile does) will somehow result in the same API key getting different hashes, resulting in those calls failing.