### PR TITLE
Bump version for test containers

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -23,7 +23,7 @@
         <maven.compiler.target>21</maven.compiler.target>
         <cxf.version>4.0.8</cxf.version>
         <slf4j.version>2.0.7</slf4j.version>
-        <jackson.version>2.14.2</jackson.version>
+        <jackson.version>2.15.0</jackson.version>
         <jacoco.skip>false</jacoco.skip>
         <maven-surefire.version>3.0.0</maven-surefire.version>
         <junit.version>5.9.3</junit.version>
@@ -34,7 +34,7 @@
             <dependency>
                 <groupId>org.apache.commons</groupId>
                 <artifactId>commons-lang3</artifactId>
-                <version>3.12.0</version>
+                <version>3.18.0</version>
             </dependency>
             <dependency>
                 <groupId>org.apache.cxf.xjc-utils</groupId>

--- a/proxyserver/pom.xml
+++ b/proxyserver/pom.xml
@@ -21,9 +21,9 @@
     <properties>
         <cxf.version>4.0.8</cxf.version>
         <slf4j.version>2.0.7</slf4j.version>
-        <jackson.version>2.14.2</jackson.version>
+        <jackson.version>2.15.0</jackson.version>
         <bouncycastle.version>1.81</bouncycastle.version>
-        <testcontainers.version>1.18.0</testcontainers.version>
+        <testcontainers.version>2.0.3</testcontainers.version>
         <jacoco.skip>false</jacoco.skip>
         <skipTestsOnBuild>true</skipTestsOnBuild>
     </properties>
@@ -68,7 +68,7 @@
         <dependency>
             <groupId>org.apache.commons</groupId>
             <artifactId>commons-compress</artifactId>
-            <version>1.21</version>
+            <version>1.28.0</version>
         </dependency>
         <dependency>
             <groupId>org.apache.httpcomponents.client5</groupId>
@@ -289,13 +289,13 @@
         </dependency>
         <dependency>
             <groupId>org.testcontainers</groupId>
-            <artifactId>junit-jupiter</artifactId>
+            <artifactId>testcontainers-junit-jupiter</artifactId>
             <version>${testcontainers.version}</version>
             <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.testcontainers</groupId>
-            <artifactId>postgresql</artifactId>
+            <artifactId>testcontainers-postgresql</artifactId>
             <version>${testcontainers.version}</version>
             <scope>test</scope>
         </dependency>

--- a/proxyserver/src/test/java/edu/suffolk/litlab/efsp/db/UserDatabaseTest.java
+++ b/proxyserver/src/test/java/edu/suffolk/litlab/efsp/db/UserDatabaseTest.java
@@ -1,7 +1,7 @@
 package edu.suffolk.litlab.efsp.db;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import edu.suffolk.litlab.efsp.db.model.Transaction;
 import java.sql.Connection;
@@ -13,8 +13,8 @@ import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
-import org.testcontainers.containers.PostgreSQLContainer;
 import org.testcontainers.junit.jupiter.Container;
+import org.testcontainers.postgresql.PostgreSQLContainer;
 import org.testcontainers.utility.DockerImageName;
 
 @Tag("Docker")
@@ -23,8 +23,8 @@ public class UserDatabaseTest {
   private UserDatabase ud;
 
   @Container
-  public PostgreSQLContainer<?> postgres =
-      new PostgreSQLContainer<>(DockerImageName.parse(DatabaseVersionTest.POSTGRES_DOCKER_NAME));
+  public PostgreSQLContainer postgres =
+      new PostgreSQLContainer(DockerImageName.parse(DatabaseVersionTest.POSTGRES_DOCKER_NAME));
 
   /**
    * Start's the Container and creates the UserDatabase. More info on the TestContainer Library at:

--- a/proxyserver/src/test/java/edu/suffolk/litlab/efsp/server/AddressTest.java
+++ b/proxyserver/src/test/java/edu/suffolk/litlab/efsp/server/AddressTest.java
@@ -1,9 +1,9 @@
 package edu.suffolk.litlab.efsp.server;
 
-import static org.junit.Assert.assertNotEquals;
-import static org.junit.Assert.assertTrue;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 

--- a/proxyserver/src/test/java/edu/suffolk/litlab/efsp/server/InfoCollectorTest.java
+++ b/proxyserver/src/test/java/edu/suffolk/litlab/efsp/server/InfoCollectorTest.java
@@ -1,9 +1,9 @@
 package edu.suffolk.litlab.efsp.server;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.JsonMappingException;


### PR DESCRIPTION
Doesn't work with newer versions of Docker Desktop on Mac (needed for my local test running).

* Apparent I was using Junit 4 functions, which were brought in by testcontainers, so removed those.
* Needed to bump other versions of libraries like Jackson, Apache commons compress and Apache commons lang.

* https://github.com/testcontainers/testcontainers-java/issues/ 11236
* https://github.com/testcontainers/testcontainers-java/releases/tag/2.0.3