### PR TITLE
Some version bumps

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -171,7 +171,7 @@
                     <artifactId>maven-javadoc-plugin</artifactId>
                     <version>3.11.2</version>
                     <configuration>
-                        <additionalparam>-Xdoclint:none</additionalparam>
+                        <doclint>none</doclint>
                         <tags>
                             <tag>
                                 <name>requestExample</name>

--- a/pom.xml
+++ b/pom.xml
@@ -21,7 +21,7 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <maven.compiler.source>21</maven.compiler.source>
         <maven.compiler.target>21</maven.compiler.target>
-        <cxf.version>4.0.8</cxf.version>
+        <cxf.version>4.1.5</cxf.version>
         <slf4j.version>2.0.7</slf4j.version>
         <jackson.version>2.21.2</jackson.version>
         <jacoco.skip>false</jacoco.skip>
@@ -40,7 +40,7 @@
             <dependency>
                 <groupId>org.apache.cxf.xjc-utils</groupId>
                 <artifactId>cxf-xjc-runtime</artifactId>
-                <version>4.0.2</version>
+                <version>4.1.2</version>
             </dependency>
             <dependency>
                 <groupId>jakarta.xml.bind</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -23,7 +23,7 @@
         <maven.compiler.target>21</maven.compiler.target>
         <cxf.version>4.0.8</cxf.version>
         <slf4j.version>2.0.7</slf4j.version>
-        <jackson.version>2.15.0</jackson.version>
+        <jackson.version>2.21.2</jackson.version>
         <jacoco.skip>false</jacoco.skip>
         <maven-surefire.version>3.0.0</maven-surefire.version>
         <junit.version>5.9.3</junit.version>

--- a/proxyserver/pom.xml
+++ b/proxyserver/pom.xml
@@ -219,12 +219,12 @@
         <dependency>
             <groupId>com.hubspot</groupId>
             <artifactId>algebra</artifactId>
-            <version>1.3</version>
+            <version>1.7.2</version>
         </dependency>
         <dependency>
             <groupId>com.hubspot</groupId>
             <artifactId>algebra-testing</artifactId>
-            <version>1.3</version>
+            <version>1.7.2</version>
         </dependency>
         <dependency>
             <groupId>com.hubspot.jinjava</groupId>
@@ -239,7 +239,7 @@
         <dependency>
             <groupId>com.opencsv</groupId>
             <artifactId>opencsv</artifactId>
-            <version>5.7.1</version>
+            <version>5.12.0</version>
         </dependency>
         <dependency>
             <groupId>com.sendgrid</groupId>
@@ -261,7 +261,14 @@
         <dependency>
             <groupId>org.quartz-scheduler</groupId>
             <artifactId>quartz</artifactId>
-            <version>2.3.2</version>
+            <version>2.5.2</version>
+        </dependency>
+        <!-- Source: https://mvnrepository.com/artifact/com.mchange/c3p0 -->
+        <dependency>
+            <groupId>com.mchange</groupId>
+            <artifactId>c3p0</artifactId>
+            <version>0.12.0</version>
+            <scope>compile</scope>
         </dependency>
         <dependency>
             <groupId>com.papertrailapp</groupId>
@@ -271,7 +278,7 @@
         <dependency>
             <groupId>org.codehaus.janino</groupId>
             <artifactId>janino</artifactId>
-            <version>3.1.9</version>
+            <version>3.1.12</version>
         </dependency>
         <dependency>
             <groupId>org.junit.jupiter</groupId>

--- a/proxyserver/pom.xml
+++ b/proxyserver/pom.xml
@@ -226,6 +226,13 @@
             <artifactId>algebra-testing</artifactId>
             <version>1.7.2</version>
         </dependency>
+        <!-- to force hubspot algebra to use latest assertj-->
+        <dependency>
+            <groupId>org.assertj</groupId>
+            <artifactId>assertj-core</artifactId>
+            <version>3.27.7</version>
+            <scope>test</scope>
+        </dependency>
         <dependency>
             <groupId>com.hubspot.jinjava</groupId>
             <artifactId>jinjava</artifactId>

--- a/proxyserver/pom.xml
+++ b/proxyserver/pom.xml
@@ -18,7 +18,7 @@
     <properties>
         <cxf.version>4.0.8</cxf.version>
         <slf4j.version>2.0.7</slf4j.version>
