### PR TITLE
Do inner joins on domain too, not just location

### DIFF
--- a/proxyserver/src/main/java/edu/suffolk/litlab/efsp/ecfcodes/tyler/CaseCategory.java
+++ b/proxyserver/src/main/java/edu/suffolk/litlab/efsp/ecfcodes/tyler/CaseCategory.java
@@ -144,7 +144,7 @@ public class CaseCategory {
               ROW_NUMBER() OVER(PARTITION BY cate.code ORDER BY type.code) AS RN
             FROM casecategory as cate
               INNER JOIN casetype AS type
-              ON cate.code = type.casecategory AND cate.location = type.location
+              ON cate.code = type.casecategory AND cate.location = type.location AND cate.domain = type.domain
             WHERE cate.domain=? AND cate.location=? AND cate.ecfcasetype != 'CriminalCase'
         ) cat
     WHERE cat.RN = 1
@@ -163,7 +163,7 @@ public class CaseCategory {
               ROW_NUMBER() OVER(PARTITION BY cate.code ORDER BY type.code) AS RN
             FROM casecategory as cate
               INNER JOIN casetype AS type
-              ON cate.code = type.casecategory AND cate.location = type.location
+              ON cate.code = type.casecategory AND cate.location = type.location AND cate.domain = type.domain
             WHERE cate.domain=? AND cate.location=? AND cate.ecfcasetype != 'CriminalCase' AND type.initial ILIKE ?
         ) cat
     WHERE cat.RN = 1


### PR DESCRIPTION
Some locations (i.e. Carroll) are present in multiple jurisdictions (Illinois and Indiana); this would cause issues by saying that a case category had fileable case types under it, when it didn't really (they were in the other jurisdiction).

Currently a local + test server issue; not a prod issue, as I don't think that any Illinois or Massachusetts locations/courts share the same name.