### PR TITLE
Remove TylerEnv from CodeDatabase

### DIFF
--- a/proxyserver/src/main/java/edu/suffolk/litlab/efsp/db/DatabaseVersion.java
+++ b/proxyserver/src/main/java/edu/suffolk/litlab/efsp/db/DatabaseVersion.java
@@ -538,6 +538,8 @@ public class DatabaseVersion {
 
   public void update10To11() throws SQLException {
     // The codes database doesn't need to know about Tyler's environment
+    // Strips the "-stage" and "-prod" suffix off existing domain values so "illinois-stage" becomes
+    // "illinois", then renames the column to jurisdiction
     final String stripEnvSuffix =
         "UPDATE %s SET domain = regexp_replace(domain, '-(stage|prod)$', '')";
 
@@ -595,6 +597,10 @@ public class DatabaseVersion {
     try (Statement st = codeConn.createStatement()) {
       for (String tableName : tableNames) {
         st.executeUpdate(stripEnvSuffix.formatted(tableName));
+      }
+      for (String tableName : tableNames) {
+        st.executeUpdate(
+            "ALTER TABLE %s RENAME COLUMN domain TO jurisdiction".formatted(tableName));
       }
     }
     codeConn.commit();

--- a/proxyserver/src/main/java/edu/suffolk/litlab/efsp/db/DatabaseVersion.java
+++ b/proxyserver/src/main/java/edu/suffolk/litlab/efsp/db/DatabaseVersion.java
@@ -24,7 +24,7 @@ import org.slf4j.LoggerFactory;
  */
 public class DatabaseVersion {
 
-  static final int CURRENT_VERSION = 10;
+  static final int CURRENT_VERSION = 11;
   private static Logger log = LoggerFactory.getLogger(DatabaseVersion.class);
   private final Connection codeConn;
   private final Connection userConn;
@@ -149,6 +149,8 @@ public class DatabaseVersion {
       update8To9();
     } else if (onDiskVersion == 9) {
       update9To10();
+    } else if (onDiskVersion == 10) {
+      update10To11();
     }
     setSchemaVersion(onDiskVersion + 1);
     userConn.commit();
@@ -530,6 +532,70 @@ public class DatabaseVersion {
       // Then, we'll remake the indices
       st.executeUpdate("CREATE INDEX ON optionalservices (location)");
       st.executeUpdate("CREATE INDEX ON optionalservices (domain)");
+    }
+    codeConn.commit();
+  }
+
+  public void update10To11() throws SQLException {
+    // The codes database doesn't need to know about Tyler's environment
+    final String stripEnvSuffix =
+        "UPDATE %s SET domain = regexp_replace(domain, '-(stage|prod)$', '')";
+
+    final List<String> tableNames =
+        List.of(
+            "location",
+            "error",
+            "version",
+            "installedversion",
+            "country",
+            "state",
+            "filingstatus",
+            "datafieldconfig",
+            "answer",
+            "arrestlocation",
+            "bond",
+            "casecategory",
+            "casesubtype",
+            "casetype",
+            "chargephase",
+            "citationjurisdiction",
+            "crossreference",
+            "damageamount",
+            "degree",
+            "disclaimerrequirement",
+            "driverlicensetype",
+            "documenttype",
+            "ethnicity",
+            "eyecolor",
+            "filertype",
+            "filetype",
+            "filing",
+            "filingcomponent",
+            "generaloffense",
+            "haircolor",
+            "language",
+            "lawenforcementunit",
+            "motiontype",
+            "namesuffix",
+            "optionalservices",
+            "optionalservices_filinglist",
+            "partytype",
+            "physicalfeature",
+            "procedureremedy",
+            "question",
+            "race",
+            "refundreason",
+            "servicetype",
+            "statute",
+            "statutetype",
+            "vehiclecolor",
+            "vehiclemake",
+            "vehicletype");
+
+    try (Statement st = codeConn.createStatement()) {
+      for (String tableName : tableNames) {
+        st.executeUpdate(stripEnvSuffix.formatted(tableName));
+      }
     }
     codeConn.commit();
   }

--- a/proxyserver/src/main/java/edu/suffolk/litlab/efsp/ecfcodes/CodeDatabaseAPI.java
+++ b/proxyserver/src/main/java/edu/suffolk/litlab/efsp/ecfcodes/CodeDatabaseAPI.java
@@ -1,9 +1,9 @@
 package edu.suffolk.litlab.efsp.ecfcodes;
 
+import edu.suffolk.litlab.efsp.Jurisdiction;
 import edu.suffolk.litlab.efsp.db.Database;
 import edu.suffolk.litlab.efsp.stdlib.SQLFunction;
 import edu.suffolk.litlab.efsp.stdlib.SQLGetter;
-import edu.suffolk.litlab.efsp.tyler.TylerDomain;
 import java.io.InputStream;
 import java.sql.Connection;
 import java.sql.PreparedStatement;
@@ -33,11 +33,8 @@ public abstract class CodeDatabaseAPI extends Database {
     super(conn);
   }
 
-  /**
-   * The domain (the juristiction + environment, e.g. illinois-stage) that this database is working
-   * over.
-   */
-  public abstract TylerDomain getDomain();
+  /** The jurisdiction (e.g illinois) that this database is working over */
+  public abstract Jurisdiction getDomain();
 
   /**
    * Gets all court location identifiers (CLI) stored in the database.

--- a/proxyserver/src/main/java/edu/suffolk/litlab/efsp/ecfcodes/CodeDatabaseAPI.java
+++ b/proxyserver/src/main/java/edu/suffolk/litlab/efsp/ecfcodes/CodeDatabaseAPI.java
@@ -34,7 +34,7 @@ public abstract class CodeDatabaseAPI extends Database {
   }
 
   /** The jurisdiction (e.g illinois) that this database is working over */
-  public abstract Jurisdiction getDomain();
+  public abstract Jurisdiction getJurisdiction();
 
   /**
    * Gets all court location identifiers (CLI) stored in the database.

--- a/proxyserver/src/main/java/edu/suffolk/litlab/efsp/server/EfspServer.java
+++ b/proxyserver/src/main/java/edu/suffolk/litlab/efsp/server/EfspServer.java
@@ -265,7 +265,6 @@ public class EfspServer {
       var jurisdiction = jurisdictions.get(idx);
       TylerModuleSetup.create(
               jurisdiction,
-              tylerEnv,
               togaKeys.get(idx),
               codesUpdateTime,
               converterMap,

--- a/proxyserver/src/main/java/edu/suffolk/litlab/efsp/server/EfspServer.java
+++ b/proxyserver/src/main/java/edu/suffolk/litlab/efsp/server/EfspServer.java
@@ -33,7 +33,6 @@ import edu.suffolk.litlab.efsp.server.utils.OrgMessageSender;
 import edu.suffolk.litlab.efsp.server.utils.SendMessage;
 import edu.suffolk.litlab.efsp.server.utils.ServiceHelpers;
 import edu.suffolk.litlab.efsp.server.utils.SoapExceptionMapper;
-import edu.suffolk.litlab.efsp.tyler.TylerDomain;
 import edu.suffolk.litlab.efsp.tyler.TylerEnv;
 import edu.suffolk.litlab.efsp.tyler.ecfcodes.CodeDatabase;
 import edu.suffolk.litlab.efsp.utils.InterviewToFilingInformationConverter;
@@ -162,8 +161,8 @@ public class EfspServer {
       @SuppressWarnings("resource")
       LoginDatabase ld = new LoginDatabase(userConn);
       @SuppressWarnings("resource")
-      // Jurisdiction and env args can be null, we're just making the tables
-      CodeDatabase cd = new CodeDatabase(new TylerDomain(null, null), codeConn);
+      // Jurisdiction can be null here, we're just checking if tables exist
+      CodeDatabase cd = new CodeDatabase(null, codeConn);
       boolean brandNew = !ld.tablesExist() || !cd.tablesExist();
 
       // Now we can tell if everything is being set up fresh. If so, we'll make everything now.

--- a/proxyserver/src/main/java/edu/suffolk/litlab/efsp/server/setup/tyler/TylerModuleSetup.java
+++ b/proxyserver/src/main/java/edu/suffolk/litlab/efsp/server/setup/tyler/TylerModuleSetup.java
@@ -180,7 +180,7 @@ public class TylerModuleSetup implements EfmModuleSetup {
     SoapX509CallbackHandler.setX509Password(x509Password);
 
     log.info("Checking table if absent");
-    try (CodeDatabase cd = new CodeDatabase(tylerDomain, codeDs.getConnection())) {
+    try (CodeDatabase cd = new CodeDatabase(tylerDomain.jurisdiction(), codeDs.getConnection())) {
       cd.createTablesIfAbsent();
       List<String> locations = cd.getAllLocations();
       log.info("All locations for {}: {}", tylerDomain, locations);
@@ -263,7 +263,7 @@ public class TylerModuleSetup implements EfmModuleSetup {
   }
 
   public Set<String> getCourts() {
-    try (CodeDatabase cd = new CodeDatabase(tylerDomain, codeDs.getConnection())) {
+    try (CodeDatabase cd = new CodeDatabase(tylerDomain.jurisdiction(), codeDs.getConnection())) {
       Set<String> allCourts = new HashSet<String>(cd.getAllLocations());
       // 0 and 1 are special "system" courts that have defaults for all courts.
       // They aren't available for filing
@@ -286,7 +286,7 @@ public class TylerModuleSetup implements EfmModuleSetup {
 
     Supplier<CodeDatabase> cdSupplier =
         () -> {
-          return CodeDatabase.fromDS(tylerDomain, this.codeDs);
+          return CodeDatabase.fromDS(tylerDomain.jurisdiction(), this.codeDs);
         };
 
     PolicyCacher policyCacher = new PolicyCacher();
@@ -358,7 +358,7 @@ public class TylerModuleSetup implements EfmModuleSetup {
 
   @Override
   public void setupGlobals() {
-    Supplier<CodeDatabase> makeCD = () -> CodeDatabase.fromDS(tylerDomain, codeDs);
+    Supplier<CodeDatabase> makeCD = () -> CodeDatabase.fromDS(tylerDomain.jurisdiction(), codeDs);
     Supplier<UserDatabase> makeUD = () -> UserDatabase.fromDS(userDs);
     OasisEcfWsCallback implementor = new OasisEcfWsCallback(makeCD, makeUD, sender);
     String baseLocalUrl = ServiceHelpers.BASE_LOCAL_URL;

--- a/proxyserver/src/main/java/edu/suffolk/litlab/efsp/server/setup/tyler/TylerModuleSetup.java
+++ b/proxyserver/src/main/java/edu/suffolk/litlab/efsp/server/setup/tyler/TylerModuleSetup.java
@@ -145,7 +145,7 @@ public class TylerModuleSetup implements EfmModuleSetup {
     args.pgUser = GetEnv("POSTGRES_USER").orElse("postgres");
     Optional<String> maybeDbPassword = GetEnv("POSTGRES_PASSWORD");
     if (maybeDbPassword.isEmpty()) {
-      log.warn("You need to define a TOGA_URL. Tyler will not be used.");
+      log.warn("You need to define a POSTGRES_PASSWORD. Tyler will not be used.");
       return Optional.empty();
     }
     args.pgPassword = maybeDbPassword.get();

--- a/proxyserver/src/main/java/edu/suffolk/litlab/efsp/server/setup/tyler/TylerModuleSetup.java
+++ b/proxyserver/src/main/java/edu/suffolk/litlab/efsp/server/setup/tyler/TylerModuleSetup.java
@@ -25,8 +25,6 @@ import edu.suffolk.litlab.efsp.server.utils.ServiceHelpers;
 import edu.suffolk.litlab.efsp.server.utils.SoapX509CallbackHandler;
 import edu.suffolk.litlab.efsp.server.utils.UpdateCodeVersions;
 import edu.suffolk.litlab.efsp.stdlib.StdLib;
-import edu.suffolk.litlab.efsp.tyler.TylerDomain;
-import edu.suffolk.litlab.efsp.tyler.TylerEnv;
 import edu.suffolk.litlab.efsp.tyler.ecfcodes.CodeDatabase;
 import edu.suffolk.litlab.efsp.tyler.ecfcodes.CodeUpdater;
 import edu.suffolk.litlab.efsp.tyler.ecfcodes.DataFieldRow;
@@ -63,7 +61,7 @@ public class TylerModuleSetup implements EfmModuleSetup {
   private final String pgDb;
   private final String pgUser;
   private final String pgPassword;
-  private final TylerDomain tylerDomain;
+  private final Jurisdiction jurisdiction;
   private final String x509Password;
   private final DataSource codeDs;
   private final DataSource userDs;
@@ -81,7 +79,6 @@ public class TylerModuleSetup implements EfmModuleSetup {
     public String pgDb;
     public String pgUser;
     public String pgPassword;
-    public TylerEnv tylerEnv;
     public String x509Password;
     public String togaUrl;
   }
@@ -89,14 +86,13 @@ public class TylerModuleSetup implements EfmModuleSetup {
   /** Use this factory method instead of the class constructor. */
   public static Optional<TylerModuleSetup> create(
       Jurisdiction jurisdiction,
-      TylerEnv env,
       String togaKey,
       LocalTime codesDbUpdateTime,
       Map<String, InterviewToFilingInformationConverter> converterMap,
       DataSource codeDs,
       DataSource userDs,
       OrgMessageSender sender) {
-    Optional<CreationArgs> args = createFromEnvVars(env);
+    Optional<CreationArgs> args = createFromEnvVars();
     if (args.isEmpty()) {
       return Optional.empty();
     }
@@ -129,7 +125,7 @@ public class TylerModuleSetup implements EfmModuleSetup {
     this.pgDb = args.pgDb;
     this.pgUser = args.pgUser;
     this.pgPassword = args.pgPassword;
-    this.tylerDomain = new TylerDomain(jurisdiction, args.tylerEnv);
+    this.jurisdiction = jurisdiction;
     this.x509Password = args.x509Password;
     this.togaKey = togaKey;
     this.togaUrl = args.togaUrl;
@@ -137,7 +133,7 @@ public class TylerModuleSetup implements EfmModuleSetup {
     this.codesDbUpdateTime = codesDbUpdateTime;
   }
 
-  private static Optional<CreationArgs> createFromEnvVars(TylerEnv tylerEnv) {
+  private static Optional<CreationArgs> createFromEnvVars() {
     Optional<String> maybeX509Password = GetEnv("X509_PASSWORD");
     if (maybeX509Password.isEmpty() || maybeX509Password.orElse("").isBlank()) {
       log.warn("If using Tyler, X509_PASSWORD can't be null. Did you forget to source .env?");
@@ -146,12 +142,10 @@ public class TylerModuleSetup implements EfmModuleSetup {
     CreationArgs args = new CreationArgs();
     args.x509Password = maybeX509Password.get();
 
-    args.tylerEnv = tylerEnv;
-
     args.pgUser = GetEnv("POSTGRES_USER").orElse("postgres");
     Optional<String> maybeDbPassword = GetEnv("POSTGRES_PASSWORD");
     if (maybeDbPassword.isEmpty()) {
-      log.warn("You need to define a POSTGRES_PASSWORD. Tyler will not be used");
+      log.warn("You need to define a TOGA_URL. Tyler will not be used.");
       return Optional.empty();
     }
     args.pgPassword = maybeDbPassword.get();
@@ -164,8 +158,7 @@ public class TylerModuleSetup implements EfmModuleSetup {
 
     Optional<String> maybeTogaUrl = GetEnv("TOGA_URL");
     if (maybeTogaUrl.isEmpty()) {
-      log.warn(
-          "You need to define a TOGA_URL. Tyler will not be used (for env '" + tylerEnv + "')");
+      log.warn("You need to define a TOGA_URL. Tyler will not be used.");
       return Optional.empty();
     }
     args.togaUrl = maybeTogaUrl.get();
@@ -174,16 +167,16 @@ public class TylerModuleSetup implements EfmModuleSetup {
 
   @Override
   public void preSetup() {
-    MDC.put(MDCWrappers.USER_ID, tylerDomain.getName());
+    MDC.put(MDCWrappers.USER_ID, jurisdiction.getName());
     // HACK(brycew): cheap DI. Should have something better, but
     // I don't quite understand Spring yet
     SoapX509CallbackHandler.setX509Password(x509Password);
 
     log.info("Checking table if absent");
-    try (CodeDatabase cd = new CodeDatabase(tylerDomain.jurisdiction(), codeDs.getConnection())) {
+    try (CodeDatabase cd = new CodeDatabase(jurisdiction, codeDs.getConnection())) {
       cd.createTablesIfAbsent();
       List<String> locations = cd.getAllLocations();
-      log.info("All locations for {}: {}", tylerDomain, locations);
+      log.info("All locations for {}: {}", jurisdiction, locations);
       boolean downloadAll = (cd.getAllLocations().size() == 0);
       if (downloadAll) {
         String testOnlyLocation = StdLib.GetEnv("_TEST_ONLY_LOCATION").orElse("");
@@ -191,16 +184,13 @@ public class TylerModuleSetup implements EfmModuleSetup {
           log.info(
               "Downloading just codes for {} in {}: please wait a bit",
               testOnlyLocation,
-              tylerDomain);
+              jurisdiction);
           CodeUpdater.executeCommand(
-              () -> cd,
-              tylerDomain.jurisdiction(),
-              List.of("replacesome", testOnlyLocation),
-              this.x509Password);
+              () -> cd, jurisdiction, List.of("replacesome", testOnlyLocation), this.x509Password);
         } else {
-          log.info("Downloading all codes for {}: please wait a bit", tylerDomain);
+          log.info("Downloading all codes for {}: please wait a bit", jurisdiction);
           CodeUpdater.executeCommand(
-              () -> cd, tylerDomain.jurisdiction(), List.of("replaceall"), this.x509Password);
+              () -> cd, jurisdiction, List.of("replaceall"), this.x509Password);
         }
       }
     } catch (SQLException e) {
@@ -226,7 +216,7 @@ public class TylerModuleSetup implements EfmModuleSetup {
       int hour = codesDbUpdateTime.getHour();
       int min = codesDbUpdateTime.getMinute();
       var r = new Random();
-      String triggerName = "trigger-" + tylerDomain.getName();
+      String triggerName = "trigger-" + jurisdiction.getName();
       Trigger trigger =
           TriggerBuilder.newTrigger()
               .withIdentity(triggerName, "codesdb-group")
@@ -235,7 +225,7 @@ public class TylerModuleSetup implements EfmModuleSetup {
               .build();
 
       log.info("Scheduling daily Tyler EFM code update job around {}", codesDbUpdateTime);
-      scheduler.scheduleJob(buildJob("job-" + tylerDomain.getName()), trigger);
+      scheduler.scheduleJob(buildJob("job-" + jurisdiction.getName()), trigger);
 
       if (scheduleImmediately) {
         // Schedule immediate codes update.
@@ -244,12 +234,13 @@ public class TylerModuleSetup implements EfmModuleSetup {
         // by external cron
         Trigger immediateTrigger =
             TriggerBuilder.newTrigger()
-                .withIdentity("trigger-immediate-" + tylerDomain.getName(), "codesdb-group")
+                .withIdentity("trigger-immediate-" + jurisdiction.getName(), "codesdb-group")
                 .startNow()
                 .withSchedule(SimpleScheduleBuilder.simpleSchedule().withIntervalInSeconds(20))
                 .build();
         log.info("Scheduling immediate Tyler EFM code update job.");
-        scheduler.scheduleJob(buildJob("job-immediate-" + tylerDomain.getName()), immediateTrigger);
+        scheduler.scheduleJob(
+            buildJob("job-immediate-" + jurisdiction.getName()), immediateTrigger);
       }
     } catch (SchedulerException se) {
       log.error("Scheduler Exception: ", se);
@@ -259,11 +250,11 @@ public class TylerModuleSetup implements EfmModuleSetup {
 
   @Override
   public Jurisdiction getJurisdiction() {
-    return tylerDomain.jurisdiction();
+    return jurisdiction;
   }
 
   public Set<String> getCourts() {
-    try (CodeDatabase cd = new CodeDatabase(tylerDomain.jurisdiction(), codeDs.getConnection())) {
+    try (CodeDatabase cd = new CodeDatabase(jurisdiction, codeDs.getConnection())) {
       Set<String> allCourts = new HashSet<String>(cd.getAllLocations());
       // 0 and 1 are special "system" courts that have defaults for all courts.
       // They aren't available for filing
@@ -286,11 +277,11 @@ public class TylerModuleSetup implements EfmModuleSetup {
 
     Supplier<CodeDatabase> cdSupplier =
         () -> {
-          return CodeDatabase.fromDS(tylerDomain.jurisdiction(), this.codeDs);
+          return CodeDatabase.fromDS(jurisdiction, this.codeDs);
         };
 
     PolicyCacher policyCacher = new PolicyCacher();
-    EfmFilingInterface filer = new Ecf4Filer(tylerDomain.jurisdiction(), cdSupplier, policyCacher);
+    EfmFilingInterface filer = new Ecf4Filer(jurisdiction, cdSupplier, policyCacher);
     for (String court : getCourts()) {
       filingMap.put(court, filer);
       getCallback().ifPresent(call -> callbackMap.put(court, call));
@@ -322,22 +313,20 @@ public class TylerModuleSetup implements EfmModuleSetup {
 
     Supplier<UserDatabase> udSupplier = () -> UserDatabase.fromDS(this.userDs);
 
-    var adminUser = new AdminUserService(tylerDomain.jurisdiction(), cdSupplier, passwordChecker);
-    var cases = new CasesService(tylerDomain.jurisdiction(), cdSupplier);
-    var codes = new EcfCodesService(tylerDomain.jurisdiction(), cdSupplier);
+    var adminUser = new AdminUserService(jurisdiction, cdSupplier, passwordChecker);
+    var cases = new CasesService(jurisdiction, cdSupplier);
+    var codes = new EcfCodesService(jurisdiction, cdSupplier);
     Optional<CourtSchedulingService> courtScheduler = Optional.empty();
-    if (tylerDomain.jurisdiction() == Jurisdiction.ILLINOIS) {
+    if (jurisdiction == Jurisdiction.ILLINOIS) {
       courtScheduler =
           Optional.of(
-              new CourtSchedulingService(
-                  converterMap, tylerDomain.jurisdiction(), cdSupplier, policyCacher));
+              new CourtSchedulingService(converterMap, jurisdiction, cdSupplier, policyCacher));
     }
     var filingReview =
         new FilingReviewService(
             getJurisdiction(), udSupplier, converterMap, filingMap, callbackMap, this.sender);
-    var firmAttorney = new FirmAttorneyAndServiceService(tylerDomain.jurisdiction(), cdSupplier);
-    var payments =
-        new PaymentsService(tylerDomain.jurisdiction(), this.togaKey, this.togaUrl, cdSupplier);
+    var firmAttorney = new FirmAttorneyAndServiceService(jurisdiction, cdSupplier);
+    var payments = new PaymentsService(jurisdiction, this.togaKey, this.togaUrl, cdSupplier);
     JurisdictionServiceHandle handle =
         new JurisdictionServiceHandle(
             getJurisdiction(),
@@ -358,15 +347,12 @@ public class TylerModuleSetup implements EfmModuleSetup {
 
   @Override
   public void setupGlobals() {
-    Supplier<CodeDatabase> makeCD = () -> CodeDatabase.fromDS(tylerDomain.jurisdiction(), codeDs);
+    Supplier<CodeDatabase> makeCD = () -> CodeDatabase.fromDS(jurisdiction, codeDs);
     Supplier<UserDatabase> makeUD = () -> UserDatabase.fromDS(userDs);
     OasisEcfWsCallback implementor = new OasisEcfWsCallback(makeCD, makeUD, sender);
     String baseLocalUrl = ServiceHelpers.BASE_LOCAL_URL;
     String address =
-        baseLocalUrl
-            + "/jurisdictions/"
-            + tylerDomain.jurisdiction().getName()
-            + ServiceHelpers.ASSEMBLY_PORT;
+        baseLocalUrl + "/jurisdictions/" + jurisdiction.getName() + ServiceHelpers.ASSEMBLY_PORT;
     log.info("Starting NFRC callback server at {}", address);
     EndpointImpl jaxWsEndpoint =
         (EndpointImpl) jakarta.xml.ws.Endpoint.publish(address, implementor);
@@ -375,10 +361,7 @@ public class TylerModuleSetup implements EfmModuleSetup {
 
     OasisEcfv5WsCallback impl2 = new OasisEcfv5WsCallback(makeCD, makeUD, sender);
     String v5Address =
-        baseLocalUrl
-            + "/jurisdictions/"
-            + tylerDomain.jurisdiction().getName()
-            + ServiceHelpers.ASSEMBLY_PORT_V5;
+        baseLocalUrl + "/jurisdictions/" + jurisdiction.getName() + ServiceHelpers.ASSEMBLY_PORT_V5;
     EndpointImpl jaxWsV5Endpoint = (EndpointImpl) jakarta.xml.ws.Endpoint.publish(v5Address, impl2);
     log.info("V5 Address : {}", jaxWsV5Endpoint.getAddress());
     log.info("V5 Bean name: {}", jaxWsV5Endpoint.getBeanName());
@@ -416,13 +399,13 @@ public class TylerModuleSetup implements EfmModuleSetup {
 
   @Override
   public String toString() {
-    return "TylerModuleSetup[domain=" + tylerDomain + "]";
+    return "TylerModuleSetup[jurisdiction=" + jurisdiction + "]";
   }
 
   private JobDetail buildJob(final String jobName) {
     return JobBuilder.newJob(UpdateCodeVersions.class)
         .withIdentity(jobName, "codesdb-group")
-        .usingJobData("TYLER_JURISDICTION", this.tylerDomain.jurisdiction().getName())
+        .usingJobData("TYLER_JURISDICTION", this.jurisdiction.getName())
         .usingJobData("X509_PASSWORD", this.x509Password)
         .usingJobData("POSTGRES_URL", this.pgUrl)
         .usingJobData("POSTGRES_DB", this.pgDb)

--- a/proxyserver/src/main/java/edu/suffolk/litlab/efsp/server/utils/UpdateCodeVersions.java
+++ b/proxyserver/src/main/java/edu/suffolk/litlab/efsp/server/utils/UpdateCodeVersions.java
@@ -5,7 +5,6 @@ import edu.suffolk.litlab.efsp.db.DatabaseCreator;
 import edu.suffolk.litlab.efsp.server.logging.MDCWrappers;
 import edu.suffolk.litlab.efsp.server.logging.Monitor;
 import edu.suffolk.litlab.efsp.tyler.TylerClients;
-import edu.suffolk.litlab.efsp.tyler.TylerDomain;
 import edu.suffolk.litlab.efsp.tyler.ecfcodes.CodeDatabase;
 import edu.suffolk.litlab.efsp.tyler.ecfcodes.CodeUpdater;
 import java.sql.Connection;
@@ -42,7 +41,6 @@ public class UpdateCodeVersions implements Job {
   public void execute(JobExecutionContext context) throws JobExecutionException {
     JobDataMap dataMap = context.getJobDetail().getJobDataMap();
     var jurisdiction = Jurisdiction.parse(dataMap.getString("TYLER_JURISDICTION"));
-    var domain = new TylerDomain(jurisdiction, TylerClients.getTylerEnv());
     MDC.put(MDCWrappers.OPERATION, "UpdateCodeVersions.execute");
     MDC.put(MDCWrappers.USER_ID, jurisdiction.getName());
     String x509Password = dataMap.getString("X509_PASSWORD");
@@ -55,7 +53,7 @@ public class UpdateCodeVersions implements Job {
     boolean success = true;
     try (Connection conn =
             DatabaseCreator.makeSingleConnection(pgDb, pgFullUrl, pgUser, pgPassword);
-        CodeDatabase cd = new CodeDatabase(domain, conn)) {
+        CodeDatabase cd = new CodeDatabase(jurisdiction, conn)) {
       success =
           CodeUpdater.executeCommand(() -> cd, jurisdiction, List.of("refresh"), x509Password);
     } catch (SQLException e) {

--- a/proxyserver/src/main/java/edu/suffolk/litlab/efsp/tyler/ecfcodes/CaseCategory.java
+++ b/proxyserver/src/main/java/edu/suffolk/litlab/efsp/tyler/ecfcodes/CaseCategory.java
@@ -76,22 +76,22 @@ public class CaseCategory {
   }
 
   public static PreparedStatement prepFilableQueryTiming(
-      Connection conn, String domain, String courtLocationId, Boolean isInitial)
+      Connection conn, String jurisdiction, String courtLocationId, Boolean isInitial)
       throws SQLException {
     if (isInitial) {
       PreparedStatement st = conn.prepareStatement(getFileableCaseCategoryForTiming());
-      st.setString(1, domain);
+      st.setString(1, jurisdiction);
       st.setString(2, courtLocationId);
       st.setString(3, Boolean.toString(isInitial));
       return st;
     }
-    return prepFileableQuery(conn, domain, courtLocationId);
+    return prepFileableQuery(conn, jurisdiction, courtLocationId);
   }
 
   public static PreparedStatement prepFileableQuery(
-      Connection conn, String domain, String courtLocationId) throws SQLException {
+      Connection conn, String jurisdiction, String courtLocationId) throws SQLException {
     PreparedStatement st = conn.prepareStatement(getFileableCaseCategoryForLoc());
-    st.setString(1, domain);
+    st.setString(1, jurisdiction);
     st.setString(2, courtLocationId);
     return st;
   }
@@ -100,7 +100,7 @@ public class CaseCategory {
     return """
     SELECT DISTINCT name
     FROM casecategory
-    WHERE domain=? AND name ILIKE ?
+    WHERE jurisdiction=? AND name ILIKE ?
     ORDER BY name
     """;
   }
@@ -109,7 +109,7 @@ public class CaseCategory {
     return """
     SELECT DISTINCT location
     FROM casecategory
-    WHERE domain=? AND name ILIKE ?
+    WHERE jurisdiction=? AND name ILIKE ?
     ORDER BY location
     """;
   }
@@ -118,7 +118,7 @@ public class CaseCategory {
     return """
     SELECT DISTINCT code, location
     FROM casecategory
-    WHERE domain=? AND name=?
+    WHERE jurisdiction=? AND name=?
     ORDER BY location
     """;
   }
@@ -128,7 +128,7 @@ public class CaseCategory {
     return """
     SELECT code, name, ecfcasetype, procedureremedyinitial,
       procedureremedysubsequent, damageamountinitial, damageamountsubsequent
-    FROM casecategory WHERE domain=? AND location=? AND ecfcasetype !='CriminalCase'\
+    FROM casecategory WHERE jurisdiction=? AND location=? AND ecfcasetype !='CriminalCase'\
     """;
   }
 
@@ -144,8 +144,8 @@ public class CaseCategory {
               ROW_NUMBER() OVER(PARTITION BY cate.code ORDER BY type.code) AS RN
             FROM casecategory as cate
               INNER JOIN casetype AS type
-              ON cate.code = type.casecategory AND cate.location = type.location AND cate.domain = type.domain
-            WHERE cate.domain=? AND cate.location=? AND cate.ecfcasetype != 'CriminalCase'
+              ON cate.code = type.casecategory AND cate.location = type.location AND cate.jurisdiction = type.jurisdiction
+            WHERE cate.jurisdiction=? AND cate.location=? AND cate.ecfcasetype != 'CriminalCase'
         ) cat
     WHERE cat.RN = 1
     """;
@@ -163,8 +163,8 @@ public class CaseCategory {
               ROW_NUMBER() OVER(PARTITION BY cate.code ORDER BY type.code) AS RN
             FROM casecategory as cate
               INNER JOIN casetype AS type
-              ON cate.code = type.casecategory AND cate.location = type.location AND cate.domain = type.domain
-            WHERE cate.domain=? AND cate.location=? AND cate.ecfcasetype != 'CriminalCase' AND type.initial ILIKE ?
+              ON cate.code = type.casecategory AND cate.location = type.location AND cate.jurisdiction = type.jurisdiction
+            WHERE cate.jurisdiction=? AND cate.location=? AND cate.ecfcasetype != 'CriminalCase' AND type.initial ILIKE ?
         ) cat
     WHERE cat.RN = 1
     """;
@@ -174,7 +174,7 @@ public class CaseCategory {
     return """
     SELECT code, name, ecfcasetype, procedureremedyinitial,
       procedureremedysubsequent, damageamountinitial, damageamountsubsequent
-    FROM casecategory WHERE domain=? AND location=? AND code=?
+    FROM casecategory WHERE jurisdiction=? AND location=? AND code=?
     """;
   }
 

--- a/proxyserver/src/main/java/edu/suffolk/litlab/efsp/tyler/ecfcodes/CaseType.java
+++ b/proxyserver/src/main/java/edu/suffolk/litlab/efsp/tyler/ecfcodes/CaseType.java
@@ -86,10 +86,10 @@ public class CaseType {
   }
 
   public static PreparedStatement prepQueryBroad(
-      Connection conn, String domain, String courtLocationId, String caseCategoryCode)
+      Connection conn, String jurisdiction, String courtLocationId, String caseCategoryCode)
       throws SQLException {
     PreparedStatement st = conn.prepareStatement(getCaseTypesForCategory());
-    st.setString(1, domain);
+    st.setString(1, jurisdiction);
     st.setString(2, courtLocationId);
     st.setString(3, caseCategoryCode);
     return st;
@@ -97,7 +97,7 @@ public class CaseType {
 
   public static PreparedStatement prepQueryTiming(
       Connection conn,
-      String domain,
+      String jurisdiction,
       String courtLocationId,
       String caseCategoryCode,
       Optional<Boolean> isInitial)
@@ -105,7 +105,7 @@ public class CaseType {
     boolean specifiedInitial = isInitial.orElse(false);
     if (specifiedInitial) {
       PreparedStatement st = conn.prepareStatement(getCaseTypesForTiming());
-      st.setString(1, domain);
+      st.setString(1, jurisdiction);
       st.setString(2, courtLocationId);
       st.setString(3, caseCategoryCode);
       st.setString(4, Boolean.toString(specifiedInitial));
@@ -113,7 +113,7 @@ public class CaseType {
     }
 
     PreparedStatement st = conn.prepareStatement(getCaseTypesForCategory());
-    st.setString(1, domain);
+    st.setString(1, jurisdiction);
     st.setString(2, courtLocationId);
     st.setString(3, caseCategoryCode);
     return st;
@@ -123,7 +123,7 @@ public class CaseType {
     return """
     SELECT code, name, casecategory, initial,
     fee, willfileddate, efspcode, location
-    FROM casetype WHERE domain=? AND location=? AND casecategory=?\
+    FROM casetype WHERE jurisdiction=? AND location=? AND casecategory=?\
     """;
   }
 
@@ -132,62 +132,62 @@ public class CaseType {
   }
 
   public static PreparedStatement prepQueryWithCode(
-      Connection conn, String domain, String courtLocationId, String caseTypeCode)
+      Connection conn, String jurisdiction, String courtLocationId, String caseTypeCode)
       throws SQLException {
     String withCode =
         """
         SELECT code, name, casecategory, initial,
           fee, willfileddate, efspcode, location
-        FROM casetype WHERE domain=? AND location=? AND code=?
+        FROM casetype WHERE jurisdiction=? AND location=? AND code=?
         """;
     PreparedStatement st = conn.prepareStatement(withCode);
-    st.setString(1, domain);
+    st.setString(1, jurisdiction);
     st.setString(2, courtLocationId);
     st.setString(3, caseTypeCode);
     return st;
   }
 
-  public static PreparedStatement prepSearchQuery(Connection conn, String domain, String searchTerm)
-      throws SQLException {
+  public static PreparedStatement prepSearchQuery(
+      Connection conn, String jurisdiction, String searchTerm) throws SQLException {
     String search =
         """
         SELECT DISTINCT name
         FROM casetype
-        WHERE domain=? AND name ILIKE ?
+        WHERE jurisdiction=? AND name ILIKE ?
         ORDER BY name
         """;
     PreparedStatement st = conn.prepareStatement(search);
-    st.setString(1, domain);
+    st.setString(1, jurisdiction);
     st.setString(2, searchTerm);
     return st;
   }
 
   public static PreparedStatement prepCourtCoverage(
-      Connection conn, String domain, String searchTerm) throws SQLException {
+      Connection conn, String jurisdiction, String searchTerm) throws SQLException {
     String search =
         """
         SELECT DISTINCT location
         FROM casetype
-        WHERE domain=? AND name ILIKE ?
+        WHERE jurisdiction=? AND name ILIKE ?
         ORDER BY location
         """;
     PreparedStatement st = conn.prepareStatement(search);
-    st.setString(1, domain);
+    st.setString(1, jurisdiction);
     st.setString(2, searchTerm);
     return st;
   }
 
   public static PreparedStatement prepRetrieveQuery(
-      Connection conn, String domain, String caseTypeName) throws SQLException {
+      Connection conn, String jurisdiction, String caseTypeName) throws SQLException {
     String retrieve =
         """
         SELECT DISTINCT code, location
         FROM casetype
-        WHERE domain=? AND name=?
+        WHERE jurisdiction=? AND name=?
         ORDER BY location
         """;
     PreparedStatement st = conn.prepareStatement(retrieve);
-    st.setString(1, domain);
+    st.setString(1, jurisdiction);
     st.setString(2, caseTypeName);
     return st;
   }

--- a/proxyserver/src/main/java/edu/suffolk/litlab/efsp/tyler/ecfcodes/CodeDatabase.java
+++ b/proxyserver/src/main/java/edu/suffolk/litlab/efsp/tyler/ecfcodes/CodeDatabase.java
@@ -80,11 +80,11 @@ public class CodeDatabase extends CodeDatabaseAPI {
   }
 
   @Override
-  public Jurisdiction getDomain() {
+  public Jurisdiction getJurisdiction() {
     return jurisdiction;
   }
 
-  private String domainStr() {
+  private String jurisStr() {
     return jurisdiction.getName();
   }
 
@@ -175,7 +175,7 @@ public class CodeDatabase extends CodeDatabaseAPI {
     String versionUpdate = CodeTableConstants.updateVersion();
     try (PreparedStatement update = conn.prepareStatement(versionUpdate)) {
       if (tableName.equals("optionalservices")) {
-        OptionalServiceCode.updateOptionalServiceTable(courtName, domainStr(), rows, this.conn);
+        OptionalServiceCode.updateOptionalServiceTable(courtName, jurisStr(), rows, this.conn);
       } else {
         updateTableInner(tableName, courtName, rows);
       }
@@ -185,7 +185,7 @@ public class CodeDatabase extends CodeDatabaseAPI {
       update.setString(1, courtName);
       update.setString(2, zipName);
       update.setString(3, newVersion);
-      update.setString(4, domainStr());
+      update.setString(4, jurisStr());
       update.setString(5, newVersion);
       update.executeUpdate();
     } catch (UnsupportedTableException ex) {
@@ -247,7 +247,7 @@ public class CodeDatabase extends CodeDatabaseAPI {
       stmt.setString(idx, courtName);
       idx += 1;
     }
-    stmt.setString(idx, domainStr());
+    stmt.setString(idx, jurisStr());
     return stmt;
   }
 
@@ -258,7 +258,7 @@ public class CodeDatabase extends CodeDatabaseAPI {
         (term) -> {
           String query = CaseCategory.searchCaseCategories();
           PreparedStatement st = conn.prepareStatement(query);
-          st.setString(1, domainStr());
+          st.setString(1, jurisStr());
           st.setString(2, term);
           return st;
         });
@@ -271,7 +271,7 @@ public class CodeDatabase extends CodeDatabaseAPI {
         (term) -> {
           String query = CaseCategory.courtCoverageCaseCategories();
           PreparedStatement st = conn.prepareStatement(query);
-          st.setString(1, domainStr());
+          st.setString(1, jurisStr());
           st.setString(2, term);
           return st;
         });
@@ -284,7 +284,7 @@ public class CodeDatabase extends CodeDatabaseAPI {
           String query = CaseCategory.retrieveCaseCategoryForName();
           List<CodeAndLocation> cats = new ArrayList<>();
           try (PreparedStatement st = conn.prepareStatement(query)) {
-            st.setString(1, domainStr());
+            st.setString(1, jurisStr());
             st.setString(2, categoryName);
             ResultSet rs = st.executeQuery();
             while (rs.next()) {
@@ -301,7 +301,7 @@ public class CodeDatabase extends CodeDatabaseAPI {
           String query = CaseCategory.getCaseCategoriesForLoc();
           List<NameAndCode> nacs = new ArrayList<>();
           try (PreparedStatement st = conn.prepareStatement(query)) {
-            st.setString(1, domainStr());
+            st.setString(1, jurisStr());
             st.setString(2, courtLocationId);
             ResultSet rs = st.executeQuery();
             while (rs.next()) {
@@ -318,7 +318,7 @@ public class CodeDatabase extends CodeDatabaseAPI {
           String query = CaseCategory.getCaseCategoriesForLoc();
           List<CaseCategory> cats = new ArrayList<>();
           try (PreparedStatement st = conn.prepareStatement(query)) {
-            st.setString(1, domainStr());
+            st.setString(1, jurisStr());
             st.setString(2, courtLocationId);
             ResultSet rs = st.executeQuery();
             while (rs.next()) {
@@ -337,9 +337,9 @@ public class CodeDatabase extends CodeDatabaseAPI {
           if (initial.isPresent()) {
             st =
                 CaseCategory.prepFilableQueryTiming(
-                    conn, domainStr(), courtLocationId, initial.get());
+                    conn, jurisStr(), courtLocationId, initial.get());
           } else {
-            st = CaseCategory.prepFileableQuery(conn, domainStr(), courtLocationId);
+            st = CaseCategory.prepFileableQuery(conn, jurisStr(), courtLocationId);
           }
           ResultSet rs = st.executeQuery();
           List<CaseCategory> cats = new ArrayList<>();
@@ -357,7 +357,7 @@ public class CodeDatabase extends CodeDatabaseAPI {
         () -> {
           String query = CaseCategory.getCaseCategoryWithCode();
           try (PreparedStatement st = conn.prepareStatement(query)) {
-            st.setString(1, domainStr());
+            st.setString(1, jurisStr());
             st.setString(2, courtLocationId);
             st.setString(3, caseCatCode);
             ResultSet rs = st.executeQuery();
@@ -374,19 +374,19 @@ public class CodeDatabase extends CodeDatabaseAPI {
 
   @Override
   public List<String> searchCaseType(String searchTerm) {
-    return genericSearch(searchTerm, (term) -> CaseType.prepSearchQuery(conn, domainStr(), term));
+    return genericSearch(searchTerm, (term) -> CaseType.prepSearchQuery(conn, jurisStr(), term));
   }
 
   @Override
   public List<String> courtCoverageCaseType(String searchTerm) {
-    return genericSearch(searchTerm, (term) -> CaseType.prepCourtCoverage(conn, domainStr(), term));
+    return genericSearch(searchTerm, (term) -> CaseType.prepCourtCoverage(conn, jurisStr(), term));
   }
 
   @Override
   public List<CodeAndLocation> retrieveCaseTypeByName(String caseTypeName) {
     return safetyWrap(
         () -> {
-          try (PreparedStatement st = CaseType.prepRetrieveQuery(conn, domainStr(), caseTypeName)) {
+          try (PreparedStatement st = CaseType.prepRetrieveQuery(conn, jurisStr(), caseTypeName)) {
             List<CodeAndLocation> types = new ArrayList<>();
             ResultSet rs = st.executeQuery();
             while (rs.next()) {
@@ -406,9 +406,9 @@ public class CodeDatabase extends CodeDatabaseAPI {
           if (initial.isPresent()) {
             st =
                 CaseType.prepQueryTiming(
-                    conn, domainStr(), courtLocationId, caseCategoryCode, initial);
+                    conn, jurisStr(), courtLocationId, caseCategoryCode, initial);
           } else {
-            st = CaseType.prepQueryBroad(conn, domainStr(), courtLocationId, caseCategoryCode);
+            st = CaseType.prepQueryBroad(conn, jurisStr(), courtLocationId, caseCategoryCode);
           }
           ResultSet rs = st.executeQuery();
           List<NameAndCode> nacs = new ArrayList<>();
@@ -430,9 +430,9 @@ public class CodeDatabase extends CodeDatabaseAPI {
           if (initial.isPresent()) {
             st =
                 CaseType.prepQueryTiming(
-                    conn, domainStr(), courtLocationId, caseCategoryCode, initial);
+                    conn, jurisStr(), courtLocationId, caseCategoryCode, initial);
           } else {
-            st = CaseType.prepQueryBroad(conn, domainStr(), courtLocationId, caseCategoryCode);
+            st = CaseType.prepQueryBroad(conn, jurisStr(), courtLocationId, caseCategoryCode);
           }
           ResultSet rs = st.executeQuery();
           List<CaseType> types = new ArrayList<>();
@@ -448,7 +448,7 @@ public class CodeDatabase extends CodeDatabaseAPI {
     return safetyWrapOpt(
         () -> {
           try (PreparedStatement st =
-              CaseType.prepQueryWithCode(conn, domainStr(), courtLocationId, caseTypeCode)) {
+              CaseType.prepQueryWithCode(conn, jurisStr(), courtLocationId, caseTypeCode)) {
             ResultSet rs = st.executeQuery();
             if (rs.next()) {
               return Optional.of(new CaseType(rs));
@@ -465,7 +465,7 @@ public class CodeDatabase extends CodeDatabaseAPI {
           String query = CodeTableConstants.getCaseSubtypesFor();
           List<NameAndCode> subtypes = new ArrayList<NameAndCode>();
           try (PreparedStatement st = conn.prepareStatement(query)) {
-            st.setString(1, domainStr());
+            st.setString(1, jurisStr());
             st.setString(2, courtLocationId);
             st.setString(3, caseType);
             ResultSet rs = st.executeQuery();
@@ -488,7 +488,7 @@ public class CodeDatabase extends CodeDatabaseAPI {
       String query = DataFieldRow.getAllFromDataFieldConfigForLoc();
       for (String currentCourt : parentList) {
         try (PreparedStatement st = conn.prepareStatement(query)) {
-          st.setString(1, domainStr());
+          st.setString(1, jurisStr());
           st.setString(2, currentCourt);
           st.setString(3, dataName);
           ResultSet rs = st.executeQuery();
@@ -532,7 +532,7 @@ public class CodeDatabase extends CodeDatabaseAPI {
       Set<String> codesInList = new HashSet<>();
       for (String currentCourt : parentList) {
         try (PreparedStatement st = conn.prepareStatement(query)) {
-          st.setString(1, domainStr());
+          st.setString(1, jurisStr());
           st.setString(2, currentCourt);
           ResultSet rs = st.executeQuery();
           while (rs.next()) {
@@ -564,7 +564,7 @@ public class CodeDatabase extends CodeDatabaseAPI {
       List<Map<String, DataFieldRow>> allDataFields = new ArrayList<>();
       for (String currentCourt : parentList) {
         try (PreparedStatement st = conn.prepareStatement(query)) {
-          st.setString(1, domainStr());
+          st.setString(1, jurisStr());
           st.setString(2, currentCourt);
           ResultSet rs = st.executeQuery();
           var dataFieldMap = new HashMap<String, DataFieldRow>();
@@ -603,7 +603,7 @@ public class CodeDatabase extends CodeDatabaseAPI {
 
     String query = CodeTableConstants.getProcedureOrRemedy();
     try (PreparedStatement st = conn.prepareStatement(query)) {
-      st.setString(1, domainStr());
+      st.setString(1, jurisStr());
       st.setString(2, courtLocationId);
       st.setString(3, caseCategory);
       ResultSet rs = st.executeQuery();
@@ -625,7 +625,7 @@ public class CodeDatabase extends CodeDatabaseAPI {
    * @return
    */
   public List<String> searchFilingType(String searchTerm) {
-    return genericSearch(searchTerm, (term) -> FilingCode.prepSearchQuery(conn, domainStr(), term));
+    return genericSearch(searchTerm, (term) -> FilingCode.prepSearchQuery(conn, jurisStr(), term));
   }
 
   /**
@@ -636,7 +636,7 @@ public class CodeDatabase extends CodeDatabaseAPI {
    */
   public List<String> courtCoverageFilingType(String searchTerm) {
     return genericSearch(
-        searchTerm, (term) -> FilingCode.prepCourtCoverageQuery(conn, domainStr(), term));
+        searchTerm, (term) -> FilingCode.prepCourtCoverageQuery(conn, jurisStr(), term));
   }
 
   /**
@@ -649,7 +649,7 @@ public class CodeDatabase extends CodeDatabaseAPI {
     return safetyWrap(
         () -> {
           try (PreparedStatement st =
-              FilingCode.prepRetrieveQuery(conn, domainStr(), caseTypeName)) {
+              FilingCode.prepRetrieveQuery(conn, jurisStr(), caseTypeName)) {
             List<CodeAndLocation> types = new ArrayList<>();
             ResultSet rs = st.executeQuery();
             while (rs.next()) {
@@ -667,7 +667,7 @@ public class CodeDatabase extends CodeDatabaseAPI {
           List<FilingCode> filingTypes = new ArrayList<>();
           try (PreparedStatement specificSt =
               FilingCode.prepQueryWithCaseInfo(
-                  conn, initial, domainStr(), courtLocationId, categoryCode, typeCode)) {
+                  conn, initial, jurisStr(), courtLocationId, categoryCode, typeCode)) {
             ResultSet rs = specificSt.executeQuery();
             while (rs.next()) {
               filingTypes.add(new FilingCode(rs));
@@ -676,7 +676,7 @@ public class CodeDatabase extends CodeDatabaseAPI {
             // categories or types
             if (filingTypes.isEmpty()) {
               try (PreparedStatement broadSt =
-                  FilingCode.prepQueryNoCaseInfo(conn, initial, domainStr(), courtLocationId)) {
+                  FilingCode.prepQueryNoCaseInfo(conn, initial, jurisStr(), courtLocationId)) {
                 ResultSet broadRs = broadSt.executeQuery();
                 while (broadRs.next()) {
                   filingTypes.add(new FilingCode(broadRs));
@@ -692,7 +692,7 @@ public class CodeDatabase extends CodeDatabaseAPI {
     return safetyWrapOpt(
         () -> {
           try (PreparedStatement st =
-              FilingCode.prepQueryWithCode(conn, domainStr(), courtLocationId, filingCode)) {
+              FilingCode.prepQueryWithCode(conn, jurisStr(), courtLocationId, filingCode)) {
             ResultSet rs = st.executeQuery();
             if (rs.next()) {
               return Optional.of(new FilingCode(rs));
@@ -721,7 +721,7 @@ public class CodeDatabase extends CodeDatabaseAPI {
           String query = CodeTableConstants.getDamageAmount();
           List<NameAndCode> amounts = new ArrayList<>();
           try (PreparedStatement st = conn.prepareStatement(query)) {
-            st.setString(1, domainStr());
+            st.setString(1, jurisStr());
             st.setString(2, courtLocationId);
             st.setString(3, caseCategory);
             try (ResultSet rs = st.executeQuery()) {
@@ -746,7 +746,7 @@ public class CodeDatabase extends CodeDatabaseAPI {
         (term) -> {
           String query = PartyType.searchPartyType();
           PreparedStatement st = conn.prepareStatement(query);
-          st.setString(1, domainStr());
+          st.setString(1, jurisStr());
           st.setString(2, term);
           return st;
         });
@@ -758,7 +758,7 @@ public class CodeDatabase extends CodeDatabaseAPI {
         (term) -> {
           String query = PartyType.courtCoveragePartyType();
           PreparedStatement st = conn.prepareStatement(query);
-          st.setString(1, domainStr());
+          st.setString(1, jurisStr());
           st.setString(2, term);
           return st;
         });
@@ -770,7 +770,7 @@ public class CodeDatabase extends CodeDatabaseAPI {
           String query = PartyType.retrievePartyTypeFromName();
           List<CodeAndLocation> types = new ArrayList<>();
           try (PreparedStatement st = conn.prepareStatement(query)) {
-            st.setString(1, domainStr());
+            st.setString(1, jurisStr());
             st.setString(2, partyTypeName);
             ResultSet rs = st.executeQuery();
             while (rs.next()) {
@@ -795,7 +795,7 @@ public class CodeDatabase extends CodeDatabaseAPI {
           String query = PartyType.getPartyTypeFromCaseType();
           List<PartyType> partyTypes = new ArrayList<>();
           try (PreparedStatement caseSt = conn.prepareStatement(query)) {
-            caseSt.setString(1, domainStr());
+            caseSt.setString(1, jurisStr());
             caseSt.setString(2, courtLocationId);
             if (caseTypeCode != null) {
               caseSt.setString(3, caseTypeCode);
@@ -808,7 +808,7 @@ public class CodeDatabase extends CodeDatabaseAPI {
             if (partyTypes.isEmpty()) {
               String broadQuery = PartyType.getPartyTypeNoCaseType();
               try (PreparedStatement broadSt = conn.prepareStatement(broadQuery)) {
-                broadSt.setString(1, domainStr());
+                broadSt.setString(1, jurisStr());
                 broadSt.setString(2, courtLocationId);
                 try (ResultSet broadRs = broadSt.executeQuery()) {
                   while (broadRs.next()) {
@@ -828,7 +828,7 @@ public class CodeDatabase extends CodeDatabaseAPI {
           String query = PartyType.retrievePartyTypeFromName();
           List<PartyType> types = new ArrayList<>();
           try (PreparedStatement st = conn.prepareStatement(query)) {
-            st.setString(1, domainStr());
+            st.setString(1, jurisStr());
             st.setString(2, courtLocationId);
             st.setString(3, partyTypeCode);
             ResultSet rs = st.executeQuery();
@@ -844,7 +844,7 @@ public class CodeDatabase extends CodeDatabaseAPI {
     return safetyWrap(
         () -> {
           try (PreparedStatement st = conn.prepareStatement(CrossReference.query())) {
-            st.setString(1, domainStr());
+            st.setString(1, jurisStr());
             st.setString(2, courtLocationId);
             st.setString(3, caseTypeId);
             ResultSet rs = st.executeQuery();
@@ -863,7 +863,7 @@ public class CodeDatabase extends CodeDatabaseAPI {
           String query = ServiceCodeType.query();
           List<ServiceCodeType> types = new ArrayList<>();
           try (PreparedStatement st = conn.prepareStatement(query)) {
-            st.setString(1, domainStr());
+            st.setString(1, jurisStr());
             st.setString(2, courtLocationId);
             ResultSet rs = st.executeQuery();
             while (rs.next()) {
@@ -882,7 +882,7 @@ public class CodeDatabase extends CodeDatabaseAPI {
 
     String specificQuery = DocumentTypeTableRow.getDocumentTypeWithFilingCode();
     try (PreparedStatement specificSt = conn.prepareStatement(specificQuery)) {
-      specificSt.setString(1, domainStr());
+      specificSt.setString(1, jurisStr());
       specificSt.setString(2, courtLocationId);
       specificSt.setString(3, filingCodeId);
       ResultSet spefRs = specificSt.executeQuery();
@@ -893,7 +893,7 @@ public class CodeDatabase extends CodeDatabaseAPI {
       if (docTypes.isEmpty()) {
         String broadQuery = DocumentTypeTableRow.getDocumentTypeNoFiling();
         try (PreparedStatement broadSt = conn.prepareStatement(broadQuery)) {
-          broadSt.setString(1, domainStr());
+          broadSt.setString(1, jurisStr());
           broadSt.setString(2, courtLocationId);
           ResultSet broadRs = broadSt.executeQuery();
           while (broadRs.next()) {
@@ -916,7 +916,7 @@ public class CodeDatabase extends CodeDatabaseAPI {
 
     String query = CodeTableConstants.getMotionTypes();
     try (PreparedStatement st = conn.prepareStatement(query)) {
-      st.setString(1, domainStr());
+      st.setString(1, jurisStr());
       st.setString(2, courtLocationId);
       st.setString(3, filingCodeId);
       ResultSet rs = st.executeQuery();
@@ -939,7 +939,7 @@ public class CodeDatabase extends CodeDatabaseAPI {
 
     String query = CodeTableConstants.getNameSuffixes();
     try (PreparedStatement st = conn.prepareStatement(query)) {
-      st.setString(1, domainStr());
+      st.setString(1, jurisStr());
       st.setString(2, courtLocationId);
       ResultSet rs = st.executeQuery();
       var motions = new ArrayList<NameAndCode>();
@@ -961,7 +961,7 @@ public class CodeDatabase extends CodeDatabaseAPI {
 
     String query = FilingComponent.getFilingComponents();
     try (PreparedStatement st = conn.prepareStatement(query)) {
-      st.setString(1, domainStr());
+      st.setString(1, jurisStr());
       st.setString(2, courtLocationId);
       st.setString(3, filingCodeId);
       ResultSet rs = st.executeQuery();
@@ -985,7 +985,7 @@ public class CodeDatabase extends CodeDatabaseAPI {
     String query = CodeTableConstants.getSpecificStatesForCountryForLoc();
     try (PreparedStatement st = conn.prepareStatement(query)) {
       // TODO(brycew-later): Tyler docs say state is a system table, but there's one per court?
-      st.setString(1, domainStr());
+      st.setString(1, jurisStr());
       st.setString(2, courtId);
       st.setString(3, country);
       ResultSet rs = st.executeQuery();
@@ -1015,7 +1015,7 @@ public class CodeDatabase extends CodeDatabaseAPI {
         () -> {
           String query = FileType.fileTypeQueries();
           try (PreparedStatement st = conn.prepareStatement(query)) {
-            st.setString(1, domainStr());
+            st.setString(1, jurisStr());
             st.setString(2, courtId);
             ResultSet rs = st.executeQuery();
             List<FileType> types = new ArrayList<>();
@@ -1032,7 +1032,7 @@ public class CodeDatabase extends CodeDatabaseAPI {
         () -> {
           String query = FilerType.query();
           try (PreparedStatement st = conn.prepareStatement(query)) {
-            st.setString(1, domainStr());
+            st.setString(1, jurisStr());
             st.setString(2, courtId);
             ResultSet rs = st.executeQuery();
             List<FilerType> types = new ArrayList<>();
@@ -1052,7 +1052,7 @@ public class CodeDatabase extends CodeDatabaseAPI {
 
     String query = CodeTableConstants.getFilingStatuses();
     try (PreparedStatement st = conn.prepareStatement(query)) {
-      st.setString(1, domainStr());
+      st.setString(1, jurisStr());
       st.setString(2, courtId);
       ResultSet rs = st.executeQuery();
       List<NameAndCode> names = new ArrayList<>();
@@ -1068,19 +1068,19 @@ public class CodeDatabase extends CodeDatabaseAPI {
 
   public List<String> searchOptionalServices(String searchTerm) {
     return genericSearch(
-        searchTerm, (term) -> OptionalServiceCode.prepSearch(conn, domainStr(), term));
+        searchTerm, (term) -> OptionalServiceCode.prepSearch(conn, jurisStr(), term));
   }
 
   public List<String> courtCoverageOptionalServices(String searchTerm) {
     return genericSearch(
-        searchTerm, (term) -> OptionalServiceCode.prepCourtCoverage(conn, domainStr(), term));
+        searchTerm, (term) -> OptionalServiceCode.prepCourtCoverage(conn, jurisStr(), term));
   }
 
   public List<CodeAndLocation> retrieveOptionalServices(String optServName) {
     return safetyWrap(
         () -> {
           try (PreparedStatement st =
-              OptionalServiceCode.prepRetrieve(conn, domainStr(), optServName)) {
+              OptionalServiceCode.prepRetrieve(conn, jurisStr(), optServName)) {
             List<CodeAndLocation> optServs = new ArrayList<>();
             ResultSet rs = st.executeQuery();
             while (rs.next()) {
@@ -1095,7 +1095,7 @@ public class CodeDatabase extends CodeDatabaseAPI {
     return safetyWrap(
         () -> {
           try (PreparedStatement st =
-              OptionalServiceCode.prepQueryWithCode(conn, domainStr(), courtId, optServCode)) {
+              OptionalServiceCode.prepQueryWithCode(conn, jurisStr(), courtId, optServCode)) {
             List<OptionalServiceCode> optServs = new ArrayList<>();
             ResultSet rs = st.executeQuery();
             while (rs.next()) {
@@ -1110,7 +1110,7 @@ public class CodeDatabase extends CodeDatabaseAPI {
     return safetyWrap(
         () -> {
           try (PreparedStatement st =
-              OptionalServiceCode.prepQuery(conn, domainStr(), courtId, filingCode)) {
+              OptionalServiceCode.prepQuery(conn, jurisStr(), courtId, filingCode)) {
             ResultSet rs = st.executeQuery();
             List<OptionalServiceCode> services = new ArrayList<>();
             while (rs.next()) {
@@ -1126,7 +1126,7 @@ public class CodeDatabase extends CodeDatabaseAPI {
         () -> {
           String query = CodeTableConstants.getLanguages();
           try (PreparedStatement st = conn.prepareStatement(query)) {
-            st.setString(1, domainStr());
+            st.setString(1, jurisStr());
             st.setString(2, courtLocationId);
             ResultSet rs = st.executeQuery();
             List<String> languages = new ArrayList<>();
@@ -1143,7 +1143,7 @@ public class CodeDatabase extends CodeDatabaseAPI {
         () -> {
           String query = CodeTableConstants.getLanguages();
           try (PreparedStatement st = conn.prepareStatement(query)) {
-            st.setString(1, domainStr());
+            st.setString(1, jurisStr());
             st.setString(2, courtLocationId);
             ResultSet rs = st.executeQuery();
             List<NameAndCode> languages = new ArrayList<>();
@@ -1163,7 +1163,7 @@ public class CodeDatabase extends CodeDatabaseAPI {
     String query = CodeTableConstants.needToUpdateVersion();
     Map<String, List<String>> courtTables = new HashMap<>();
     try (PreparedStatement st = conn.prepareStatement(query)) {
-      st.setString(1, this.domainStr());
+      st.setString(1, this.jurisStr());
       ResultSet rs = st.executeQuery();
       log.info("Query was {}", st);
       while (rs.next()) {
@@ -1191,12 +1191,12 @@ public class CodeDatabase extends CodeDatabaseAPI {
       throw new SQLException();
     }
     if (tableName.equals("optionalservices")) {
-      OptionalServiceCode.deleteFromOptionalServiceTable(null, domainStr(), conn);
+      OptionalServiceCode.deleteFromOptionalServiceTable(null, jurisStr(), conn);
     } else {
       final String deleteFromTable = CodeTableConstants.getDeleteAllCourtsFrom(tableName);
       // TODO(brycew): make variant that deletes everything with a specific jurisdiction
       try (PreparedStatement st = conn.prepareStatement(deleteFromTable)) {
-        st.setString(1, domainStr());
+        st.setString(1, jurisStr());
         log.debug(st.toString());
         st.executeUpdate();
       }
@@ -1213,7 +1213,7 @@ public class CodeDatabase extends CodeDatabaseAPI {
       return false;
     }
     if (tableName.equals("optionalservices")) {
-      OptionalServiceCode.deleteFromOptionalServiceTable(courtLocation, domainStr(), conn);
+      OptionalServiceCode.deleteFromOptionalServiceTable(courtLocation, jurisStr(), conn);
       return true;
     }
     // TODO(brycew): make variant that deletes everything with a specific jurisdiction
@@ -1227,7 +1227,7 @@ public class CodeDatabase extends CodeDatabaseAPI {
       return false;
     }
     try (PreparedStatement st = conn.prepareStatement(deleteFromTableStr)) {
-      st.setString(1, domainStr());
+      st.setString(1, jurisStr());
       st.setString(2, courtLocation);
       st.executeUpdate();
     }
@@ -1246,7 +1246,7 @@ public class CodeDatabase extends CodeDatabaseAPI {
       return List.of();
     }
     try (PreparedStatement st = conn.prepareStatement(CourtLocationInfo.allOrderedQuery())) {
-      st.setString(1, domainStr());
+      st.setString(1, jurisStr());
       ResultSet rs = st.executeQuery();
       var locs = new ArrayList<String>();
       while (rs.next()) {
@@ -1264,7 +1264,7 @@ public class CodeDatabase extends CodeDatabaseAPI {
     return safetyWrap(
         () -> {
           try (PreparedStatement st = conn.prepareStatement(CourtLocationInfo.allNames())) {
-            st.setString(1, domainStr());
+            st.setString(1, jurisStr());
             ResultSet rs = st.executeQuery();
             var names = new ArrayList<NameAndCode>();
             while (rs.next()) {
@@ -1279,7 +1279,7 @@ public class CodeDatabase extends CodeDatabaseAPI {
     return safetyWrap(
         () -> {
           try (PreparedStatement st = conn.prepareStatement(CourtLocationInfo.fileableQuery())) {
-            st.setString(1, domainStr());
+            st.setString(1, jurisStr());
             ResultSet rs = st.executeQuery();
             var codes = new ArrayList<NameAndCode>();
             while (rs.next()) {
@@ -1295,7 +1295,7 @@ public class CodeDatabase extends CodeDatabaseAPI {
         () -> {
           try (PreparedStatement st =
               conn.prepareStatement(CourtLocationInfo.fileableInitialQuery())) {
-            st.setString(1, domainStr());
+            st.setString(1, jurisStr());
             ResultSet rs = st.executeQuery();
             var codes = new ArrayList<NameAndCode>();
             while (rs.next()) {
@@ -1311,7 +1311,7 @@ public class CodeDatabase extends CodeDatabaseAPI {
         () -> {
           try (PreparedStatement st =
               conn.prepareStatement(CourtLocationInfo.fileableSubsequentQuery())) {
-            st.setString(1, domainStr());
+            st.setString(1, jurisStr());
             ResultSet rs = st.executeQuery();
             var codes = new ArrayList<NameAndCode>();
             while (rs.next()) {
@@ -1326,7 +1326,7 @@ public class CodeDatabase extends CodeDatabaseAPI {
     return safetyWrapOpt(
         () -> {
           try (PreparedStatement st = conn.prepareStatement(CourtLocationInfo.fullSingleQuery())) {
-            st.setString(1, domainStr());
+            st.setString(1, jurisStr());
             st.setString(2, courtId);
             ResultSet rs = st.executeQuery();
             if (rs.next()) {
@@ -1350,7 +1350,7 @@ public class CodeDatabase extends CodeDatabaseAPI {
     while (!currentCourt.isBlank()) {
       parentList.add(currentCourt);
       try (PreparedStatement st = conn.prepareStatement(CourtLocationInfo.parentQuery())) {
-        st.setString(1, domainStr());
+        st.setString(1, jurisStr());
         st.setString(2, currentCourt);
         ResultSet rs = st.executeQuery();
         if (rs.next()) {
@@ -1372,7 +1372,7 @@ public class CodeDatabase extends CodeDatabaseAPI {
         () -> {
           String query = Disclaimer.getDisclaimerRequirements();
           try (PreparedStatement st = conn.prepareStatement(query)) {
-            st.setString(1, domainStr());
+            st.setString(1, jurisStr());
             st.setString(2, courtLocation);
             ResultSet rs = st.executeQuery();
             List<Disclaimer> disclaimers = new ArrayList<>();

--- a/proxyserver/src/main/java/edu/suffolk/litlab/efsp/tyler/ecfcodes/CodeDatabase.java
+++ b/proxyserver/src/main/java/edu/suffolk/litlab/efsp/tyler/ecfcodes/CodeDatabase.java
@@ -1,5 +1,6 @@
 package edu.suffolk.litlab.efsp.tyler.ecfcodes;
 
+import edu.suffolk.litlab.efsp.Jurisdiction;
 import edu.suffolk.litlab.efsp.ecfcodes.CodeAndLocation;
 import edu.suffolk.litlab.efsp.ecfcodes.CodeDatabaseAPI;
 import edu.suffolk.litlab.efsp.ecfcodes.CodeDatabaseUtils;
@@ -7,7 +8,6 @@ import edu.suffolk.litlab.efsp.ecfcodes.CodeDatabaseUtils.UnsupportedTableExcept
 import edu.suffolk.litlab.efsp.ecfcodes.CodeDocException;
 import edu.suffolk.litlab.efsp.ecfcodes.CodeDocIterator;
 import edu.suffolk.litlab.efsp.ecfcodes.NameAndCode;
-import edu.suffolk.litlab.efsp.tyler.TylerDomain;
 import java.io.InputStream;
 import java.sql.Connection;
 import java.sql.PreparedStatement;
@@ -39,19 +39,16 @@ import org.slf4j.LoggerFactory;
 public class CodeDatabase extends CodeDatabaseAPI {
   private static final Logger log = LoggerFactory.getLogger(CodeDatabase.class);
 
-  /** The tyler jurisdiction + tyler environment, i.e. illinois-stage. */
-  private final TylerDomain tylerDomain;
+  private final Jurisdiction jurisdiction;
 
-  // TODO(brycew): the database doesn't need the env. Should be implicit, but it's gonna be a lot to
-  // take out.
-  public CodeDatabase(TylerDomain domain, Connection conn) {
+  public CodeDatabase(Jurisdiction jurisdiction, Connection conn) {
     super(conn);
-    this.tylerDomain = domain;
+    this.jurisdiction = jurisdiction;
   }
 
-  public static CodeDatabase fromDS(TylerDomain domain, DataSource ds) {
+  public static CodeDatabase fromDS(Jurisdiction jurisdiction, DataSource ds) {
     try {
-      CodeDatabase cd = new CodeDatabase(domain, ds.getConnection());
+      CodeDatabase cd = new CodeDatabase(jurisdiction, ds.getConnection());
       return cd;
     } catch (SQLException e) {
       log.error("In CodeDatabase constructor, can't get connection: ", e);
@@ -83,12 +80,12 @@ public class CodeDatabase extends CodeDatabaseAPI {
   }
 
   @Override
-  public TylerDomain getDomain() {
-    return tylerDomain;
+  public Jurisdiction getDomain() {
+    return jurisdiction;
   }
 
   private String domainStr() {
-    return tylerDomain.getName();
+    return jurisdiction.getName();
   }
 
   public void createTableIfAbsent(String tableName) throws SQLException {
@@ -714,7 +711,7 @@ public class CodeDatabase extends CodeDatabaseAPI {
         vacuumSt.executeUpdate();
       }
     } catch (SQLException ex) {
-      log.error("Error when vacuuming in {}", this.tylerDomain, ex);
+      log.error("Error when vacuuming in {}", this.jurisdiction, ex);
     }
   }
 

--- a/proxyserver/src/main/java/edu/suffolk/litlab/efsp/tyler/ecfcodes/CodeTableConstants.java
+++ b/proxyserver/src/main/java/edu/suffolk/litlab/efsp/tyler/ecfcodes/CodeTableConstants.java
@@ -82,7 +82,7 @@ public class CodeTableConstants {
           new ImmutablePair<String, String>("location", "text"),
           new ImmutablePair<String, String>("codelist", "text"), 
           new ImmutablePair<String, String>("installedversion", "text")),
-          List.of("location", "codelist", "domain"))),
+          List.of("location", "codelist", "jurisdiction"))),
         //////////// Tables that are both system wide, and court specific
         Map.entry("country", makeCourtColumnInfo(List.of(
           new ImmutablePair<String, String>("code", "text"), 
@@ -321,9 +321,9 @@ public class CodeTableConstants {
     for (Map.Entry<String, TableColumns> table : tableColumns.entrySet()) {
       createQueries.put(table.getKey(), createTableQuery(table.getKey(), table.getValue()));
       insertQueries.put(table.getKey(), createInsertQuery(table.getKey(), table.getValue()));
-      deleteAllCourtsFromQueries.put(table.getKey(), "DELETE FROM " + table.getKey() + " WHERE domain=?");
+      deleteAllCourtsFromQueries.put(table.getKey(), "DELETE FROM " + table.getKey() + " WHERE jurisdiction=?");
       if (table.getValue().needsExtraLocCol) {
-        deleteFromQueries.put(table.getKey(), "DELETE FROM " + table.getKey() + " WHERE domain=? AND location=?");
+        deleteFromQueries.put(table.getKey(), "DELETE FROM " + table.getKey() + " WHERE jurisdiction=? AND location=?");
       }
     }
     
@@ -331,11 +331,11 @@ public class CodeTableConstants {
         "CREATE INDEX ON filing (location)",
         "CREATE INDEX ON filing (casecategory)",
         "CREATE INDEX ON filing (casetypeid)",
-        "CREATE INDEX ON filing (domain)"));
+        "CREATE INDEX ON filing (jurisdiction)"));
     tableIndices.put("filingcomponent", List.of(
         "CREATE INDEX ON filingcomponent (location)", 
         "CREATE INDEX ON filingcomponent (filingcodeid)",
-        "CREATE INDEX ON filingcomponent (domain)")); 
+        "CREATE INDEX ON filingcomponent (jurisdiction)")); 
   }
 
   public static String getZipNameFromTable(String tableName) {
@@ -390,51 +390,51 @@ public class CodeTableConstants {
 
   public static String updateVersion() {
     return """
-        INSERT INTO installedversion (location, codelist, installedversion, domain) VALUES(?, ?, ?, ?)
-        ON CONFLICT (domain, location, codelist) DO UPDATE SET installedversion=?""";
+        INSERT INTO installedversion (location, codelist, installedversion, jurisdiction) VALUES(?, ?, ?, ?)
+        ON CONFLICT (jurisdiction, location, codelist) DO UPDATE SET installedversion=?""";
   }
 
   public static String needToUpdateVersion() {
     return """
         SELECT v.location, v.codelist, iv.installedversion, v.version
         FROM version AS v LEFT OUTER JOIN installedversion AS iv
-        ON (v.domain=iv.domain AND v.location=iv.location AND v.codelist=iv.codelist)
-        WHERE v.domain=? AND ((iv.installedversion IS NULL) OR (v.version != iv.installedversion))""";
+        ON (v.jurisdiction=iv.jurisdiction AND v.location=iv.location AND v.codelist=iv.codelist)
+        WHERE v.jurisdiction=? AND ((iv.installedversion IS NULL) OR (v.version != iv.installedversion))""";
   }
 
   public static String getCaseSubtypesFor() {
     return """
         SELECT code, name
-        FROM casesubtype WHERE domain=? AND location=? AND casetypeid=?""";
+        FROM casesubtype WHERE jurisdiction=? AND location=? AND casetypeid=?""";
   }
 
   public static String getProcedureOrRemedy() {
-    return "SELECT name, code FROM procedureremedy WHERE domain=? AND location=? AND casecategory=?";
+    return "SELECT name, code FROM procedureremedy WHERE jurisdiction=? AND location=? AND casecategory=?";
   }
 
   public static String getMotionTypes() {
-    return "SELECT name, code FROM motiontype WHERE domain=? AND location=? AND filingcodeid=?";
+    return "SELECT name, code FROM motiontype WHERE jurisdiction=? AND location=? AND filingcodeid=?";
   }
 
   public static String getSpecificStatesForCountryForLoc() {
     return "SELECT code, name, countrycode, location "
-        + " FROM state WHERE domain=? AND location=? and countrycode=?";
+        + " FROM state WHERE jurisdiction=? AND location=? and countrycode=?";
   }
 
   public static String getFilingStatuses() {
-    return "SELECT name, code FROM filingstatus WHERE domain=? AND location=?";
+    return "SELECT name, code FROM filingstatus WHERE jurisdiction=? AND location=?";
   }
 
   public static String getLanguages() {
-    return "SELECT code, name, efspcode, location FROM language WHERE domain=? AND location=?";
+    return "SELECT code, name, efspcode, location FROM language WHERE jurisdiction=? AND location=?";
   }
 
   public static String getDamageAmount() {
-    return "SELECT code, name, efspcode, location FROM damageamount WHERE domain=? AND location=? AND casecategory=?";
+    return "SELECT code, name, efspcode, location FROM damageamount WHERE jurisdiction=? AND location=? AND casecategory=?";
   }
 
   public static String getNameSuffixes() {
-    return "SELECT name, code FROM namesuffix WHERE domain=? AND location=?";
+    return "SELECT name, code FROM namesuffix WHERE jurisdiction=? AND location=?";
   }
 
   public static String vacuumAnalyzeAll() {
@@ -504,7 +504,7 @@ public class CodeTableConstants {
     if (tc.needsExtraLocCol) {
       colNames.append(", location");
     }
-    colNames.append(", domain");
+    colNames.append(", jurisdiction");
     insertLocation.append(colNames.toString());
     insertLocation.append(") VALUES (");
     for (int i = 0; i < tc.mainList.size(); i++) {
@@ -536,7 +536,7 @@ public class CodeTableConstants {
     if (tc.needsExtraLocCol) {
       createLocation.append(", \"location\" varchar(80)");
     }
-    createLocation.append(", \"domain\" varchar(80)");
+    createLocation.append(", \"jurisdiction\" varchar(80)");
 
     if (!tc.primaryKeys.isEmpty()) {
       createLocation.append(

--- a/proxyserver/src/main/java/edu/suffolk/litlab/efsp/tyler/ecfcodes/CodeUpdater.java
+++ b/proxyserver/src/main/java/edu/suffolk/litlab/efsp/tyler/ecfcodes/CodeUpdater.java
@@ -664,7 +664,6 @@ public class CodeUpdater {
 
   /** Should just be called from main. */
   private static CodeDatabaseAPI makeCodeDatabase(Jurisdiction jurisdiction) {
-    var domain = new TylerDomain(jurisdiction, TylerClients.getTylerEnv());
     try {
       DataSource ds =
           DatabaseCreator.makeDataSource(

--- a/proxyserver/src/main/java/edu/suffolk/litlab/efsp/tyler/ecfcodes/CodeUpdater.java
+++ b/proxyserver/src/main/java/edu/suffolk/litlab/efsp/tyler/ecfcodes/CodeUpdater.java
@@ -15,7 +15,6 @@ import edu.suffolk.litlab.efsp.server.utils.ServiceHelpers;
 import edu.suffolk.litlab.efsp.server.utils.SoapX509CallbackHandler;
 import edu.suffolk.litlab.efsp.tyler.SoapClientChooser;
 import edu.suffolk.litlab.efsp.tyler.TylerClients;
-import edu.suffolk.litlab.efsp.tyler.TylerDomain;
 import edu.suffolk.litlab.efsp.tyler.TylerUserClient;
 import edu.suffolk.litlab.efsp.tyler.TylerUserFactory;
 import edu.suffolk.litlab.efsp.tyler.TylerUserNamePassword;
@@ -313,7 +312,7 @@ public class CodeUpdater {
   }
 
   private static Map<String, CourtPolicyResponseMessageType> streamPolicies(
-      Stream<String> locations, TylerDomain domain, FilingReviewMDEPort filingPort) {
+      Stream<String> locations, Jurisdiction jurisdiction, FilingReviewMDEPort filingPort) {
     var policies = new ConcurrentHashMap<String, CourtPolicyResponseMessageType>();
     locations.forEach(
         location -> {
@@ -322,7 +321,8 @@ public class CodeUpdater {
             CourtPolicyResponseMessageType p = filingPort.getPolicy(m);
             policies.put(location, p);
           } catch (SOAPFaultException ex) {
-            log.warn("Got a SOAP excption getting policy for {} in {}: ", location, domain, ex);
+            log.warn(
+                "Got a SOAP excption getting policy for {} in {}: ", location, jurisdiction, ex);
           }
         });
     return policies;
@@ -676,7 +676,7 @@ public class CodeUpdater {
               10,
               100);
 
-      return CodeDatabase.fromDS(domain, ds);
+      return CodeDatabase.fromDS(jurisdiction, ds);
     } catch (Exception ex) {
       throw new RuntimeException(ex);
     }

--- a/proxyserver/src/main/java/edu/suffolk/litlab/efsp/tyler/ecfcodes/CodeUpdater.java
+++ b/proxyserver/src/main/java/edu/suffolk/litlab/efsp/tyler/ecfcodes/CodeUpdater.java
@@ -476,7 +476,7 @@ public class CodeUpdater {
       List<String> tables = courtAndTables.getValue();
       log.debug(
           "In {}, removing entries for court {} for tables: {}",
-          cd.getDomain(),
+          cd.getJurisdiction(),
           courtLocation,
           tables);
       for (String table : tables) {
@@ -491,7 +491,8 @@ public class CodeUpdater {
     log.info("Took {} to remove existing tables", Duration.between(startDel, Instant.now()));
     Instant startPolicy = Instant.now();
     Map<String, CourtPolicyResponseMessageType> policies =
-        streamPolicies(versionsToUpdate.keySet().stream().parallel(), cd.getDomain(), filingPort);
+        streamPolicies(
+            versionsToUpdate.keySet().stream().parallel(), cd.getJurisdiction(), filingPort);
     var soapInc = Duration.between(startPolicy, Instant.now());
     soapDuration = soapDuration.plus(soapInc);
     log.info("Soaps took: {} (total: {})", soapInc, soapDuration);
@@ -527,7 +528,7 @@ public class CodeUpdater {
       throws SQLException, IOException, JAXBException, URISyntaxException {
     cd.setAutoCommit(false);
     HeaderSigner signer = new HeaderSigner(this.pathToKeystore, this.x509Password);
-    log.info("Downloading system tables for {}", cd.getDomain());
+    log.info("Downloading system tables for {}", cd.getJurisdiction());
     boolean success = downloadSystemTables(baseUrl, cd, signer);
 
     var tablesToDeleteDomain = ecf4ElemToTableName.values();
@@ -547,7 +548,7 @@ public class CodeUpdater {
     locs.remove("0");
     Instant startPolicy = Instant.now();
     Map<String, CourtPolicyResponseMessageType> policies =
-        streamPolicies(locs.parallelStream(), cd.getDomain(), filingPort);
+        streamPolicies(locs.parallelStream(), cd.getJurisdiction(), filingPort);
     soapDuration = soapDuration.plus(Duration.between(startPolicy, Instant.now()));
     log.info("Soaps: {}", soapDuration);
     for (var policy : policies.entrySet()) {

--- a/proxyserver/src/main/java/edu/suffolk/litlab/efsp/tyler/ecfcodes/CourtLocationInfo.java
+++ b/proxyserver/src/main/java/edu/suffolk/litlab/efsp/tyler/ecfcodes/CourtLocationInfo.java
@@ -251,7 +251,7 @@ public class CourtLocationInfo {
     return """
     SELECT code, parentnodeid
     FROM location
-    WHERE domain=? AND code=?
+    WHERE jurisdiction=? AND code=?
     """;
   }
 
@@ -271,23 +271,23 @@ public class CourtLocationInfo {
         allowwaiveronredaction, disallowelectronicserviceonnewcontacts,
         allowindividualregistration, redactiontargetconfig, allowhearing
     FROM location
-    WHERE domain=? AND code=?
+    WHERE jurisdiction=? AND code=?
     """;
   }
 
   public static String allOrderedQuery() {
-    return "SELECT DISTINCT code FROM location WHERE domain=? ORDER BY code";
+    return "SELECT DISTINCT code FROM location WHERE jurisdiction=? ORDER BY code";
   }
 
   public static String allNames() {
-    return "SELECT name, code FROM location WHERE domain=? ORDER BY code";
+    return "SELECT name, code FROM location WHERE jurisdiction=? ORDER BY code";
   }
 
   public static String fileableQuery() {
     return """
     SELECT name, code
     FROM location
-    WHERE domain=? AND (initial ILIKE 'true' OR subsequent ILIKE 'true')
+    WHERE jurisdiction=? AND (initial ILIKE 'true' OR subsequent ILIKE 'true')
     """;
   }
 
@@ -295,7 +295,7 @@ public class CourtLocationInfo {
     return """
     SELECT name, code
     FROM location
-    WHERE domain=? AND (initial ILIKE 'true')
+    WHERE jurisdiction=? AND (initial ILIKE 'true')
     """;
   }
 
@@ -303,7 +303,7 @@ public class CourtLocationInfo {
     return """
     SELECT name, code
     FROM location
-    WHERE domain=? AND (subsequent ILIKE 'true')
+    WHERE jurisdiction=? AND (subsequent ILIKE 'true')
     """;
   }
 }

--- a/proxyserver/src/main/java/edu/suffolk/litlab/efsp/tyler/ecfcodes/CrossReference.java
+++ b/proxyserver/src/main/java/edu/suffolk/litlab/efsp/tyler/ecfcodes/CrossReference.java
@@ -58,7 +58,7 @@ public class CrossReference {
     return """
     SELECT code, name, casetypeid, isdefault, isrequired, validationregex,
       customvalidationfailuremessage, efspcode, location
-    FROM crossreference WHERE domain=? AND location=? AND casetypeid=?
+    FROM crossreference WHERE jurisdiction=? AND location=? AND casetypeid=?
     """;
   }
 

--- a/proxyserver/src/main/java/edu/suffolk/litlab/efsp/tyler/ecfcodes/DataFieldRow.java
+++ b/proxyserver/src/main/java/edu/suffolk/litlab/efsp/tyler/ecfcodes/DataFieldRow.java
@@ -82,16 +82,16 @@ public class DataFieldRow {
   public static String getAllFromDataFieldConfigForLoc() {
     return "SELECT code, name, isvisible, isrequired, helptext, ghosttext, contextualhelpdata, "
         + "validationmessage, regularexpression, defaultvalueexpression, isreadonly, location "
-        + "FROM datafieldconfig WHERE domain=? AND location=? AND code=?";
+        + "FROM datafieldconfig WHERE jurisdiction=? AND location=? AND code=?";
   }
 
   public static String getAllDataFieldConfigsForLoc() {
     return "SELECT code, name, isvisible, isrequired, helptext, ghosttext, contextualhelpdata, "
         + "validationmessage, regularexpression, defaultvalueexpression, isreadonly, location "
-        + "FROM datafieldconfig WHERE domain=? AND location=?";
+        + "FROM datafieldconfig WHERE jurisdiction=? AND location=?";
   }
 
   public static String getAllDataFieldNames() {
-    return "SELECT code, name FROM datafieldconfig WHERE domain=? AND location=?";
+    return "SELECT code, name FROM datafieldconfig WHERE jurisdiction=? AND location=?";
   }
 }

--- a/proxyserver/src/main/java/edu/suffolk/litlab/efsp/tyler/ecfcodes/Disclaimer.java
+++ b/proxyserver/src/main/java/edu/suffolk/litlab/efsp/tyler/ecfcodes/Disclaimer.java
@@ -18,7 +18,7 @@ public class Disclaimer {
   }
 
   public static String getDisclaimerRequirements() {
-    return "SELECT code, name, listorder, requirementtext FROM disclaimerrequirement WHERE domain=?"
+    return "SELECT code, name, listorder, requirementtext FROM disclaimerrequirement WHERE jurisdiction=?"
         + " AND location=?";
   }
 }

--- a/proxyserver/src/main/java/edu/suffolk/litlab/efsp/tyler/ecfcodes/DocumentTypeTableRow.java
+++ b/proxyserver/src/main/java/edu/suffolk/litlab/efsp/tyler/ecfcodes/DocumentTypeTableRow.java
@@ -44,7 +44,7 @@ public class DocumentTypeTableRow {
     return """
     SELECT code, name, filingcodeid, iscourtuseonly, isdefault, efspcode, location
     FROM documenttype
-    WHERE domain=? AND location=? AND iscourtuseonly='False' AND filingcodeid=?\
+    WHERE jurisdiction=? AND location=? AND iscourtuseonly='False' AND filingcodeid=?\
     """;
   }
 
@@ -52,7 +52,7 @@ public class DocumentTypeTableRow {
     return """
     SELECT code, name, filingcodeid, iscourtuseonly, isdefault, efspcode, location
     FROM documenttype
-    WHERE domain=? AND location=? AND iscourtuseonly='False' AND filingcodeid=''\
+    WHERE jurisdiction=? AND location=? AND iscourtuseonly='False' AND filingcodeid=''\
     """;
   }
 }

--- a/proxyserver/src/main/java/edu/suffolk/litlab/efsp/tyler/ecfcodes/FileType.java
+++ b/proxyserver/src/main/java/edu/suffolk/litlab/efsp/tyler/ecfcodes/FileType.java
@@ -29,7 +29,7 @@ public class FileType {
   public static String fileTypeQueries() {
     return """
     SELECT name, code, extension, location
-    FROM filetype WHERE domain=? AND location=?\
+    FROM filetype WHERE jurisdiction=? AND location=?\
     """;
   }
 

--- a/proxyserver/src/main/java/edu/suffolk/litlab/efsp/tyler/ecfcodes/FilerType.java
+++ b/proxyserver/src/main/java/edu/suffolk/litlab/efsp/tyler/ecfcodes/FilerType.java
@@ -31,7 +31,7 @@ public class FilerType {
     return """
     SELECT "code", "name", "default", "efspcode", "location"
     FROM filertype
-    WHERE domain=? AND location=?\
+    WHERE jurisdiction=? AND location=?\
     """;
   }
 }

--- a/proxyserver/src/main/java/edu/suffolk/litlab/efsp/tyler/ecfcodes/FilingCode.java
+++ b/proxyserver/src/main/java/edu/suffolk/litlab/efsp/tyler/ecfcodes/FilingCode.java
@@ -79,49 +79,49 @@ public class FilingCode {
     );
   }
   
-  public static PreparedStatement prepSearchQuery(Connection conn, String domain, String searchTerm) throws SQLException {
+  public static PreparedStatement prepSearchQuery(Connection conn, String jurisdiction, String searchTerm) throws SQLException {
     final String search = """
         SELECT DISTINCT name
         FROM filing
-        WHERE domain=? AND name ILIKE ?
+        WHERE jurisdiction=? AND name ILIKE ?
         ORDER BY name
         """;
     PreparedStatement st = conn.prepareStatement(search);
-    st.setString(1, domain);
+    st.setString(1, jurisdiction);
     st.setString(2, searchTerm);
     return st;
   }
 
-  public static PreparedStatement prepCourtCoverageQuery(Connection conn, String domain, String searchTerm) throws SQLException {
+  public static PreparedStatement prepCourtCoverageQuery(Connection conn, String jurisdiction, String searchTerm) throws SQLException {
     final String search = """
         SELECT DISTINCT location
         FROM filing
-        WHERE domain=? AND casecategory='' AND casetypeid='' AND name ILIKE ?
+        WHERE jurisdiction=? AND casecategory='' AND casetypeid='' AND name ILIKE ?
         ORDER BY location
         """;
     PreparedStatement st = conn.prepareStatement(search);
-    st.setString(1, domain);
+    st.setString(1, jurisdiction);
     st.setString(2, searchTerm);
     return st;
   }
   
-  public static PreparedStatement prepRetrieveQuery(Connection conn, String domain, String filingName) throws SQLException {
+  public static PreparedStatement prepRetrieveQuery(Connection conn, String jurisdiction, String filingName) throws SQLException {
     String retrieve = """
         SELECT DISTINCT code, location
         FROM filing
-        WHERE domain=? AND name=?
+        WHERE jurisdiction=? AND name=?
         ORDER BY location
         """;
     PreparedStatement st = conn.prepareStatement(retrieve);
-    st.setString(1, domain);
+    st.setString(1, jurisdiction);
     st.setString(2, filingName);
     return st;
   }
   
   public static PreparedStatement prepQueryWithCaseInfo(Connection conn, 
-      boolean initial, String domain, String courtLocationId, String categoryId, String caseTypeId) throws SQLException {
+      boolean initial, String jurisdiction, String courtLocationId, String categoryId, String caseTypeId) throws SQLException {
     PreparedStatement st = conn.prepareStatement(getFilingWithCaseInfo(initial));
-    st.setString(1, domain);
+    st.setString(1, jurisdiction);
     st.setString(2, courtLocationId);
     st.setString(3, categoryId);
     st.setString(4, caseTypeId);
@@ -135,7 +135,7 @@ public class FilingCode {
                  civilclaimamount, probateestateamount, amountincontroversy, useduedate, 
                  isproposedorder, efspcode, location
           FROM filing 
-          WHERE domain=? AND location=? AND iscourtuseonly='False' AND ((casecategory=? AND casetypeid='') OR casetypeid=?) """;
+          WHERE jurisdiction=? AND location=? AND iscourtuseonly='False' AND ((casecategory=? AND casetypeid='') OR casetypeid=?) """;
     if (initial) {
       return mainQuery + "AND (filingtype='Initial' OR filingtype='Both')";
     } else {
@@ -145,9 +145,9 @@ public class FilingCode {
   
 
   public static PreparedStatement prepQueryNoCaseInfo(Connection conn, 
-      boolean initial, String domain, String courtLocationId) throws SQLException {
+      boolean initial, String jurisdiction, String courtLocationId) throws SQLException {
     PreparedStatement st = conn.prepareStatement(getFilingNoCaseInfo(initial));
-    st.setString(1, domain);
+    st.setString(1, jurisdiction);
     st.setString(2, courtLocationId);
     return st;
   }
@@ -158,7 +158,7 @@ public class FilingCode {
                  civilclaimamount, probateestateamount, amountincontroversy, useduedate, 
                  isproposedorder, efspcode, location
           FROM filing 
-          WHERE domain=? AND location=? AND iscourtuseonly='False' AND 
+          WHERE jurisdiction=? AND location=? AND iscourtuseonly='False' AND 
             ((casecategory='' OR casecategory=null) AND (casetypeid='' OR casetypeid=null)) """;
     if (initial) {
       return mainQuery + "AND (filingtype='Initial' OR filingtype='Both')";
@@ -168,9 +168,9 @@ public class FilingCode {
   }
   
   // TODO(brycew): test this one in particular, it was wrong
-  public static PreparedStatement prepQueryWithCode(Connection conn, String domain, String courtId, String typeCode) throws SQLException {
+  public static PreparedStatement prepQueryWithCode(Connection conn, String jurisdiction, String courtId, String typeCode) throws SQLException {
     PreparedStatement st = conn.prepareStatement(getFilingWithCode());
-    st.setString(1, domain);
+    st.setString(1, jurisdiction);
     st.setString(2, courtId);
     st.setString(3, typeCode);
     return st;
@@ -182,7 +182,7 @@ public class FilingCode {
                civilclaimamount, probateestateamount, amountincontroversy, useduedate,
                isproposedorder, efspcode, location
         FROM filing
-        WHERE domain=? AND location=? AND code=?
+        WHERE jurisdiction=? AND location=? AND code=?
         """;
   }
   

--- a/proxyserver/src/main/java/edu/suffolk/litlab/efsp/tyler/ecfcodes/FilingComponent.java
+++ b/proxyserver/src/main/java/edu/suffolk/litlab/efsp/tyler/ecfcodes/FilingComponent.java
@@ -49,7 +49,7 @@ public class FilingComponent {
     return """
     SELECT code, name, filingcodeid, required, allowmultiple, displayorder, efspcode, location
     FROM filingcomponent
-    WHERE domain=? AND location=? AND filingcodeid=?
+    WHERE jurisdiction=? AND location=? AND filingcodeid=?
     """;
   }
 

--- a/proxyserver/src/main/java/edu/suffolk/litlab/efsp/tyler/ecfcodes/OptionalServiceCode.java
+++ b/proxyserver/src/main/java/edu/suffolk/litlab/efsp/tyler/ecfcodes/OptionalServiceCode.java
@@ -78,77 +78,79 @@ public class OptionalServiceCode {
   }
 
   public static PreparedStatement prepQuery(
-      Connection conn, String domain, String courtId, String filingCodeId) throws SQLException {
+      Connection conn, String jurisdiction, String courtId, String filingCodeId)
+      throws SQLException {
     final String query =
         """
         SELECT os.code, os.name, os.displayorder, os.fee, os_fl.filingcodeid, os.multiplier, os.altfeedesc, os.hasfeeprompt,
           os.feeprompttext
-        FROM optionalservices as os JOIN optionalservices_filinglist as os_fl ON os.domain=os_fl.domain AND os.location=os_fl.location AND os.code=os_fl.code
-        WHERE os.domain=? AND os.location=? AND os_fl.filingcodeid=?
+        FROM optionalservices as os JOIN optionalservices_filinglist as os_fl ON os.jurisdiction=os_fl.jurisdiction AND os.location=os_fl.location AND os.code=os_fl.code
+        WHERE os.jurisdiction=? AND os.location=? AND os_fl.filingcodeid=?
         """;
     PreparedStatement st = conn.prepareStatement(query);
-    st.setString(1, domain);
+    st.setString(1, jurisdiction);
     st.setString(2, courtId);
     st.setString(3, filingCodeId);
     return st;
   }
 
-  public static PreparedStatement prepSearch(Connection conn, String domain, String searchTerm)
-      throws SQLException {
+  public static PreparedStatement prepSearch(
+      Connection conn, String jurisdiction, String searchTerm) throws SQLException {
     final String search =
         """
         SELECT DISTINCT os.name
         FROM optionalservices as os
-        WHERE os.domain=? AND os.name ILIKE ?
+        WHERE os.jurisdiction=? AND os.name ILIKE ?
         ORDER BY os.name
         """;
     PreparedStatement st = conn.prepareStatement(search);
-    st.setString(1, domain);
+    st.setString(1, jurisdiction);
     st.setString(2, searchTerm);
     return st;
   }
 
   public static PreparedStatement prepCourtCoverage(
-      Connection conn, String domain, String searchTerm) throws SQLException {
+      Connection conn, String jurisdiction, String searchTerm) throws SQLException {
     final String search =
         """
         SELECT DISTINCT location
         FROM optionalservices as os
-        WHERE os.domain=? AND os.name ILIKE ?
+        WHERE os.jurisdiction=? AND os.name ILIKE ?
         ORDER BY location
         """;
     PreparedStatement st = conn.prepareStatement(search);
-    st.setString(1, domain);
+    st.setString(1, jurisdiction);
     st.setString(2, searchTerm);
     return st;
   }
 
-  public static PreparedStatement prepRetrieve(Connection conn, String domain, String optServName)
-      throws SQLException {
+  public static PreparedStatement prepRetrieve(
+      Connection conn, String jurisdiction, String optServName) throws SQLException {
     final String retrieve =
         """
         SELECT DISTINCT os.code, os.location
         FROM optionalservices as os
-        WHERE os.domain=? AND os.name=?
+        WHERE os.jurisdiction=? AND os.name=?
         ORDER BY os.location
         """;
     PreparedStatement st = conn.prepareStatement(retrieve);
-    st.setString(1, domain);
+    st.setString(1, jurisdiction);
     st.setString(2, optServName);
     return st;
   }
 
   public static PreparedStatement prepQueryWithCode(
-      Connection conn, String domain, String courtId, String optServCode) throws SQLException {
+      Connection conn, String jurisdiction, String courtId, String optServCode)
+      throws SQLException {
     final String query =
         """
         SELECT os.code, os.name, os.displayorder, os.fee, os_fl.filingcodeid, os.multiplier, os.altfeedesc, os.hasfeeprompt,
           os.feeprompttext
-        FROM optionalservices as os JOIN optionalservices_filinglist as os_fl ON os.domain=os_fl.domain AND os.location=os_fl.location AND os.code=os_fl.code
-        WHERE os.domain=? AND os.location=? AND os.code=?
+        FROM optionalservices as os JOIN optionalservices_filinglist as os_fl ON os.jurisdiction=os_fl.jurisdiction AND os.location=os_fl.location AND os.code=os_fl.code
+        WHERE os.jurisdiction=? AND os.location=? AND os.code=?
         """;
     PreparedStatement st = conn.prepareStatement(query);
-    st.setString(1, domain);
+    st.setString(1, jurisdiction);
     st.setString(2, courtId);
     st.setString(3, optServCode);
     return st;
@@ -167,7 +169,7 @@ public class OptionalServiceCode {
             "hasfeeprompt" boolean,
             "feeprompttext" text,
             "efspcode" text,
-            "domain" varchar(80),
+            "jurisdiction" varchar(80),
             "location" varchar(80)
         )
         """;
@@ -176,7 +178,7 @@ public class OptionalServiceCode {
         CREATE TABLE optionalservices_filinglist (
             "code" varchar(40),
             "filingcodeid" varchar(40),
-            "domain" varchar(80),
+            "jurisdiction" varchar(80),
             "location" varchar(80)
         )
         """;
@@ -190,9 +192,9 @@ public class OptionalServiceCode {
     var indices =
         List.of(
             "CREATE INDEX ON optionalservices (location)",
-            "CREATE INDEX ON optionalservices (domain)",
+            "CREATE INDEX ON optionalservices (jurisdiction)",
             "CREATE INDEX ON optionalservices_filinglist (location)",
-            "CREATE INDEX ON optionalservices_filinglist (domain)");
+            "CREATE INDEX ON optionalservices_filinglist (jurisdiction)");
     try (Statement statement = conn.createStatement()) {
       for (var myStr : indices) {
         statement.executeUpdate(myStr);
@@ -201,19 +203,19 @@ public class OptionalServiceCode {
   }
 
   public static void deleteFromOptionalServiceTable(
-      String courtLocation, String tylerDomain, Connection conn) throws SQLException {
+      String courtLocation, String jurisdiction, Connection conn) throws SQLException {
     final String DELETE_FROM =
         (courtLocation == null)
-            ? "DELETE FROM optionalservices WHERE domain=?"
-            : "DELETE FROM optionalservices WHERE domain=? AND location=?";
+            ? "DELETE FROM optionalservices WHERE jurisdiction=?"
+            : "DELETE FROM optionalservices WHERE jurisdiction=? AND location=?";
     final String DELETE_FROM_FL =
         (courtLocation == null)
-            ? "DELETE FROM optionalservices_filinglist WHERE domain=?"
-            : "DELETE FROM optionalservices_filinglist WHERE domain=? AND location=?";
+            ? "DELETE FROM optionalservices_filinglist WHERE jurisdiction=?"
+            : "DELETE FROM optionalservices_filinglist WHERE jurisdiction=? AND location=?";
     try (PreparedStatement stmt = conn.prepareStatement(DELETE_FROM);
         PreparedStatement stmtFL = conn.prepareStatement(DELETE_FROM_FL)) {
-      stmt.setString(1, tylerDomain);
-      stmtFL.setString(1, tylerDomain);
+      stmt.setString(1, jurisdiction);
+      stmtFL.setString(1, jurisdiction);
       if (courtLocation != null) {
         stmt.setString(2, courtLocation);
         stmtFL.setString(2, courtLocation);
@@ -223,22 +225,22 @@ public class OptionalServiceCode {
     }
   }
 
-  private static record DistinctOptServ(String code, String domain, String location) {}
+  private static record DistinctOptServ(String code, String jurisdiction, String location) {}
 
   public static void updateOptionalServiceTable(
-      String courtName, String tylerDomain, Iterator<Map<String, String>> rows, Connection conn)
+      String courtName, String jurisdiction, Iterator<Map<String, String>> rows, Connection conn)
       throws SQLException {
     String insertMainQuery =
         """
         INSERT INTO "optionalservices" ("code", "name", "displayorder", "fee", "multiplier", "altfeedesc", "hasfeeprompt",
-          "feeprompttext", "efspcode", "domain", "location"
+          "feeprompttext", "efspcode", "jurisdiction", "location"
         ) VALUES (
           ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?
         )
         """;
     String insertFLQuery =
         """
-        INSERT INTO "optionalservices_filinglist" ("code", "filingcodeid", "domain", "location"
+        INSERT INTO "optionalservices_filinglist" ("code", "filingcodeid", "jurisdiction", "location"
         ) VALUES (
           ?, ?, ?, ?
         )
@@ -277,11 +279,11 @@ public class OptionalServiceCode {
             stmt.setString(9, valString);
           }
         }
-        stmt.setString(10, tylerDomain);
-        stmtFilingList.setString(3, tylerDomain);
+        stmt.setString(10, jurisdiction);
+        stmtFilingList.setString(3, jurisdiction);
         stmt.setString(11, courtName);
         stmtFilingList.setString(4, courtName);
-        var dis = new DistinctOptServ(colCode, tylerDomain, courtName);
+        var dis = new DistinctOptServ(colCode, jurisdiction, courtName);
 
         stmtFilingList.addBatch();
         if (alreadyAdded.contains(dis)) {

--- a/proxyserver/src/main/java/edu/suffolk/litlab/efsp/tyler/ecfcodes/PartyType.java
+++ b/proxyserver/src/main/java/edu/suffolk/litlab/efsp/tyler/ecfcodes/PartyType.java
@@ -80,7 +80,7 @@ public class PartyType {
     return """
     SELECT DISTINCT name
     FROM partytype
-    WHERE domain=? AND name ILIKE ?
+    WHERE jurisdiction=? AND name ILIKE ?
     ORDER BY name
     """;
   }
@@ -89,7 +89,7 @@ public class PartyType {
     return """
     SELECT DISTINCT location
     FROM partytype
-    WHERE domain=? and name ILIKE ?
+    WHERE jurisdiction=? and name ILIKE ?
     ORDER BY location
     """;
   }
@@ -98,7 +98,7 @@ public class PartyType {
     return """
     SELECT DISTINCT code, location
     FROM partytype
-    WHERE domain=? AND name=?
+    WHERE jurisdiction=? AND name=?
     ORDER BY location
     """;
   }
@@ -109,7 +109,7 @@ public class PartyType {
            numberofpartiestoignore, sendforredaction, dateofdeath, displayorder,
            efspcode, location
     FROM partytype
-    WHERE domain=? AND location=? AND casetypeid=?
+    WHERE jurisdiction=? AND location=? AND casetypeid=?
     ORDER BY isrequired DESC, displayorder, casetypeid DESC\
     """;
   }
@@ -120,7 +120,7 @@ public class PartyType {
            numberofpartiestoignore, sendforredaction, dateofdeath, displayorder,
            efspcode, location
     FROM partytype
-    WHERE domain=? AND location=? AND casetypeid=''
+    WHERE jurisdiction=? AND location=? AND casetypeid=''
     ORDER BY isrequired DESC, displayorder, casetypeid DESC\
     """;
   }
@@ -131,7 +131,7 @@ public class PartyType {
            numberofpartiestoignore, sendforredaction, dateofdeath, displayorder,
            efspcode, location
     FROM partytype
-    WHERE domain=? AND location=? AND code=?\
+    WHERE jurisdiction=? AND location=? AND code=?\
     """;
   }
 

--- a/proxyserver/src/main/java/edu/suffolk/litlab/efsp/tyler/ecfcodes/ServiceCodeType.java
+++ b/proxyserver/src/main/java/edu/suffolk/litlab/efsp/tyler/ecfcodes/ServiceCodeType.java
@@ -24,7 +24,7 @@ public class ServiceCodeType {
   }
 
   public static String query() {
-    return "SELECT code, name, servicemethod, fee, disclaimertext FROM servicetype WHERE domain=?"
+    return "SELECT code, name, servicemethod, fee, disclaimertext FROM servicetype WHERE jurisdiction=?"
         + " AND location=?";
   }
 }

--- a/proxyserver/src/main/java/edu/suffolk/litlab/efsp/tyler/ecfcodes/TylerCodesParser.java
+++ b/proxyserver/src/main/java/edu/suffolk/litlab/efsp/tyler/ecfcodes/TylerCodesParser.java
@@ -241,7 +241,7 @@ public class TylerCodesParser implements CodesParser {
     if (stateCodes.isEmpty()) {
       FilingError err =
           FilingError.malformedInterview(
-              "There are no allowed states for " + countryString + " in " + cd.getDomain());
+              "There are no allowed states for " + countryString + " in " + cd.getJurisdiction());
       return Result.err(new BadCode(err));
     }
     if (!stateCodes.contains(state)) {

--- a/proxyserver/src/test/java/edu/suffolk/litlab/efsp/db/DatabaseVersionTest.java
+++ b/proxyserver/src/test/java/edu/suffolk/litlab/efsp/db/DatabaseVersionTest.java
@@ -138,7 +138,7 @@ public class DatabaseVersionTest {
     }
 
     Statement codeSt = codeConn.createStatement();
-    rs = codeSt.executeQuery("SELECT DISTINCT domain from location");
+    rs = codeSt.executeQuery("SELECT DISTINCT jurisdiction from location");
 
     while (rs.next()) {
       assertEquals(rs.getString(1), "illinois");

--- a/proxyserver/src/test/java/edu/suffolk/litlab/efsp/db/DatabaseVersionTest.java
+++ b/proxyserver/src/test/java/edu/suffolk/litlab/efsp/db/DatabaseVersionTest.java
@@ -3,8 +3,6 @@ package edu.suffolk.litlab.efsp.db;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import edu.suffolk.litlab.efsp.Jurisdiction;
-import edu.suffolk.litlab.efsp.tyler.TylerDomain;
-import edu.suffolk.litlab.efsp.tyler.TylerEnv;
 import edu.suffolk.litlab.efsp.tyler.ecfcodes.CodeDatabase;
 import edu.suffolk.litlab.efsp.tyler.ecfcodes.FilingComponent;
 import edu.suffolk.litlab.efsp.tyler.ecfcodes.OptionalServiceCode;
@@ -143,11 +141,10 @@ public class DatabaseVersionTest {
     rs = codeSt.executeQuery("SELECT DISTINCT domain from location");
 
     while (rs.next()) {
-      assertEquals(rs.getString(1), "illinois-stage");
+      assertEquals(rs.getString(1), "illinois");
     }
 
-    try (var codesDatabase =
-        new CodeDatabase(new TylerDomain(Jurisdiction.ILLINOIS, TylerEnv.STAGE), codeConn)) {
+    try (var codesDatabase = new CodeDatabase(Jurisdiction.ILLINOIS, codeConn)) {
       List<OptionalServiceCode> opts = codesDatabase.getOptionalServices("adams", "27959");
       assertEquals(23, opts.size());
       List<PartyType> partyTypes = codesDatabase.getPartyTypeFor("adams", "27898");

--- a/proxyserver/src/test/java/edu/suffolk/litlab/efsp/docassemble/DocassembleToFilingInformationConverterTest.java
+++ b/proxyserver/src/test/java/edu/suffolk/litlab/efsp/docassemble/DocassembleToFilingInformationConverterTest.java
@@ -72,7 +72,7 @@ public class DocassembleToFilingInformationConverterTest {
     when(cd.getFilingComponents("01", exampleFilingType.code))
         .thenReturn(List.of(new FilingComponent("332", null, null, false, false, 0, null, null)));
     when(cd.getStateCodes("01", "US")).thenReturn(List.of("MA", "TX", "IL", "VT"));
-    when(cd.getDomain()).thenReturn(Jurisdiction.ILLINOIS);
+    when(cd.getJurisdiction()).thenReturn(Jurisdiction.ILLINOIS);
     when(cd.getDataFields("01"))
         .thenReturn(
             new DataFields(

--- a/proxyserver/src/test/java/edu/suffolk/litlab/efsp/docassemble/DocassembleToFilingInformationConverterTest.java
+++ b/proxyserver/src/test/java/edu/suffolk/litlab/efsp/docassemble/DocassembleToFilingInformationConverterTest.java
@@ -14,7 +14,6 @@ import edu.suffolk.litlab.efsp.ecfcodes.CodesParser;
 import edu.suffolk.litlab.efsp.model.FilingDoc;
 import edu.suffolk.litlab.efsp.model.FilingInformation;
 import edu.suffolk.litlab.efsp.model.Person;
-import edu.suffolk.litlab.efsp.tyler.TylerDomain;
 import edu.suffolk.litlab.efsp.tyler.TylerEnv;
 import edu.suffolk.litlab.efsp.tyler.ecfcodes.CaseCategory;
 import edu.suffolk.litlab.efsp.tyler.ecfcodes.CaseType;
@@ -73,7 +72,7 @@ public class DocassembleToFilingInformationConverterTest {
     when(cd.getFilingComponents("01", exampleFilingType.code))
         .thenReturn(List.of(new FilingComponent("332", null, null, false, false, 0, null, null)));
     when(cd.getStateCodes("01", "US")).thenReturn(List.of("MA", "TX", "IL", "VT"));
-    when(cd.getDomain()).thenReturn(new TylerDomain(Jurisdiction.ILLINOIS, TylerEnv.STAGE));
+    when(cd.getDomain()).thenReturn(Jurisdiction.ILLINOIS);
     when(cd.getDataFields("01"))
         .thenReturn(
             new DataFields(

--- a/proxyserver/src/test/java/edu/suffolk/litlab/efsp/docassemble/PersonDocassembleJacksonDeserializerTest.java
+++ b/proxyserver/src/test/java/edu/suffolk/litlab/efsp/docassemble/PersonDocassembleJacksonDeserializerTest.java
@@ -39,7 +39,7 @@ public class PersonDocassembleJacksonDeserializerTest {
     var allDataFields = mock(DataFields.class);
     when(cd.getStateCodes("adams", "US")).thenReturn(List.of("MA", "TX", "IL", "VT"));
     when(cd.getDataFields("adams")).thenReturn(allDataFields);
-    when(cd.getDomain()).thenReturn(Jurisdiction.ILLINOIS);
+    when(cd.getJurisdiction()).thenReturn(Jurisdiction.ILLINOIS);
     when(allDataFields.getFieldRow("PartyFirstName"))
         .thenReturn(new DataFieldRow("PartyFirstName", "", true, true, "adams"));
     when(allDataFields.getFieldRow("PartyMiddleName"))

--- a/proxyserver/src/test/java/edu/suffolk/litlab/efsp/docassemble/PersonDocassembleJacksonDeserializerTest.java
+++ b/proxyserver/src/test/java/edu/suffolk/litlab/efsp/docassemble/PersonDocassembleJacksonDeserializerTest.java
@@ -11,8 +11,6 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import edu.suffolk.litlab.efsp.Jurisdiction;
 import edu.suffolk.litlab.efsp.ecfcodes.CodesParser;
 import edu.suffolk.litlab.efsp.model.PartyId;
-import edu.suffolk.litlab.efsp.tyler.TylerDomain;
-import edu.suffolk.litlab.efsp.tyler.TylerEnv;
 import edu.suffolk.litlab.efsp.tyler.ecfcodes.CodeDatabase;
 import edu.suffolk.litlab.efsp.tyler.ecfcodes.CourtLocationInfo;
 import edu.suffolk.litlab.efsp.tyler.ecfcodes.DataFieldRow;
@@ -41,7 +39,7 @@ public class PersonDocassembleJacksonDeserializerTest {
     var allDataFields = mock(DataFields.class);
     when(cd.getStateCodes("adams", "US")).thenReturn(List.of("MA", "TX", "IL", "VT"));
     when(cd.getDataFields("adams")).thenReturn(allDataFields);
-    when(cd.getDomain()).thenReturn(new TylerDomain(Jurisdiction.ILLINOIS, TylerEnv.STAGE));
+    when(cd.getDomain()).thenReturn(Jurisdiction.ILLINOIS);
     when(allDataFields.getFieldRow("PartyFirstName"))
         .thenReturn(new DataFieldRow("PartyFirstName", "", true, true, "adams"));
     when(allDataFields.getFieldRow("PartyMiddleName"))

--- a/proxyserver/src/test/java/edu/suffolk/litlab/efsp/ecfcodes/tyler/CodeDatabaseTest.java
+++ b/proxyserver/src/test/java/edu/suffolk/litlab/efsp/ecfcodes/tyler/CodeDatabaseTest.java
@@ -9,8 +9,6 @@ import edu.suffolk.litlab.efsp.Jurisdiction;
 import edu.suffolk.litlab.efsp.db.DatabaseCreator;
 import edu.suffolk.litlab.efsp.db.DatabaseVersionTest;
 import edu.suffolk.litlab.efsp.ecfcodes.NameAndCode;
-import edu.suffolk.litlab.efsp.tyler.TylerDomain;
-import edu.suffolk.litlab.efsp.tyler.TylerEnv;
 import edu.suffolk.litlab.efsp.tyler.ecfcodes.CaseCategory;
 import edu.suffolk.litlab.efsp.tyler.ecfcodes.CaseType;
 import edu.suffolk.litlab.efsp.tyler.ecfcodes.CodeDatabase;
@@ -53,7 +51,7 @@ public class CodeDatabaseTest {
             postgres.getJdbcUrl(),
             postgres.getUsername(),
             postgres.getPassword());
-    cd = new CodeDatabase(new TylerDomain(Jurisdiction.ILLINOIS, TylerEnv.STAGE), conn);
+    cd = new CodeDatabase(Jurisdiction.ILLINOIS, conn);
     cd.createTablesIfAbsent();
   }
 

--- a/proxyserver/src/test/java/edu/suffolk/litlab/efsp/server/services/CodesServiceTest.java
+++ b/proxyserver/src/test/java/edu/suffolk/litlab/efsp/server/services/CodesServiceTest.java
@@ -12,8 +12,6 @@ import edu.suffolk.litlab.efsp.db.DatabaseCreator;
 import edu.suffolk.litlab.efsp.db.DatabaseVersionTest;
 import edu.suffolk.litlab.efsp.server.EfspServer;
 import edu.suffolk.litlab.efsp.server.utils.ServiceHelpers;
-import edu.suffolk.litlab.efsp.tyler.TylerDomain;
-import edu.suffolk.litlab.efsp.tyler.TylerEnv;
 import edu.suffolk.litlab.efsp.tyler.ecfcodes.CodeDatabase;
 import jakarta.ws.rs.core.MediaType;
 import jakarta.ws.rs.core.Response;
@@ -58,7 +56,7 @@ public class CodesServiceTest {
             100);
     Supplier<CodeDatabase> cdSupplier =
         () -> {
-          return CodeDatabase.fromDS(new TylerDomain(Jurisdiction.ILLINOIS, TylerEnv.STAGE), ds);
+          return CodeDatabase.fromDS(Jurisdiction.ILLINOIS, ds);
         };
     try (CodeDatabase cd = cdSupplier.get()) {
       cd.createTablesIfAbsent();


### PR DESCRIPTION
The code database was tagging every row with 'illinois-stage' instead of just 'illinois' because `CodeDatabase` was accepting a `TylerDomain`, which combined the jurisdiction and the env together. The env does not belong here, as one database should only ever serve one jurisdiction.

To fix this, I changed `CodeDatabase` and `CodeDatabaseAPI` to accept the Jurisdiction directly., and wrote a migration (which strips '-stage' and '-prod') to clean up existing rows, and updated all callers to follow the same pattern used in recent refactors.

Resolves #400 