### PR TITLE
Return login expiration times from tyler auth response

### DIFF
--- a/proxyserver/src/main/java/edu/suffolk/litlab/efsp/db/model/NewTokens.java
+++ b/proxyserver/src/main/java/edu/suffolk/litlab/efsp/db/model/NewTokens.java
@@ -11,17 +11,29 @@ import java.util.Map;
 public class NewTokens {
 
   @JsonUnwrapped private final Map<String, String> tokens;
+  private final Map<String, String> expirationTimes;
 
   public NewTokens() {
     this.tokens = Map.of();
+    this.expirationTimes = Map.of();
   }
 
   public NewTokens(Map<String, String> tokens) {
     this.tokens = tokens;
+    this.expirationTimes = Map.of();
+  }
+
+  public NewTokens(Map<String, String> tokens, Map<String, String> expirationTimes) {
+    this.tokens = tokens;
+    this.expirationTimes = expirationTimes;
   }
 
   public Map<String, String> getTokens() {
     return tokens;
+  }
+
+  public Map<String, String> getExpirationTimes() {
+    return expirationTimes;
   }
 
   @Override
@@ -30,7 +42,8 @@ public class NewTokens {
       return false;
     }
     if (other instanceof NewTokens otherTokens) {
-      return tokens.equals(otherTokens.tokens);
+      return tokens.equals(otherTokens.tokens)
+          && expirationTimes.equals(otherTokens.expirationTimes);
     } else {
       return false;
     }
@@ -38,11 +51,11 @@ public class NewTokens {
 
   @Override
   public int hashCode() {
-    return tokens.hashCode();
+    return tokens.hashCode() * 31 + expirationTimes.hashCode();
   }
 
   @Override
   public String toString() {
-    return tokens.toString();
+    return "tokens=" + tokens + ", expirationTimes=" + expirationTimes;
   }
 }

--- a/proxyserver/src/main/java/edu/suffolk/litlab/efsp/server/auth/LoginInterface.java
+++ b/proxyserver/src/main/java/edu/suffolk/litlab/efsp/server/auth/LoginInterface.java
@@ -1,12 +1,11 @@
 package edu.suffolk.litlab.efsp.server.auth;
 
 import com.fasterxml.jackson.databind.JsonNode;
-import java.util.Map;
 import java.util.Optional;
 
 public interface LoginInterface {
 
-  Optional<Map<String, String>> login(JsonNode loginInfo);
+  Optional<LoginResult> login(JsonNode loginInfo);
 
   String getLoginName();
 

--- a/proxyserver/src/main/java/edu/suffolk/litlab/efsp/server/auth/LoginResult.java
+++ b/proxyserver/src/main/java/edu/suffolk/litlab/efsp/server/auth/LoginResult.java
@@ -1,0 +1,6 @@
+package edu.suffolk.litlab.efsp.server.auth;
+
+import java.util.Map;
+import java.util.Optional;
+
+public record LoginResult(Map<String, String> tokens, Optional<String> expirationDateTime) {}

--- a/proxyserver/src/main/java/edu/suffolk/litlab/efsp/server/auth/SecurityHub.java
+++ b/proxyserver/src/main/java/edu/suffolk/litlab/efsp/server/auth/SecurityHub.java
@@ -31,7 +31,7 @@ public class SecurityHub {
   private static final Logger log = LoggerFactory.getLogger(SecurityHub.class);
 
   private final List<LoginInterface> tylerLoginObjs;
-  private final Map<String, Function<JsonNode, Optional<Map<String, String>>>> loginFunctions;
+  private final Map<String, Function<JsonNode, Optional<LoginResult>>> loginFunctions;
   private final Supplier<LoginDatabase> ldSupplier;
 
   /**
@@ -49,7 +49,8 @@ public class SecurityHub {
     }
 
     this.loginFunctions = new HashMap<>();
-    this.loginFunctions.put("jeffnet", info -> Optional.of(Map.of("JEFFNET-TOKEN", "deprecated")));
+    this.loginFunctions.put("jeffnet",
+        info -> Optional.of(new LoginResult(Map.of("JEFFNET-TOKEN", "deprecated"), Optional.empty())));
     this.loginFunctions.putAll(
         this.tylerLoginObjs.stream()
             .collect(Collectors.toMap(lo -> lo.getLoginName(), lo -> (info) -> lo.login(info))));
@@ -89,6 +90,7 @@ public class SecurityHub {
       return Optional.empty();
     }
     var newTokens = new HashMap<String, String>();
+    var expirationTimes = new HashMap<String, String>();
     Iterable<String> orgs = loginInfo::fieldNames;
     for (String orgName : orgs) {
       orgName = orgName.toLowerCase();
@@ -111,18 +113,21 @@ public class SecurityHub {
         log.error("There is no {} to login to: enabled map: {}", permissionsName, atRest.enabled);
         return Optional.empty();
       }
-      Optional<Map<String, String>> maybeNewTokens =
+      Optional<LoginResult> maybeResult =
           loginFunctions.get(orgName).apply(loginInfo.get(orgName));
-      if (maybeNewTokens.isEmpty()) {
+      if (maybeResult.isEmpty()) {
         log.warn("Couldn't login to {}", orgName);
         return Optional.empty();
       }
       log.info("New tokens for {}", orgName);
-      newTokens.putAll(maybeNewTokens.get());
+      LoginResult result = maybeResult.get();
+      newTokens.putAll(result.tokens());
+      final String finalOrgName = orgName;
+      result.expirationDateTime().ifPresent(expiry -> expirationTimes.put(finalOrgName, expiry));
     }
     if (newTokens.isEmpty()) {
       log.warn("No successful logins occurred: returning empty tokens object");
     }
-    return Optional.of(new NewTokens(newTokens));
+    return Optional.of(new NewTokens(newTokens, expirationTimes));
   }
 }

--- a/proxyserver/src/main/java/edu/suffolk/litlab/efsp/server/auth/SecurityHub.java
+++ b/proxyserver/src/main/java/edu/suffolk/litlab/efsp/server/auth/SecurityHub.java
@@ -49,8 +49,10 @@ public class SecurityHub {
     }
 
     this.loginFunctions = new HashMap<>();
-    this.loginFunctions.put("jeffnet",
-        info -> Optional.of(new LoginResult(Map.of("JEFFNET-TOKEN", "deprecated"), Optional.empty())));
+    this.loginFunctions.put(
+        "jeffnet",
+        info ->
+            Optional.of(new LoginResult(Map.of("JEFFNET-TOKEN", "deprecated"), Optional.empty())));
     this.loginFunctions.putAll(
         this.tylerLoginObjs.stream()
             .collect(Collectors.toMap(lo -> lo.getLoginName(), lo -> (info) -> lo.login(info))));
@@ -113,8 +115,7 @@ public class SecurityHub {
         log.error("There is no {} to login to: enabled map: {}", permissionsName, atRest.enabled);
         return Optional.empty();
       }
-      Optional<LoginResult> maybeResult =
-          loginFunctions.get(orgName).apply(loginInfo.get(orgName));
+      Optional<LoginResult> maybeResult = loginFunctions.get(orgName).apply(loginInfo.get(orgName));
       if (maybeResult.isEmpty()) {
         log.warn("Couldn't login to {}", orgName);
         return Optional.empty();

--- a/proxyserver/src/main/java/edu/suffolk/litlab/efsp/server/auth/TylerLogin.java
+++ b/proxyserver/src/main/java/edu/suffolk/litlab/efsp/server/auth/TylerLogin.java
@@ -8,7 +8,6 @@ import edu.suffolk.litlab.efsp.tyler.TylerUserClient;
 import edu.suffolk.litlab.efsp.tyler.TylerUserFactory;
 import java.util.Map;
 import java.util.Optional;
-import javax.xml.datatype.XMLGregorianCalendar;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import tyler.efm.latest.services.schema.authenticaterequest.AuthenticateRequestType;
@@ -66,12 +65,16 @@ public class TylerLogin implements LoginInterface {
               + authRes.getError().getErrorText());
       return Optional.empty();
     } else {
-      Map<String, String> tokens = Map.of(
-          getHeaderKey(), authRes.getEmail() + ":" + authRes.getPasswordHash(),
-          getHeaderId(jurisdiction), authRes.getUserID());
-      Optional<String> expirationDateTime = authRes.getExpirationDateTime() != null
-          ? Optional.of(authRes.getExpirationDateTime().toString())
-          : Optional.empty();
+      Map<String, String> tokens =
+          Map.of(
+              getHeaderKey(),
+              authRes.getEmail() + ":" + authRes.getPasswordHash(),
+              getHeaderId(jurisdiction),
+              authRes.getUserID());
+      Optional<String> expirationDateTime =
+          authRes.getExpirationDateTime() != null
+              ? Optional.of(authRes.getExpirationDateTime().toString())
+              : Optional.empty();
       return Optional.of(new LoginResult(tokens, expirationDateTime));
     }
   }

--- a/proxyserver/src/main/java/edu/suffolk/litlab/efsp/server/auth/TylerLogin.java
+++ b/proxyserver/src/main/java/edu/suffolk/litlab/efsp/server/auth/TylerLogin.java
@@ -8,6 +8,7 @@ import edu.suffolk.litlab.efsp.tyler.TylerUserClient;
 import edu.suffolk.litlab.efsp.tyler.TylerUserFactory;
 import java.util.Map;
 import java.util.Optional;
+import javax.xml.datatype.XMLGregorianCalendar;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import tyler.efm.latest.services.schema.authenticaterequest.AuthenticateRequestType;
@@ -35,7 +36,7 @@ public class TylerLogin implements LoginInterface {
   }
 
   @Override
-  public Optional<Map<String, String>> login(JsonNode loginInfo) {
+  public Optional<LoginResult> login(JsonNode loginInfo) {
     if (!loginInfo.isObject()
         || !loginInfo.has("username")
         || !loginInfo.get("username").isTextual()) {
@@ -65,12 +66,13 @@ public class TylerLogin implements LoginInterface {
               + authRes.getError().getErrorText());
       return Optional.empty();
     } else {
-      return Optional.of(
-          Map.of(
-              getHeaderKey(),
-              authRes.getEmail() + ":" + authRes.getPasswordHash(),
-              getHeaderId(jurisdiction),
-              authRes.getUserID()));
+      Map<String, String> tokens = Map.of(
+          getHeaderKey(), authRes.getEmail() + ":" + authRes.getPasswordHash(),
+          getHeaderId(jurisdiction), authRes.getUserID());
+      Optional<String> expirationDateTime = authRes.getExpirationDateTime() != null
+          ? Optional.of(authRes.getExpirationDateTime().toString())
+          : Optional.empty();
+      return Optional.of(new LoginResult(tokens, expirationDateTime));
     }
   }
 

--- a/proxyserver/src/test/java/edu/suffolk/litlab/efsp/server/auth/SecurityHubTest.java
+++ b/proxyserver/src/test/java/edu/suffolk/litlab/efsp/server/auth/SecurityHubTest.java
@@ -18,6 +18,8 @@ import edu.suffolk.litlab.efsp.tyler.TylerUserFactory;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+import java.util.GregorianCalendar;
+import javax.xml.datatype.DatatypeFactory;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
@@ -94,7 +96,7 @@ public class SecurityHubTest {
     private ObjectNode loginNode;
 
     @BeforeEach
-    public void setup() {
+    public void setup() throws Exception {
       AtRest atRest = new AtRest();
       atRest.enabled = Map.of("tyler", true, "jeffnet", false);
       when(ld.getAtRestInfo(API_KEY)).thenReturn(Optional.of(atRest));
@@ -106,11 +108,15 @@ public class SecurityHubTest {
       var error = new ErrorType();
       error.setErrorCode("0");
 
+      var expiry = DatatypeFactory.newInstance()
+          .newXMLGregorianCalendar(new GregorianCalendar(2026, 11, 31, 23, 59, 59));
+
       var authResp = new AuthenticateResponseType();
       authResp.setEmail(EMAIL);
       authResp.setError(error);
       authResp.setUserID("abc123");
       authResp.setPasswordHash(PASSWORD_HASH);
+      authResp.setExpirationDateTime(expiry);
       when(tylerUserClient.authenticateUser(refEq(authReq))).thenReturn(authResp);
 
       tylerNode = mapper.createObjectNode();
@@ -140,11 +146,12 @@ public class SecurityHubTest {
       assertThat(activeTyler).isPresent();
       assertThat(activeTyler.get().getTokens().get("TYLER-TOKEN-ILLINOIS"))
           .isEqualTo("bob@example.com:the_password_hash");
+      assertThat(activeTyler.get().getExpirationTimes()).containsKey("tyler-illinois");
       Optional<NewTokens> repeatLogin = hub.login(API_KEY, loginNode);
       assertThat(repeatLogin).isPresent();
       assertThat(activeTyler.get()).isEqualTo(repeatLogin.get());
     }
-
+    
     @Test
     public void testLoginWithUnauthorizedJeffNet() throws Exception {
       ObjectNode jeffNetNode = mapper.createObjectNode();

--- a/proxyserver/src/test/java/edu/suffolk/litlab/efsp/server/auth/SecurityHubTest.java
+++ b/proxyserver/src/test/java/edu/suffolk/litlab/efsp/server/auth/SecurityHubTest.java
@@ -15,10 +15,10 @@ import edu.suffolk.litlab.efsp.db.model.NewTokens;
 import edu.suffolk.litlab.efsp.tyler.TylerClients;
 import edu.suffolk.litlab.efsp.tyler.TylerUserClient;
 import edu.suffolk.litlab.efsp.tyler.TylerUserFactory;
+import java.util.GregorianCalendar;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
-import java.util.GregorianCalendar;
 import javax.xml.datatype.DatatypeFactory;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
@@ -108,8 +108,9 @@ public class SecurityHubTest {
       var error = new ErrorType();
       error.setErrorCode("0");
 
-      var expiry = DatatypeFactory.newInstance()
-          .newXMLGregorianCalendar(new GregorianCalendar(2026, 11, 31, 23, 59, 59));
+      var expiry =
+          DatatypeFactory.newInstance()
+              .newXMLGregorianCalendar(new GregorianCalendar(2026, 11, 31, 23, 59, 59));
 
       var authResp = new AuthenticateResponseType();
       authResp.setEmail(EMAIL);
@@ -151,7 +152,7 @@ public class SecurityHubTest {
       assertThat(repeatLogin).isPresent();
       assertThat(activeTyler.get()).isEqualTo(repeatLogin.get());
     }
-    
+
     @Test
     public void testLoginWithUnauthorizedJeffNet() throws Exception {
       ObjectNode jeffNetNode = mapper.createObjectNode();


### PR DESCRIPTION
Tyler already sends back an `ExpirationDateTime` in the auth response - we just weren't passing it through.

Added a `LoginResult` record to carry both the tokens and expiry out of TylerLogin, threaded it through `SecurityHub`, and surfaced it as a separate expirationTimes field in `NewTokens` so clients can see it in the response.

Updated `SecurityHubTest` to set the expiry on the mock and assert it comes back correctly.
Addresses #334 