### PR TITLE
Needed to manually add the XML stuff to the XSDs we download.

### DIFF
--- a/scripts/redo_wsdls.py
+++ b/scripts/redo_wsdls.py
@@ -579,6 +579,8 @@ def add_new_ecf4_version(version, url):
   with open('bindings.xjb', 'w') as f:
     f.write(bindings_xjb_contents_ecf4)
 
+  unused = input("PAUSE HERE: go edit and add `civil.xsd` and `hs.xsd` to the new version")
+
   java_prefix = f"{start_dir}/../TylerEcf4/src/main/java/"
   wsdl2java['-xjc-Xts', '-d', java_prefix, f'{start_dir}/{path_prefix}/stage/illinois-ECF-4.0-CourtRecordMDEService.wsdl'] & FG
   wsdl2java['-xjc-Xts', '-d', java_prefix, f'{start_dir}/{path_prefix}/stage/illinois-ECF-4.0-FilingReviewMDEService.wsdl'] & FG


### PR DESCRIPTION
Adds a pause in the `redo_wsdl.py` generation script to allow us to add the massachusetts extension, civil.xsd, and hs.xsd to the downloaded stuff. They aren't present in the Tyler values, but are necessary when using the service.

Will merge because it's an easy addition.