### PR TITLE
Remove CountryCodeSimpleType enum

### DIFF
--- a/proxyserver/src/main/java/edu/suffolk/litlab/efsp/docassemble/AddressDocassembleJacksonDeserializer.java
+++ b/proxyserver/src/main/java/edu/suffolk/litlab/efsp/docassemble/AddressDocassembleJacksonDeserializer.java
@@ -1,16 +1,13 @@
 package edu.suffolk.litlab.efsp.docassemble;
 
 import com.fasterxml.jackson.databind.JsonNode;
-import ecf4.latest.gov.niem.niem.fips_10_4._2.CountryCodeSimpleType;
 import edu.suffolk.litlab.efsp.model.Address;
 import edu.suffolk.litlab.efsp.utils.FilingError;
 import edu.suffolk.litlab.efsp.utils.InfoCollector;
 import edu.suffolk.litlab.efsp.utils.InterviewVariable;
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.List;
 import java.util.Optional;
-import java.util.stream.Collectors;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -66,24 +63,17 @@ public class AddressDocassembleJacksonDeserializer {
     String city = (node.has("city")) ? node.get("city").asText("") : "";
     String state = (node.has("state")) ? node.get("state").asText("") : "";
     String zip = (node.has("zip")) ? node.get("zip").asText("") : "";
-    String country = (node.has("country")) ? node.get("country").asText("US") : "US";
-    CountryCodeSimpleType countryCode;
-    try {
-      countryCode = CountryCodeSimpleType.fromValue(country);
-    } catch (IllegalArgumentException ex) {
-      log.error("Country {} isn't a valid country", country, ex);
-      List<String> countries =
-          Arrays.stream(CountryCodeSimpleType.values())
-              .map((t) -> t.toString())
-              .collect(Collectors.toList());
+    String country = (node.has("country")) ? node.get("country").asText("US").toUpperCase() : "US";
+    if (country.length() > 2) {
+      log.error("Country {} isn't a valid country (should be 2 letters", country);
       InterviewVariable countryOptions =
           collector.requestVar(
-              "country", "The 2 letter country code", "choices", countries, Optional.of(country));
+              "country", "The 2 letter country code", "choices", List.of(), Optional.of(country));
       FilingError err = FilingError.wrongValue(countryOptions);
       collector.error(err);
       throw err;
     }
-    Address addr = new Address(address, unit, city, state, zip, countryCode);
+    Address addr = new Address(address, unit, city, state, zip, country);
     return Optional.of(addr);
   }
 }

--- a/proxyserver/src/main/java/edu/suffolk/litlab/efsp/model/Address.java
+++ b/proxyserver/src/main/java/edu/suffolk/litlab/efsp/model/Address.java
@@ -1,7 +1,6 @@
 package edu.suffolk.litlab.efsp.model;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
