### PR TITLE
Fix prod bug with spaces on the end of phone numbers 

### DIFF
--- a/proxyserver/src/main/java/edu/suffolk/litlab/efsp/server/ecf4/EcfCourtSpecificSerializer.java
+++ b/proxyserver/src/main/java/edu/suffolk/litlab/efsp/server/ecf4/EcfCourtSpecificSerializer.java
@@ -523,7 +523,7 @@ public class EcfCourtSpecificSerializer {
         collector.addRequired(var);
       }
       boolean atLeastOnePhoneAdded = false;
-      for (String phoneNumber : contactInfo.getPhoneNumbers()) {
+      for (String phoneNumber : numbers) {
         if (!phoneRow.matchRegex(phoneNumber)) {
           if (phoneNumber.contains("-")) {
             // HACK(brycew): Massachusetts doesn't like dashes in the number, just numbers
@@ -541,7 +541,7 @@ public class EcfCourtSpecificSerializer {
         cit.getContactMeans().add(niemObjFac.createContactTelephoneNumber(tnt));
         atLeastOnePhoneAdded = true;
       }
-      if (!atLeastOnePhoneAdded) {
+      if (!numbers.isEmpty() && !atLeastOnePhoneAdded) {
         collector.addWrong(var);
       }
     }


### PR DESCRIPTION
A regex for the MA Appeals court was failing on a phone number because one
of the two possible numbers from a user had a space at the end that wasn't
stripped.

Fixed in a few regards:

* adds the regex to the end of the error description (would have saved me a bit of time when triaging)
* strips spaces off the end of the phone number if it doesn't pass the regex the first time
* if at least one number that the user gives is valid, use it, and just discard the others.

Related to the recent production alerts.