### PR TITLE
Add param for court list to get only inital filing ones

### DIFF
--- a/proxyserver/src/main/java/edu/suffolk/litlab/efsp/server/services/CasesService.java
+++ b/proxyserver/src/main/java/edu/suffolk/litlab/efsp/server/services/CasesService.java
@@ -33,6 +33,7 @@ import edu.suffolk.litlab.efsp.server.logging.MDCWrappers;
 import edu.suffolk.litlab.efsp.server.utils.EndpointReflection;
 import edu.suffolk.litlab.efsp.server.utils.NeedsAuthorization;
 import edu.suffolk.litlab.efsp.server.utils.ServiceHelpers;
+import edu.suffolk.litlab.efsp.server.utils.ServiceHelpers.FileableCourtType;
 import edu.suffolk.litlab.efsp.tyler.SoapClientChooser;
 import edu.suffolk.litlab.efsp.tyler.TylerUserNamePassword;
 import edu.suffolk.litlab.efsp.tyler.ecfcodes.CodeDatabase;
@@ -109,7 +110,7 @@ public class CasesService {
   @Path("/courts")
   public Response getCourts() {
     try (CodeDatabase cd = cdSupplier.get()) {
-      return ServiceHelpers.getCourts(cd, false, false).build();
+      return ServiceHelpers.getCourts(cd, FileableCourtType.NONE, false).build();
     } catch (SQLException ex) {
       return Response.status(500).entity("database error retrieving all courts!").build();
     }

--- a/proxyserver/src/main/java/edu/suffolk/litlab/efsp/server/services/CodesService.java
+++ b/proxyserver/src/main/java/edu/suffolk/litlab/efsp/server/services/CodesService.java
@@ -32,7 +32,8 @@ public abstract class CodesService {
   @Path("/courts")
   public abstract Response getCourts(
       @Context HttpHeaders httpHeaders,
-      @DefaultValue("false") @QueryParam("fileable_only") boolean fileable,
+      @Deprecated @DefaultValue("false") @QueryParam("fileable_only") boolean fileable,
+      @DefaultValue("") @QueryParam("fileable_type") String fileableType,
       @DefaultValue("false") @QueryParam("with_names") boolean withNames);
 
   @GET
@@ -47,7 +48,7 @@ public abstract class CodesService {
   @Path("/courts/{court_id}/categories")
   public abstract Response getCategories(
       @PathParam("court_id") String courtId,
-      @DefaultValue("false") @QueryParam("fileable_only") boolean fileableOnly,
+      @Deprecated @DefaultValue("false") @QueryParam("fileable_only") boolean fileableOnly,
       @QueryParam("timing") String timing)
       throws SQLException;
 

--- a/proxyserver/src/main/java/edu/suffolk/litlab/efsp/server/services/EcfCodesService.java
+++ b/proxyserver/src/main/java/edu/suffolk/litlab/efsp/server/services/EcfCodesService.java
@@ -7,6 +7,7 @@ import edu.suffolk.litlab.efsp.ecfcodes.NameAndCode;
 import edu.suffolk.litlab.efsp.server.utils.EndpointReflection;
 import edu.suffolk.litlab.efsp.server.utils.EndpointReflection.Endpoint;
 import edu.suffolk.litlab.efsp.server.utils.ServiceHelpers;
+import edu.suffolk.litlab.efsp.server.utils.ServiceHelpers.FileableCourtType;
 import edu.suffolk.litlab.efsp.tyler.ecfcodes.CaseCategory;
 import edu.suffolk.litlab.efsp.tyler.ecfcodes.CaseType;
 import edu.suffolk.litlab.efsp.tyler.ecfcodes.CodeDatabase;
@@ -90,9 +91,16 @@ public class EcfCodesService extends CodesService {
   }
 
   @Override
-  public Response getCourts(HttpHeaders httpHeaders, boolean fileableOnly, boolean withNames) {
+  public Response getCourts(
+      HttpHeaders httpHeaders, boolean fileable, String fileableType, boolean withNames) {
     try (CodeDatabase cd = cdSupplier.get()) {
-      return cors(ServiceHelpers.getCourts(cd, fileableOnly, withNames));
+      FileableCourtType param;
+      if (fileableType.isBlank()) {
+        param = (fileable) ? FileableCourtType.INITIAL_OR_SUBSEQUENT : FileableCourtType.NONE;
+      } else {
+        param = FileableCourtType.valueOf(fileableType);
+      }
+      return cors(ServiceHelpers.getCourts(cd, param, withNames));
     } catch (SQLException ex) {
       return cors(Response.status(500).entity("SQLException on server!"));
     }

--- a/proxyserver/src/main/java/edu/suffolk/litlab/efsp/server/utils/ServiceHelpers.java
+++ b/proxyserver/src/main/java/edu/suffolk/litlab/efsp/server/utils/ServiceHelpers.java
@@ -2,6 +2,7 @@ package edu.suffolk.litlab.efsp.server.utils;
 
 import static edu.suffolk.litlab.efsp.stdlib.StdLib.GetEnv;
 
+import edu.suffolk.litlab.efsp.ecfcodes.NameAndCode;
 import edu.suffolk.litlab.efsp.tyler.TylerErrorCodes;
 import edu.suffolk.litlab.efsp.tyler.TylerFirmClient;
 import edu.suffolk.litlab.efsp.tyler.TylerFirmFactory;
@@ -13,6 +14,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.stream.Collectors;
+import java.util.stream.Stream;
 import org.apache.cxf.headers.Header;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -80,6 +82,13 @@ public class ServiceHelpers {
     setupServicePort(bp);
   }
 
+  public enum FileableCourtType {
+    INITIAL_OR_SUBSEQUENT,
+    INITIAL,
+    SUBSEQUENT,
+    NONE
+  };
+
   /**
    * Helper for getting all of the valid courts that can be passed to a particular endpoint,
    *
@@ -89,29 +98,29 @@ public class ServiceHelpers {
    * @return
    */
   public static Response.ResponseBuilder getCourts(
-      CodeDatabase cd, boolean fileableOnly, boolean withNames) {
-    if (fileableOnly) {
-      // 0 and 1 are special "system" courts that have defaults for all courts.
-      // They aren't available for filing, so filter out of either query here
-      if (withNames) {
-        return Response.ok(
-            cd.getFileableLocationNames().stream()
-                .filter(c -> !c.getCode().equals("0") && !c.getCode().equals("1"))
-                .sorted()
-                .collect(Collectors.toList()));
-      } else {
-        return Response.ok(
-            cd.getFileableLocations().stream()
-                .filter(c -> !c.equals("0") && !c.equals("1"))
-                .sorted()
-                .collect(Collectors.toList()));
-      }
+      CodeDatabase cd, FileableCourtType fileableOnly, boolean withNames) {
+    Stream<NameAndCode> locs;
+    // 0 and 1 are special "system" courts that have defaults for all courts.
+    // They aren't available for filing, so filter out of either query here
+    if (fileableOnly == FileableCourtType.INITIAL_OR_SUBSEQUENT) {
+      locs =
+          cd.getFileableLocationNames().stream()
+              .filter(c -> !c.getCode().equals("0") && !c.getCode().equals("1"));
+    } else if (fileableOnly == FileableCourtType.INITIAL) {
+      locs =
+          cd.getFileableInitialLocationNames().stream()
+              .filter(c -> !c.getCode().equals("0") && !c.getCode().equals("1"));
+    } else if (fileableOnly == FileableCourtType.SUBSEQUENT) {
+      locs =
+          cd.getFileableSubsequentLocationNames().stream()
+              .filter(c -> !c.getCode().equals("0") && !c.getCode().equals("1"));
     } else {
-      if (withNames) {
-        return Response.ok(cd.getLocationNames());
-      } else {
-        return Response.ok(cd.getAllLocations());
-      }
+      locs = cd.getLocationNames().stream();
+    }
+    if (withNames) {
+      return Response.ok(locs.sorted().collect(Collectors.toList()));
+    } else {
+      return Response.ok(locs.map(c -> c.getCode()).sorted().collect(Collectors.toList()));
     }
   }
 

--- a/proxyserver/src/main/java/edu/suffolk/litlab/efsp/tyler/ecfcodes/CodeDatabase.java
+++ b/proxyserver/src/main/java/edu/suffolk/litlab/efsp/tyler/ecfcodes/CodeDatabase.java
@@ -1278,25 +1278,42 @@ public class CodeDatabase extends CodeDatabaseAPI {
         });
   }
 
-  public List<String> getFileableLocations() {
+  public List<NameAndCode> getFileableLocationNames() {
     return safetyWrap(
         () -> {
           try (PreparedStatement st = conn.prepareStatement(CourtLocationInfo.fileableQuery())) {
             st.setString(1, domainStr());
             ResultSet rs = st.executeQuery();
-            var codes = new ArrayList<String>();
+            var codes = new ArrayList<NameAndCode>();
             while (rs.next()) {
-              codes.add(rs.getString(1));
+              codes.add(new NameAndCode(rs.getString(1), rs.getString(2)));
             }
             return codes;
           }
         });
   }
 
-  public List<NameAndCode> getFileableLocationNames() {
+  public List<NameAndCode> getFileableInitialLocationNames() {
     return safetyWrap(
         () -> {
-          try (PreparedStatement st = conn.prepareStatement(CourtLocationInfo.fileableQuery())) {
+          try (PreparedStatement st =
+              conn.prepareStatement(CourtLocationInfo.fileableInitialQuery())) {
+            st.setString(1, domainStr());
+            ResultSet rs = st.executeQuery();
+            var codes = new ArrayList<NameAndCode>();
+            while (rs.next()) {
+              codes.add(new NameAndCode(rs.getString(1), rs.getString(2)));
+            }
+            return codes;
+          }
+        });
+  }
+
+  public List<NameAndCode> getFileableSubsequentLocationNames() {
+    return safetyWrap(
+        () -> {
+          try (PreparedStatement st =
+              conn.prepareStatement(CourtLocationInfo.fileableSubsequentQuery())) {
             st.setString(1, domainStr());
             ResultSet rs = st.executeQuery();
             var codes = new ArrayList<NameAndCode>();

--- a/proxyserver/src/main/java/edu/suffolk/litlab/efsp/tyler/ecfcodes/CourtLocationInfo.java
+++ b/proxyserver/src/main/java/edu/suffolk/litlab/efsp/tyler/ecfcodes/CourtLocationInfo.java
@@ -290,4 +290,20 @@ public class CourtLocationInfo {
     WHERE domain=? AND (initial ILIKE 'true' OR subsequent ILIKE 'true')
     """;
   }
+
+  public static String fileableInitialQuery() {
+    return """
+    SELECT name, code
+    FROM location
+    WHERE domain=? AND (initial ILIKE 'true')
+    """;
+  }
+
+  public static String fileableSubsequentQuery() {
+    return """
+    SELECT name, code
+    FROM location
+    WHERE domain=? AND (subsequent ILIKE 'true')
+    """;
+  }
 }

--- a/proxyserver/src/test/java/edu/suffolk/litlab/efsp/ecfcodes/tyler/CodeDatabaseTest.java
+++ b/proxyserver/src/test/java/edu/suffolk/litlab/efsp/ecfcodes/tyler/CodeDatabaseTest.java
@@ -8,6 +8,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 import edu.suffolk.litlab.efsp.Jurisdiction;
 import edu.suffolk.litlab.efsp.db.DatabaseCreator;
 import edu.suffolk.litlab.efsp.db.DatabaseVersionTest;
+import edu.suffolk.litlab.efsp.ecfcodes.NameAndCode;
 import edu.suffolk.litlab.efsp.tyler.TylerDomain;
 import edu.suffolk.litlab.efsp.tyler.TylerEnv;
 import edu.suffolk.litlab.efsp.tyler.ecfcodes.CaseCategory;
@@ -110,7 +111,7 @@ public class CodeDatabaseTest {
     Optional<CourtLocationInfo> info = cd.getFullLocationInfo("adams");
     List<String> allCourts = cd.getAllLocations();
     assertTrue(allCourts.size() > 0);
-    List<String> fileable = cd.getFileableLocations();
+    List<NameAndCode> fileable = cd.getFileableLocationNames();
     assertTrue(fileable.size() > 0);
     assertTrue(info.isPresent());
   }


### PR DESCRIPTION
Changes the "filable" boolean to an enum, which gets all courts, only those that can do initial filings, only those that can do subsequent filings, and ones that can do either.