### PR TITLE
Extend query timeout

### DIFF
--- a/EfspCommons/pom.xml
+++ b/EfspCommons/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>edu.suffolk.litlab</groupId>
         <artifactId>efspserver-parent</artifactId>
-        <version>1.3.3</version>
+        <version>1.3.4</version>
     </parent>
     <groupId>edu.suffolk.litlab</groupId>
     <artifactId>efsp-commons</artifactId>

--- a/TylerEcf4/pom.xml
+++ b/TylerEcf4/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>edu.suffolk.litlab</groupId>
         <artifactId>efspserver-parent</artifactId>
-        <version>1.3.3</version>
+        <version>1.3.4</version>
     </parent>
     <groupId>edu.suffolk.litlab</groupId>
     <artifactId>tyler-ecf4</artifactId>

--- a/TylerEcf5/pom.xml
+++ b/TylerEcf5/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>edu.suffolk.litlab</groupId>
         <artifactId>efspserver-parent</artifactId>
-        <version>1.3.3</version>
+        <version>1.3.4</version>
     </parent>
     <groupId>edu.suffolk.litlab</groupId>
     <artifactId>tyler-ecf5</artifactId>

--- a/TylerEfmClient/pom.xml
+++ b/TylerEfmClient/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>edu.suffolk.litlab</groupId>
         <artifactId>efspserver-parent</artifactId>
-        <version>1.3.3</version>
+        <version>1.3.4</version>
     </parent>
     <groupId>edu.suffolk.litlab</groupId>
     <artifactId>tyler-efm-client</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>edu.suffolk.litlab</groupId>
     <artifactId>efspserver-parent</artifactId>
-    <version>1.3.3</version>
+    <version>1.3.4</version>
     <packaging>pom</packaging>
     <name>EFSP Proxy Parent</name>
     <description>Parent project for an EFSP client for the AssemblyLine Project</description>

--- a/proxyserver/pom.xml
+++ b/proxyserver/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>edu.suffolk.litlab</groupId>
         <artifactId>efspserver-parent</artifactId>
-        <version>1.3.3</version>
+        <version>1.3.4</version>
     </parent>
     <groupId>edu.suffolk.litlab</groupId>
     <artifactId>efspserver</artifactId>

--- a/proxyserver/src/main/java/edu/suffolk/litlab/efsp/db/DatabaseVersion.java
+++ b/proxyserver/src/main/java/edu/suffolk/litlab/efsp/db/DatabaseVersion.java
@@ -596,9 +596,11 @@ public class DatabaseVersion {
 
     try (Statement st = codeConn.createStatement()) {
       for (String tableName : tableNames) {
+        st.setQueryTimeout(300);
         st.executeUpdate(stripEnvSuffix.formatted(tableName));
       }
       for (String tableName : tableNames) {
+        st.setQueryTimeout(300);
         st.executeUpdate(
             "ALTER TABLE %s RENAME COLUMN domain TO jurisdiction".formatted(tableName));
       }


### PR DESCRIPTION
Currently can't deploy because the database won't finish it's migration, because there's a too small timelimit on the query.