### PR TITLE
Cleaning up deprecated functions

### DIFF
--- a/proxyserver/src/main/java/edu/suffolk/litlab/efsp/docassemble/FilingDocDocassembleJacksonDeserializer.java
+++ b/proxyserver/src/main/java/edu/suffolk/litlab/efsp/docassemble/FilingDocDocassembleJacksonDeserializer.java
@@ -34,6 +34,8 @@ import java.io.InputStream;
 import java.math.BigDecimal;
 import java.net.HttpURLConnection;
 import java.net.MalformedURLException;
+import java.net.URI;
+import java.net.URISyntaxException;
 import java.net.URL;
 import java.time.Instant;
 import java.time.LocalDate;
@@ -361,7 +363,7 @@ public class FilingDocDocassembleJacksonDeserializer {
     // localhost, since things could be on the same server / network. TODO: inject an allow-list
     // into here somehow
     try {
-      URL inUrl = new URL(dataUrl);
+      URL inUrl = (new URI(dataUrl)).toURL();
 
       HttpURLConnection conn = (HttpURLConnection) inUrl.openConnection();
       conn.setRequestMethod("GET");
@@ -389,6 +391,11 @@ public class FilingDocDocassembleJacksonDeserializer {
     } catch (IOException ex) {
       FilingError err =
           serverError("IOException trying to connect to data_url (" + dataUrl + "):" + ex);
+      collector.error(err);
+      throw err;
+    } catch (URISyntaxException ex) {
+      FilingError err =
+          serverError("URISyntaxException trying to connect to data_url (" + dataUrl + "):" + ex);
       collector.error(err);
       throw err;
     }

--- a/proxyserver/src/main/java/edu/suffolk/litlab/efsp/tyler/ecfcodes/CodeUpdater.java
+++ b/proxyserver/src/main/java/edu/suffolk/litlab/efsp/tyler/ecfcodes/CodeUpdater.java
@@ -27,6 +27,8 @@ import java.io.FileOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.net.HttpURLConnection;
+import java.net.URI;
+import java.net.URISyntaxException;
 import java.net.URL;
 import java.sql.SQLException;
 import java.sql.Savepoint;
@@ -149,9 +151,10 @@ public class CodeUpdater {
    * @return InputStream
    * @throws IOException
    */
-  public static InputStream getCodesZip(String toRead, String authHeader) throws IOException {
+  public static InputStream getCodesZip(String toRead, String authHeader)
+      throws IOException, URISyntaxException {
     if (toRead.startsWith("http://") || toRead.startsWith("https://")) {
-      URL url = new URL(toRead);
+      URL url = (new URI(toRead)).toURL();
       HttpURLConnection conn = (HttpURLConnection) url.openConnection();
       conn.setRequestMethod("GET");
       conn.setRequestProperty("tyl-efm-api", authHeader);
@@ -170,9 +173,11 @@ public class CodeUpdater {
    * @param signedTime
    * @param process
    * @return
+   * @throws URISyntaxException
    */
   private boolean downloadAndProcessZip(
-      String toRead, String signedTime, Function<InputStream, Boolean> process) {
+      String toRead, String signedTime, Function<InputStream, Boolean> process)
+      throws URISyntaxException {
     Instant startTable = Instant.now();
     try (InputStream urlStream = getCodesZip(toRead, signedTime)) {
       // Write out the zip file
@@ -195,7 +200,7 @@ public class CodeUpdater {
   }
 
   private boolean downloadSystemTables(String baseUrl, CodeDatabaseAPI cd, HeaderSigner signer)
-      throws SQLException, IOException, JAXBException {
+      throws SQLException, IOException, JAXBException, URISyntaxException {
     MDC.put(MDCWrappers.SESSION_ID, "system");
     Map<String, String> codeUrls =
         Map.of(
@@ -299,7 +304,7 @@ public class CodeUpdater {
               zip.getNextEntry();
               codeLists.put(
                   toDownload.tableName, new DownloadedCodes(toDownload.tableName, location, zip));
-            } catch (IOException e) {
+            } catch (IOException | URISyntaxException e) {
               log.error("Error when downloading XMLs", e);
             }
           }
@@ -440,9 +445,13 @@ public class CodeUpdater {
     return toReturn;
   }
 
-  /** Returns true if successful, false if not successful */
+  /**
+   * Returns true if successful, false if not successful
+   *
+   * @throws URISyntaxException
+   */
   public boolean updateAll(String baseUrl, FilingReviewMDEPort filingPort, CodeDatabaseAPI cd)
-      throws SQLException, IOException, JAXBException {
+      throws SQLException, IOException, JAXBException, URISyntaxException {
     cd.setAutoCommit(false);
     HeaderSigner signer = new HeaderSigner(this.pathToKeystore, this.x509Password);
     if (!downloadSystemTables(baseUrl, cd, signer)) {
@@ -505,15 +514,17 @@ public class CodeUpdater {
 
   /**
    * Downloads all of the codes from scratch, deleting all of the existing info already in tables.
+   *
+   * @throws URISyntaxException
    */
   public boolean replaceAll(String baseUrl, FilingReviewMDEPort filingPort, CodeDatabaseAPI cd)
-      throws SQLException, IOException, JAXBException {
+      throws SQLException, IOException, JAXBException, URISyntaxException {
     return replaceSome(baseUrl, filingPort, cd, List.of());
   }
 
   public boolean replaceSome(
       String baseUrl, FilingReviewMDEPort filingPort, CodeDatabaseAPI cd, List<String> locs)
-      throws SQLException, IOException, JAXBException {
+      throws SQLException, IOException, JAXBException, URISyntaxException {
     cd.setAutoCommit(false);
     HeaderSigner signer = new HeaderSigner(this.pathToKeystore, this.x509Password);
     log.info("Downloading system tables for {}", cd.getDomain());
@@ -583,8 +594,12 @@ public class CodeUpdater {
     return filingPort;
   }
 
-  /** Downloads a single codes zip. For Debugging. */
-  public boolean downloadIndiv(List<String> args) {
+  /**
+   * Downloads a single codes zip. For Debugging.
+   *
+   * @throws URISyntaxException
+   */
+  public boolean downloadIndiv(List<String> args) throws URISyntaxException {
     if (args.size() < 3) {
       log.error(
           "Need to pass in args: downloadIndiv <jurisdiction> <table> <location or blank for"
@@ -641,7 +656,7 @@ public class CodeUpdater {
         log.error("Command {} isn't a real command", command);
         return false;
       }
-    } catch (SQLException | IOException | JAXBException e) {
+    } catch (SQLException | IOException | JAXBException | URISyntaxException e) {
       log.error("Exception when doing code updating! ", e);
       return false;
     }

--- a/proxyserver/src/test/java/edu/suffolk/litlab/efsp/db/DatabaseVersionTest.java
+++ b/proxyserver/src/test/java/edu/suffolk/litlab/efsp/db/DatabaseVersionTest.java
@@ -35,7 +35,7 @@ import org.apache.commons.compress.archivers.ArchiveException;
 import org.apache.commons.compress.archivers.ArchiveStreamFactory;
 import org.apache.commons.compress.archivers.tar.TarArchiveEntry;
 import org.apache.commons.compress.archivers.tar.TarArchiveInputStream;
-import org.apache.commons.compress.utils.IOUtils;
+import org.apache.commons.io.IOUtils;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Tag;

--- a/proxyserver/src/test/java/edu/suffolk/litlab/efsp/db/LoginDatabaseTest.java
+++ b/proxyserver/src/test/java/edu/suffolk/litlab/efsp/db/LoginDatabaseTest.java
@@ -11,8 +11,8 @@ import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
-import org.testcontainers.containers.PostgreSQLContainer;
 import org.testcontainers.junit.jupiter.Container;
+import org.testcontainers.postgresql.PostgreSQLContainer;
 import org.testcontainers.utility.DockerImageName;
 
 @Tag("Docker")
@@ -21,8 +21,8 @@ public class LoginDatabaseTest {
   private LoginDatabase ld;
 
   @Container
-  public static PostgreSQLContainer<?> postgres =
-      new PostgreSQLContainer<>(DockerImageName.parse(DatabaseVersionTest.POSTGRES_DOCKER_NAME));
+  public static PostgreSQLContainer postgres =
+      new PostgreSQLContainer(DockerImageName.parse(DatabaseVersionTest.POSTGRES_DOCKER_NAME));
 
   @BeforeAll
   public static void dbSetup() {

--- a/proxyserver/src/test/java/edu/suffolk/litlab/efsp/ecfcodes/tyler/CodeDatabaseTest.java
+++ b/proxyserver/src/test/java/edu/suffolk/litlab/efsp/ecfcodes/tyler/CodeDatabaseTest.java
@@ -30,8 +30,8 @@ import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import org.testcontainers.containers.PostgreSQLContainer;
 import org.testcontainers.junit.jupiter.Container;
+import org.testcontainers.postgresql.PostgreSQLContainer;
 import org.testcontainers.utility.DockerImageName;
 
 @Tag("Docker")
@@ -41,8 +41,8 @@ public class CodeDatabaseTest {
   private CodeDatabase cd;
 
   @Container
-  public PostgreSQLContainer<?> postgres =
-      new PostgreSQLContainer<>(DockerImageName.parse(DatabaseVersionTest.POSTGRES_DOCKER_NAME));
+  public PostgreSQLContainer postgres =
+      new PostgreSQLContainer(DockerImageName.parse(DatabaseVersionTest.POSTGRES_DOCKER_NAME));
 
   @BeforeEach
   public void setUp() throws SQLException {

--- a/proxyserver/src/test/java/edu/suffolk/litlab/efsp/server/services/CodesServiceTest.java
+++ b/proxyserver/src/test/java/edu/suffolk/litlab/efsp/server/services/CodesServiceTest.java
@@ -32,8 +32,8 @@ import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import org.testcontainers.containers.PostgreSQLContainer;
 import org.testcontainers.junit.jupiter.Container;
+import org.testcontainers.postgresql.PostgreSQLContainer;
 import org.testcontainers.utility.DockerImageName;
 
 @Tag("Docker")
@@ -41,8 +41,8 @@ public class CodesServiceTest {
   private static Logger log = LoggerFactory.getLogger(CodesServiceTest.class);
 
   @Container
-  public PostgreSQLContainer<?> postgres =
-      new PostgreSQLContainer<>(DockerImageName.parse(DatabaseVersionTest.POSTGRES_DOCKER_NAME));
+  public PostgreSQLContainer postgres =
+      new PostgreSQLContainer(DockerImageName.parse(DatabaseVersionTest.POSTGRES_DOCKER_NAME));
 
   private static final String ENDPOINT_ADDRESS = "http://localhost:9090";
   private Server server;


### PR DESCRIPTION
* Need to do `(new URI(...)).toURL()` now instead of just `new URL(...)`, which throws a different exception. Eh.
* apache IOUtils moved packages
* testcontainers Postgresql containers moved packages