### PR TITLE
Remove the "Optional" property from the CourtLocationInfo class

### DIFF
--- a/proxyserver/src/main/java/edu/suffolk/litlab/efsp/ecfcodes/tyler/CourtLocationInfo.java
+++ b/proxyserver/src/main/java/edu/suffolk/litlab/efsp/ecfcodes/tyler/CourtLocationInfo.java
@@ -3,7 +3,6 @@ package edu.suffolk.litlab.efsp.ecfcodes.tyler;
 import java.sql.ResultSet;
 import java.sql.SQLException;
 import java.util.List;
-import java.util.Optional;
 
 public class CourtLocationInfo {
   public String code;
@@ -95,7 +94,15 @@ public class CourtLocationInfo {
   public String protectedcasereplacementstring;
 
   public boolean allowzerofeeswithoutfilingparty;
-  public Optional<Boolean> allowserviceoninitial;
+
+  public static enum BoolOrDefault {
+    TRUE,
+    FALSE,
+    DEFAULT
+  }
+
+  public BoolOrDefault
+      allowserviceoninitial; // if default, check DataField FilingServiceCheckBoxInitial
   public boolean allowaddservicecontactsoninitial;
 
   /** True if the court allows redaction of documents. See TODO(#39) */
@@ -201,9 +208,13 @@ public class CourtLocationInfo {
     this.allowzerofeeswithoutfilingparty = Boolean.parseBoolean(rs.getString(24));
     String serviceoninitial = rs.getString(25);
     if (serviceoninitial == null || serviceoninitial.isBlank()) {
-      this.allowserviceoninitial = Optional.empty();
+      this.allowserviceoninitial = BoolOrDefault.DEFAULT;
     } else {
-      this.allowserviceoninitial = Optional.of(Boolean.parseBoolean(serviceoninitial));
+      if (Boolean.parseBoolean(serviceoninitial)) {
+        this.allowserviceoninitial = BoolOrDefault.TRUE;
+      } else {
+        this.allowserviceoninitial = BoolOrDefault.FALSE;
+      }
     }
     this.allowaddservicecontactsoninitial = Boolean.parseBoolean(rs.getString(26));
     this.allowredaction = Boolean.parseBoolean(rs.getString(27));

--- a/proxyserver/src/main/java/edu/suffolk/litlab/efsp/server/ecf4/EcfCourtSpecificSerializer.java
+++ b/proxyserver/src/main/java/edu/suffolk/litlab/efsp/server/ecf4/EcfCourtSpecificSerializer.java
@@ -869,10 +869,12 @@ public class EcfCourtSpecificSerializer {
         collector.addRequired(var);
       }
     }
-    Optional<Boolean> maybeServiceOnInitial = this.court.allowserviceoninitial;
     boolean serviceOnInitial =
-        maybeServiceOnInitial.orElse(
-            allDataFields.getFieldRow("FilingServiceCheckBoxInitial").isvisible);
+        switch (this.court.allowserviceoninitial) {
+          case TRUE -> true;
+          case FALSE -> false;
+          case DEFAULT -> allDataFields.getFieldRow("FilingServiceCheckBoxInitial").isvisible;
+        };
     // From Reference Guide: if no FilingAction is provided, the original default behavior applies:
     // * ReviewFiling API w/o service contacts: EFile
     // * ReviewFiling API w/ service contacts: EfileAndServe

--- a/proxyserver/src/main/java/edu/suffolk/litlab/efsp/server/setup/tyler/Ecf4Filer.java
+++ b/proxyserver/src/main/java/edu/suffolk/litlab/efsp/server/setup/tyler/Ecf4Filer.java
@@ -343,16 +343,14 @@ public class Ecf4Filer extends EfmCheckableFilingInterface {
         cfm.getDocumentIdentification().add(id);
       }
 
-      Optional<Boolean> serviceOnInitial = locationInfo.allowserviceoninitial;
-      if (serviceOnInitial.isEmpty()) {
-        serviceOnInitial =
-            Optional.of(
-                cd.getDataField(locationInfo.code, "FilingServiceCheckBoxInitial").isvisible);
-      }
-      if (isInitialFiling
-          && !serviceOnInitial.orElse(
-              cd.getDataField(locationInfo.code, "FilingServiceCheckBoxInitial").isvisible)
-          && info.getServiceContacts().size() > 0) {
+      boolean serviceOnInitial =
+          switch (locationInfo.allowserviceoninitial) {
+            case TRUE -> true;
+            case FALSE -> false;
+            case DEFAULT ->
+                cd.getDataField(locationInfo.code, "FilingServiceCheckBoxInitial").isvisible;
+          };
+      if (isInitialFiling && !serviceOnInitial && info.getServiceContacts().size() > 0) {
         FilingError err =
             FilingError.malformedInterview(
                 "Court " + locationInfo.name + " doesn't allow service on initial filings");


### PR DESCRIPTION
Jackson makes the ridiculous decision to stop parsing an object halfway through when this happens, printing out the error in the serialized string. Used to be parsed as `{"empty": false, "present": true}`, which is admittedly not a good serialization either (would be broken if it was used). Error below:

Fixed by storing the object specifically as an enum, TRUE, FALSE or DEFAULT (not used anywhere else, so okay for us to do this). 

> Java 8 optional type `java.util.Optional<java.lang.Boolean>` not supported by default: add Module "com.fasterxml.jackson.datatype:jackson-datatype-jdk8" to enable handling (or disable `MapperFeature.REQUIRE_HANDLERS_FOR_JAVA8_OPTIONALS`) (through reference chain: edu.suffolk.litlab.efsp.ecfcodes.tyler.CourtLocationInfo["allowserviceoninitial"])