### PR TITLE
Hacky fix to issue with not finding any Payment types

### DIFF
--- a/TylerEfmClient/src/main/java/edu/suffolk/litlab/efsp/tyler/Conversion.java
+++ b/TylerEfmClient/src/main/java/edu/suffolk/litlab/efsp/tyler/Conversion.java
@@ -14,11 +14,13 @@ import tyler.efm.latest.services.schema.common.NotificationType;
 import tyler.efm.latest.services.schema.common.PaymentAccountLocation;
 import tyler.efm.latest.services.schema.common.PaymentAccountLocationDetails;
 import tyler.efm.latest.services.schema.common.PaymentAccountType;
+import tyler.efm.latest.services.schema.common.PaymentAccountTypeType;
 import tyler.efm.latest.services.schema.common.RegistrationType;
 import tyler.efm.latest.services.schema.common.RoleLocationType;
 import tyler.efm.latest.services.schema.common.RoleType;
 import tyler.efm.latest.services.schema.common.ServiceContactType;
 import tyler.efm.latest.services.schema.common.UserType;
+import tyler.efm.latest.services.schema.paymentaccounttypelistresponse.PaymentAccountTypeListResponseType;
 
 public class Conversion {
 
@@ -38,6 +40,8 @@ public class Conversion {
             PaymentAccountLocation.class,
             PaymentAccountLocationDetails.class,
             PaymentAccountType.class,
+            PaymentAccountTypeType.class,
+            PaymentAccountTypeListResponseType.class,
             RegistrationType.class,
             RoleLocationType.class,
             RoleType.class,
@@ -52,6 +56,9 @@ public class Conversion {
             tyler.efm.v2022_1.services.schema.common.PaymentAccountLocation.class,
             tyler.efm.v2022_1.services.schema.common.PaymentAccountLocationDetails.class,
             tyler.efm.v2022_1.services.schema.common.PaymentAccountType.class,
+            tyler.efm.v2022_1.services.schema.common.PaymentAccountTypeType.class,
+            tyler.efm.v2022_1.services.schema.paymentaccounttypelistresponse
+                .PaymentAccountTypeListResponseType.class,
             tyler.efm.v2022_1.services.schema.common.RegistrationType.class,
             tyler.efm.v2022_1.services.schema.common.RoleLocationType.class,
             tyler.efm.v2022_1.services.schema.common.RoleType.class,
@@ -83,6 +90,31 @@ public class Conversion {
           String value = (String) o.getClass().getDeclaredMethod("value").invoke(o);
           T output = (T) aClass.getMethod("fromValue", String.class).invoke(null, value);
           return output;
+        } else if (aClass
+            .getName()
+            .equals(
+                tyler.efm.latest.services.schema.paymentaccounttypelistresponse
+                    .PaymentAccountTypeListResponseType.class
+                    .getName())) {
+          // TODO(brycew): this is a hack to fix BeanUtils not working with lists.
+          var pat =
+              new tyler.efm.latest.services.schema.paymentaccounttypelistresponse
+                  .PaymentAccountTypeListResponseType();
+          BeanUtils.copyProperties(pat, o);
+          if (o
+              instanceof
+              tyler.efm.v2022_1.services.schema.paymentaccounttypelistresponse
+                      .PaymentAccountTypeListResponseType
+                  oldObj) {
+            for (int i = 0; i < oldObj.getPaymentAccountType().size(); i++) {
+              pat.getPaymentAccountType()
+                  .add(
+                      convert(
+                          tyler.efm.latest.services.schema.common.PaymentAccountTypeType.class,
+                          oldObj.getPaymentAccountType().get(i)));
+            }
+          }
+          return (T) pat;
         } else {
           T output = aClass.getDeclaredConstructor().newInstance();
           BeanUtils.copyProperties(output, o);

--- a/TylerEfmClient/src/test/java/edu/suffolk/litlab/efsp/tyler/ConversionTest.java
+++ b/TylerEfmClient/src/test/java/edu/suffolk/litlab/efsp/tyler/ConversionTest.java
@@ -63,4 +63,23 @@ public class ConversionTest {
         Conversion.convert(tyler.efm.latest.services.schema.common.RegistrationType.class, oldReg);
     assertThat(newReg.value()).isEqualTo(oldReg.value());
   }
+
+  @Test
+  public void testPaymentAccountTypeList() {
+    var oldResp =
+        new tyler.efm.v2022_1.services.schema.paymentaccounttypelistresponse
+            .PaymentAccountTypeListResponseType();
+    var oldType = new tyler.efm.v2022_1.services.schema.common.PaymentAccountTypeType();
+    oldType.setCode("Wow");
+    oldType.setDescription("A test code");
+    oldResp.getPaymentAccountType().add(oldType);
+
+    var newResp =
+        Conversion.convert(
+            tyler.efm.latest.services.schema.paymentaccounttypelistresponse
+                .PaymentAccountTypeListResponseType.class,
+            oldResp);
+    assertThat(newResp.getPaymentAccountType()).hasSize(1);
+    assertThat(newResp.getPaymentAccountType().get(0).getDescription()).isEqualTo("A test code");
+  }
 }


### PR DESCRIPTION
I can't tell why it just started, but for the BeanUtils won't convert the List of response objects to the "latest" version of the objects. Apparenthly, BeanUtils doesn't handle lists very well, which is concerning, I'm not sure how I missed that in my testing before. Will have to find / consider another solution to this mess.