-        <jackson.version>2.15.0</jackson.version>
+        <jackson.version>2.21.2</jackson.version>
         <bouncycastle.version>1.81</bouncycastle.version>
         <testcontainers.version>2.0.3</testcontainers.version>
         <jacoco.skip>false</jacoco.skip>

--- a/proxyserver/pom.xml
+++ b/proxyserver/pom.xml
@@ -394,6 +394,14 @@
                 <groupId>com.webcohesion.enunciate</groupId>
                 <artifactId>enunciate-maven-plugin</artifactId>
             </plugin>
+            <plugin>
+                <groupId>org.owasp</groupId>
+                <artifactId>dependency-check-maven</artifactId>
+                <version>12.2.1</version>
+                <configuration>
+                    <failOnError>false</failOnError>
+                </configuration>
+            </plugin>
         </plugins>
     </build>
 

--- a/proxyserver/pom.xml
+++ b/proxyserver/pom.xml
@@ -16,7 +16,7 @@
     <url>https://suffolklitlab.org</url>
 
     <properties>
-        <cxf.version>4.0.8</cxf.version>
+        <cxf.version>4.1.5</cxf.version>
         <slf4j.version>2.0.7</slf4j.version>
         <jackson.version>2.21.2</jackson.version>
         <bouncycastle.version>1.81</bouncycastle.version>

--- a/proxyserver/src/test/java/edu/suffolk/litlab/efsp/server/services/CodesServiceTest.java
+++ b/proxyserver/src/test/java/edu/suffolk/litlab/efsp/server/services/CodesServiceTest.java
@@ -180,6 +180,7 @@ public class CodesServiceTest {
     JsonNode noEnumSearch = getServerJsonAt("/optional_services", Map.of("search", SEARCH_TERM));
     assertThat(noEnumSearch.isArray()).isTrue();
     assertThat(noEnumSearch.iterator())
+        .toIterable()
         .allMatch(
             node -> {
               var matches = node.isTextual() && node.asText().toLowerCase().contains(SEARCH_TERM);
@@ -190,6 +191,7 @@ public class CodesServiceTest {
                           "/optional_services/" + node.asText().replace("/", "%2F"), Map.of());
                   assertThat(retrieve.size()).isGreaterThan(0);
                   assertThat(retrieve.iterator())
+                      .toIterable()
                       .allMatch(
                           loc ->
                               loc.has("location") && loc.get("location").asText().equals("adams"));
@@ -210,6 +212,7 @@ public class CodesServiceTest {
             "/optional_services", Map.of("search", SEARCH_TERM, "result", "COURT_COVERAGE"));
     assertThat(courtCoverageSearch.size()).isEqualTo(1);
     assertThat(courtCoverageSearch.iterator())
+        .toIterable()
         .allMatch(court -> court.isTextual() && court.asText().equals("adams"));
   }
 
@@ -223,6 +226,7 @@ public class CodesServiceTest {
     JsonNode noEnumSearch = getServerJsonAt("/case_types", Map.of("search", SEARCH_TERM));
     assertThat(noEnumSearch.isArray()).isTrue();
     assertThat(noEnumSearch.iterator())
+        .toIterable()
         .allMatch(
             node -> {
               var matches = node.isTextual() && node.asText().toLowerCase().contains(SEARCH_TERM);
@@ -232,6 +236,7 @@ public class CodesServiceTest {
                       getServerJsonAt("/case_types/" + node.asText().replace("/", "%2F"), Map.of());
                   assertThat(retrieve.size()).isGreaterThan(0);
                   assertThat(retrieve.iterator())
+                      .toIterable()
                       .allMatch(
                           loc ->
                               loc.has("location") && loc.get("location").asText().equals("adams"));
@@ -251,6 +256,7 @@ public class CodesServiceTest {
         getServerJsonAt("/case_types", Map.of("search", SEARCH_TERM, "result", "COURT_COVERAGE"));
     assertThat(courtCoverageSearch.size()).isEqualTo(1);
     assertThat(courtCoverageSearch.iterator())
+        .toIterable()
         .allMatch(court -> court.isTextual() && court.asText().equals("adams"));
   }
 }


### PR DESCRIPTION
Working on version bumps of dependencies with CVEs (or that themselves include dependencies with CVEs).

Made using the owasp plugin: run `mvn org.owasp:dependency-check-maven:aggregate` to check again. Only ones that are left are some spring / jetty changes that need more testing (IMO more subtler bugs could pop up).

Also includes some javadoc config fixes.