-import ecf4.latest.gov.niem.niem.fips_10_4._2.CountryCodeSimpleType;
 
 public class Address {
   // NOTE: annotations are for Gson
@@ -30,13 +29,13 @@ public class Address {
       String cityName,
       String stateName,
       String zipCode,
-      CountryCodeSimpleType countryName) {
+      String countryName) {
     this.streetLine = streetLine;
     this.apartmentLine = apartmentLine;
     this.cityName = cityName;
     this.stateName = stateName;
     this.zipCode = zipCode;
-    this.countryName = countryName.name();
+    this.countryName = countryName;
   }
 
   public String getStreet() {

--- a/proxyserver/src/main/java/edu/suffolk/litlab/efsp/server/ecf4/Ecf4Helper.java
+++ b/proxyserver/src/main/java/edu/suffolk/litlab/efsp/server/ecf4/Ecf4Helper.java
@@ -1,8 +1,6 @@
 package edu.suffolk.litlab.efsp.server.ecf4;
 
-import com.hubspot.algebra.Result;
 import ecf4.latest.gov.niem.niem.domains.jxdm._4.CourtType;
-import ecf4.latest.gov.niem.niem.fips_10_4._2.CountryCodeSimpleType;
 import ecf4.latest.gov.niem.niem.fips_10_4._2.CountryCodeType;
 import ecf4.latest.gov.niem.niem.niem_core._2.DateType;
 import ecf4.latest.gov.niem.niem.niem_core._2.EntityType;
@@ -289,16 +287,10 @@ public class Ecf4Helper {
   }
 
   /** Turn a given string into a country type. */
-  public static Result<CountryCodeType, IllegalArgumentException> strToCountryCode(String country) {
+  public static CountryCodeType strToCountryCode(String country) {
     CountryCodeType cct = new CountryCodeType();
-    try {
-      // Trigger an illegal argument exception if not valid
-      CountryCodeSimpleType.fromValue(country);
-      cct.setValue(country);
-      return Result.ok(cct);
-    } catch (IllegalArgumentException ex) {
-      return Result.err(ex);
-    }
+    cct.setValue(country);
+    return cct;
   }
 
   public static <T extends QueryMessageType> T prep(T newMsg, String courtId) {

--- a/proxyserver/src/main/java/edu/suffolk/litlab/efsp/server/ecf4/EcfCourtSpecificSerializer.java
+++ b/proxyserver/src/main/java/edu/suffolk/litlab/efsp/server/ecf4/EcfCourtSpecificSerializer.java
@@ -3,7 +3,6 @@ package edu.suffolk.litlab.efsp.server.ecf4;
 import com.fasterxml.jackson.databind.JsonNode;
 import ecf4.latest.gov.niem.niem.fbi._2.SEXCodeSimpleType;
 import ecf4.latest.gov.niem.niem.fbi._2.SEXCodeType;
-import ecf4.latest.gov.niem.niem.fips_10_4._2.CountryCodeSimpleType;
 import ecf4.latest.gov.niem.niem.fips_10_4._2.CountryCodeType;
 import ecf4.latest.gov.niem.niem.iso_639_3._2.LanguageCodeType;
 import ecf4.latest.gov.niem.niem.niem_core._2.AddressType;
@@ -67,7 +66,6 @@ import edu.suffolk.litlab.efsp.utils.InterviewVariable;
 import jakarta.xml.bind.JAXBElement;
 import java.io.IOException;
 import java.math.BigDecimal;
-import java.util.Arrays;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
@@ -572,10 +570,6 @@ public class EcfCourtSpecificSerializer {
     addr.setAddressLine1(myAddr.getStreet());
     addr.setAddressLine2(myAddr.getApartment());
     addr.setCity(myAddr.getCity());
-    var cct = Ecf4Helper.strToCountryCode(myAddr.getCountry());
-    if (cct.isErr()) {
-      throw FilingError.serverError("Country Code is wrong: " + myAddr.getCountry());
-    }
     addr.setState(myAddr.getState());
     addr.setZipCode(myAddr.getZip());
     addr.setCountry(myAddr.getCountry());
@@ -596,22 +590,7 @@ public class EcfCourtSpecificSerializer {
     ProperNameTextType pntt = niemObjFac.createProperNameTextType();
     pntt.setValue(address.getCity());
     sat.setLocationCityName(pntt);
-    var cctResult = Ecf4Helper.strToCountryCode(address.getCountry());
-    if (cctResult.isErr()) {
-      List<String> countries =
-          Arrays.stream(CountryCodeSimpleType.values())
-              .map((t) -> t.toString())
-              .collect(Collectors.toList());
-      InterviewVariable var =
-          collector.requestVar(
-              "country",
-              "County of the World, in an address",
-              "choices",
-              countries,
-              Optional.of(address.getCountry()));
-      collector.addWrong(var);
-    }
-    CountryCodeType cct = cctResult.unwrapOrElseThrow();
+    CountryCodeType cct = Ecf4Helper.strToCountryCode(address.getCountry());
     sat.setLocationCountry(niemObjFac.createLocationCountryFIPS104Code(cct));
     if (!fillStateCode(address.getState(), cct, sat)) {
       String countryString = cct.getValue();

--- a/proxyserver/src/test/java/edu/suffolk/litlab/efsp/docassemble/PersonDocassembleJacksonDeserializerTest.java
+++ b/proxyserver/src/test/java/edu/suffolk/litlab/efsp/docassemble/PersonDocassembleJacksonDeserializerTest.java
@@ -35,7 +35,6 @@ public class PersonDocassembleJacksonDeserializerTest {
     assertThat(per.getContactInfo().getPhoneNumbers()).hasSize(1);
     assertThat(per.getContactInfo().getAddress())
         .isPresent(); // contains(new Address("123 Fake St", "", "Chicago", "IL", "60007",
-    // CountryCodeSimpleType.US));
     assertThat(per.getContactInfo().getAddress().get().getCity()).isEqualTo("Chicago");
     assertThat(per.getPartyId()).isEqualTo(PartyId.Already("abcd1234-1234-1234-1234-abcdabcd1234"));
     assertThat(per.getRole()).isEqualTo("29738");
@@ -60,7 +59,6 @@ public class PersonDocassembleJacksonDeserializerTest {
     assertThat(per.getContactInfo().getPhoneNumbers()).hasSize(1);
     assertThat(per.getContactInfo().getAddress())
         .isPresent(); // contains(new Address("123 Fake St", "", "Chicago", "IL", "60007",
-    // CountryCodeSimpleType.US));
     assertThat(per.getContactInfo().getAddress().get().getCity()).isEqualTo("Chicago");
     assertThat(per.getPartyId()).isEqualTo(PartyId.Already("abcd1234-1234-1234-1234-abcdabcd1234"));
     assertThat(per.getRole()).isEqualTo("29738");

--- a/proxyserver/src/test/java/edu/suffolk/litlab/efsp/server/AddressTest.java
+++ b/proxyserver/src/test/java/edu/suffolk/litlab/efsp/server/AddressTest.java
@@ -9,7 +9,6 @@ import static org.mockito.Mockito.when;
 
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
-import ecf4.latest.gov.niem.niem.fips_10_4._2.CountryCodeSimpleType;
 import ecf4.latest.gov.niem.niem.niem_core._2.AddressType;
 import ecf4.latest.gov.niem.niem.niem_core._2.ProperNameTextType;
 import ecf4.latest.gov.niem.niem.niem_core._2.StructuredAddressType;
@@ -33,8 +32,7 @@ public class AddressTest {
 
   @BeforeEach
   public void setUp() {
-    addr =
-        new Address("100 Circle Road", "Apt 2", "Plano", "TX", "75093", CountryCodeSimpleType.US);
+    addr = new Address("100 Circle Road", "Apt 2", "Plano", "TX", "75093", "US");
     CodeDatabase cd = mock(CodeDatabase.class);
     when(cd.getStateCodes("adams", "US")).thenReturn(List.of("TX", "MA"));
     CourtLocationInfo loc = new CourtLocationInfo();


### PR DESCRIPTION
* Removes using the `CountryCodeSimpleType` enum from our application code.  
    * Enums are nice, but `wsdl2java` makes it annoying hard (impossible?)
to generate them for all of the enums that need it, so we don't.