### PR TITLE
Bump version to 1.3.0

### DIFF
--- a/EfspCommons/pom.xml
+++ b/EfspCommons/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>edu.suffolk.litlab</groupId>
         <artifactId>efspserver-parent</artifactId>
-        <version>1.2.25</version>
+        <version>1.3.0</version>
     </parent>
     <groupId>edu.suffolk.litlab</groupId>
     <artifactId>efsp-commons</artifactId>

--- a/TylerEcf4/pom.xml
+++ b/TylerEcf4/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>edu.suffolk.litlab</groupId>
         <artifactId>efspserver-parent</artifactId>
-        <version>1.2.25</version>
+        <version>1.3.0</version>
     </parent>
     <groupId>edu.suffolk.litlab</groupId>
     <artifactId>tyler-ecf4</artifactId>

--- a/TylerEcf5/pom.xml
+++ b/TylerEcf5/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>edu.suffolk.litlab</groupId>
         <artifactId>efspserver-parent</artifactId>
-        <version>1.2.25</version>
+        <version>1.3.0</version>
     </parent>
     <groupId>edu.suffolk.litlab</groupId>
     <artifactId>tyler-ecf5</artifactId>

--- a/TylerEfmClient/pom.xml
+++ b/TylerEfmClient/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>edu.suffolk.litlab</groupId>
         <artifactId>efspserver-parent</artifactId>
-        <version>1.2.25</version>
+        <version>1.3.0</version>
     </parent>
     <groupId>edu.suffolk.litlab</groupId>
     <artifactId>tyler-efm-client</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>edu.suffolk.litlab</groupId>
     <artifactId>efspserver-parent</artifactId>
-    <version>1.2.25</version>
+    <version>1.3.0</version>
     <packaging>pom</packaging>
     <name>EFSP Proxy Parent</name>
     <description>Parent project for an EFSP client for the AssemblyLine Project</description>

--- a/proxyserver/pom.xml
+++ b/proxyserver/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>edu.suffolk.litlab</groupId>
         <artifactId>efspserver-parent</artifactId>
-        <version>1.2.25</version>
+        <version>1.3.0</version>
     </parent>
     <groupId>edu.suffolk.litlab</groupId>
     <artifactId>efspserver</artifactId>


### PR DESCRIPTION
Doing a minor version bump because:

* court list gets a new param
* `users[0]` can be automatically set to `lead_contact` now