### PR TITLE
Install awscli tools in the docker build and not at runtime

### DIFF
--- a/Docker/fly_startup_script.sh
+++ b/Docker/fly_startup_script.sh
@@ -7,12 +7,10 @@ if test -n "$FLY_MACHINE_ID"; then
   echo "Running Fly.io startup checks..."
   if ! test -f "$PATH_TO_KEYSTORE"; then
     echo "Installing cert"
-    apk add --no-cache aws-cli
     aws s3 cp "$S3_TO_KEYSTORE_CERT" .
   fi
   if ! test -f "client_sign.properties"; then
     echo "Installing client_sign.properties"
-    apk add --no-cache aws-cli
     aws s3 cp "$S3_TO_CLIENT_SIGN_PROPERTIES" .
   fi
 fi

--- a/Dockerfile
+++ b/Dockerfile
@@ -28,6 +28,7 @@ COPY --from=build  /app/proxyserver/target/efspserver-with-deps.jar /app/
 COPY config /app/
 COPY LICENSE /app/
 COPY Docker/docker_run_script.sh Docker/fly_startup_script.sh /app/
+RUN apk update && apk upgrade && apk add --no-cache aws-cli
 
 EXPOSE 9000
 CMD [ "/bin/sh", "/app/docker_run_script.sh" ]


### PR DESCRIPTION
Is currently the reason that containers are failing to start on fly. Running apk update && apk upgrade is the actual fix, and I think that the best option is to run it and install awscli at build time, so there's a gurantee that it works, and we aren't upgrading everything at the same time.

```
13:46:23
Executing busybox-1.37.0-r12.trigger
13:46:23
OK: 203 MiB in 126 packages
13:46:24
Traceback (most recent call last):
13:46:24
  File "/usr/bin/aws", line 19, in <module>
13:46:24
    import awscli.clidriver
13:46:24
  File "/usr/lib/python3.12/site-packages/awscli/clidriver.py", line 67, in <module>
13:46:24
    from awscli.autoprompt.core import AutoPromptDriver
13:46:24
  File "/usr/lib/python3.12/site-packages/awscli/autoprompt/core.py", line 16, in <module>
13:46:24
    from awscli.autoprompt.prompttoolkit import PromptToolkitPrompter
13:46:24
  File "/usr/lib/python3.12/site-packages/awscli/autoprompt/prompttoolkit.py", line 18, in <module>
13:46:24
    from prompt_toolkit.application import Application
13:46:24
  File "/usr/lib/python3.12/site-packages/prompt_toolkit/__init__.py", line 28, in <module>
13:46:24
    from .shortcuts import PromptSession, print_formatted_text, prompt
13:46:24
  File "/usr/lib/python3.12/site-packages/prompt_toolkit/shortcuts/__init__.py", line 12, in <module>
13:46:24
    from .progress_bar import ProgressBar, ProgressBarCounter
13:46:24
  File "/usr/lib/python3.12/site-packages/prompt_toolkit/shortcuts/progress_bar/__init__.py", line 3, in <module>
13:46:24
    from .base import ProgressBar, ProgressBarCounter
13:46:24
  File "/usr/lib/python3.12/site-packages/prompt_toolkit/shortcuts/progress_bar/base.py", line 57, in <module>
13:46:24
    from .formatters import Formatter, create_default_formatters
13:46:24
  File "/usr/lib/python3.12/site-packages/prompt_toolkit/shortcuts/progress_bar/formatters.py", line 129, in <module>
13:46:24
    class Percentage(Formatter):
13:46:24
  File "/usr/lib/python3.12/site-packages/prompt_toolkit/shortcuts/progress_bar/formatters.py", line 134, in Percentage
13:46:24
    template = HTML("<percentage>{percentage:>5}%</percentage>")
13:46:24
               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
13:46:24
  File "/usr/lib/python3.12/site-packages/prompt_toolkit/formatted_text/html.py", line 35, in __init__
13:46:24
    document = minidom.parseString(f"<html-root>{value}</html-root>")
13:46:24
               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
13:46:24
  File "/usr/lib/python3.12/xml/dom/minidom.py", line 1994, in parseString
13:46:24
    from xml.dom import expatbuilder
13:46:24
  File "/usr/lib/python3.12/xml/dom/expatbuilder.py", line 32, in <module>
13:46:24
    from xml.parsers import expat
13:46:24
  File "/usr/lib/python3.12/xml/parsers/expat.py", line 4, in <module>
13:46:24
    from pyexpat import *
13:46:24
ImportError: Error relocating /usr/lib/python3.12/lib-dynload/pyexpat.cpython-312-x86_64-linux-musl.so: XML_SetAllocTrackerActivationThreshold: symbol not found
```

Some related conversation, but for Fedora + RHEL, we're running an alpine: https://discuss.python.org/t/moving-expat-version-or-symbol-checks-from-buildtime-to-runtime/105769.