### PR TITLE
Don't crash response if you can't log uri info

### DIFF
--- a/proxyserver/src/main/java/edu/suffolk/litlab/efsp/server/utils/ObservabilityResetInterceptor.java
+++ b/proxyserver/src/main/java/edu/suffolk/litlab/efsp/server/utils/ObservabilityResetInterceptor.java
@@ -19,10 +19,19 @@ public class ObservabilityResetInterceptor implements ContainerResponseFilter {
   @Override
   public void filter(ContainerRequestContext request, ContainerResponseContext response)
       throws IOException {
-    log.info(
-        "Sending back status of {} in response to {}",
-        response.getStatus(),
-        request.getUriInfo().getPath());
+    var path = "";
+    // Had issues where decoding a path would crash the whole response call.
+    try {
+      path = request.getUriInfo().getPath();
+    } catch (IllegalArgumentException | IllegalStateException ex) {
+      log.warn("No valid path to log?", ex);
+      try {
+        path = request.getUriInfo().getPath(false);
+      } catch (IllegalArgumentException | IllegalStateException ex2) {
+        path = "<dev note: could not get URI info>";
+      }
+    }
+    log.info("Sending back status of {} in response to {}", response.getStatus(), path);
     MDCWrappers.removeAllMDCs();
   }
 }


### PR DESCRIPTION
Happened in production a bit, fairly confident it was a scanner but don't know for sure becasue it doesn't print out the URI path!

```
e.s.l.e.s.utils.EnumExceptionMapper - Catching non user-facing IllegalArgumentException java.lang.IllegalArgumentException: Invalid URL encoding: not a valid digit (radix 16): 117"
```