### PR TITLE
Add "JDK8 Module" to Jackson

### DIFF
--- a/proxyserver/pom.xml
+++ b/proxyserver/pom.xml
@@ -169,6 +169,11 @@
             <artifactId>jackson-jakarta-rs-json-provider</artifactId>
             <version>${jackson.version}</version>
         </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.datatype</groupId>
+            <artifactId>jackson-datatype-jdk8</artifactId>
+            <version>${jackson.version}</version>
+        </dependency>
         <!-- https://logback.qos.ch/setup.html#mavenBuild -->
         <dependency>
             <groupId>org.slf4j</groupId>

--- a/proxyserver/src/main/java/edu/suffolk/litlab/efsp/server/EfspServer.java
+++ b/proxyserver/src/main/java/edu/suffolk/litlab/efsp/server/EfspServer.java
@@ -2,6 +2,8 @@ package edu.suffolk.litlab.efsp.server;
 
 import static edu.suffolk.litlab.efsp.stdlib.StdLib.GetEnv;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.datatype.jdk8.Jdk8Module;
 import com.fasterxml.jackson.jakarta.rs.json.JacksonJsonProvider;
 import edu.suffolk.litlab.efsp.ConfigurationLoader;
 import edu.suffolk.litlab.efsp.Jurisdiction;
@@ -193,9 +195,10 @@ public class EfspServer {
   }
 
   public static List<?> providers(Supplier<LoginDatabase> ldSupplier) {
+    var objMapper = new ObjectMapper().registerModule(new Jdk8Module());
     return List.of(
         new JAXBElementProvider<Object>(),
-        new JacksonJsonProvider(), // TODO(brycew): JAXBJSon?
+        new JacksonJsonProvider(objMapper), // TODO(brycew): JAXBJSon?
         new SoapExceptionMapper(),
         new JsonExceptionMapper(),
         new EnumExceptionMapper(),


### PR DESCRIPTION
Newer versions of jackson turn off jdk 8 serialization for some reason, idk why, but it's kinda annoying.