### PR TITLE
Switch proxy server logging to JSON output

### DIFF
--- a/proxyserver/pom.xml
+++ b/proxyserver/pom.xml
@@ -191,6 +191,13 @@
             <version>1.5.27</version>
 
         </dependency>
+        <!-- JSON log output for Vector/Loki parsing -->
+        <dependency>
+            <groupId>net.logstash.logback</groupId>
+            <artifactId>logstash-logback-encoder</artifactId>
+            <version>8.0</version>
+        </dependency>
+
         <dependency>
             <groupId>jakarta.mail</groupId>
             <artifactId>jakarta.mail-api</artifactId>

--- a/proxyserver/pom.xml
+++ b/proxyserver/pom.xml
@@ -195,7 +195,7 @@
         <dependency>
             <groupId>net.logstash.logback</groupId>
             <artifactId>logstash-logback-encoder</artifactId>
-            <version>8.0</version>
+            <version>8.1</version>
         </dependency>
 
         <dependency>

--- a/proxyserver/src/main/resources/logback.xml
+++ b/proxyserver/src/main/resources/logback.xml
@@ -1,13 +1,40 @@
 <configuration scan="true" scanPeriod="30 seconds">
 
   <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
-    <encoder>
-      <pattern>%d{yyyy-MM-dd HH:mm:ss.SSS} [server=%X{serverId}] [user=%X{userId}] [session=%X{sessionId}] [corr=%X{correlationId}] [req=%X{requestId}] [op=%X{operation}]%n    %-5level %-35logger{35} - %msg %rEx%n</pattern>
+    <!-- JSON output so Vector/Loki can parse real fields out of it, see #422 -->
+    <encoder class="net.logstash.logback.encoder.LogstashEncoder">
+      <includeMdcKeyName>serverId</includeMdcKeyName>
+      <includeMdcKeyName>userId</includeMdcKeyName>
+      <includeMdcKeyName>sessionId</includeMdcKeyName>
+      <includeMdcKeyName>correlationId</includeMdcKeyName>
+      <includeMdcKeyName>requestId</includeMdcKeyName>
+      <includeMdcKeyName>operation</includeMdcKeyName>
+      <fieldNames>
+        <timestamp>timestamp</timestamp>
+        <message>message</message>
+        <logger>logger</logger>
+        <thread>thread</thread>
+        <level>level</level>
+        <stackTrace>stack_trace</stackTrace>
+      </fieldNames>
     </encoder>
   </appender>
   <appender name="PerServer" class="edu.suffolk.litlab.efsp.server.logging.ServerSpecificAppender">
-    <encoder>
-      <Pattern>| %d{yyyy-MM-dd HH:mm:ss.SSS} | %X{serverId} | %X{userId} | %X{sessionId} | %X{correlationId} | %X{requestId} | %X{operation} | %thread | %-5level | %logger{40} |- %msg | %rEx |%n</Pattern>
+    <encoder class="net.logstash.logback.encoder.LogstashEncoder">
+      <includeMdcKeyName>serverId</includeMdcKeyName>
+      <includeMdcKeyName>userId</includeMdcKeyName>
+      <includeMdcKeyName>sessionId</includeMdcKeyName>
+      <includeMdcKeyName>correlationId</includeMdcKeyName>
+      <includeMdcKeyName>requestId</includeMdcKeyName>
+      <includeMdcKeyName>operation</includeMdcKeyName>
+      <fieldNames>
+        <timestamp>timestamp</timestamp>
+        <message>message</message>
+        <logger>logger</logger>
+        <thread>thread</thread>
+        <level>level</level>
+        <stackTrace>stack_trace</stackTrace>
+      </fieldNames>
     </encoder>
   </appender>
   <condition class="ch.qos.logback.core.boolex.ExpressionPropertyCondition">

--- a/proxyserver/src/main/resources/logback.xml
+++ b/proxyserver/src/main/resources/logback.xml
@@ -21,21 +21,8 @@
     </encoder>
   </appender>
   <appender name="PerServer" class="edu.suffolk.litlab.efsp.server.logging.ServerSpecificAppender">
-    <encoder class="net.logstash.logback.encoder.LogstashEncoder">
-      <includeMdcKeyName>serverId</includeMdcKeyName>
-      <includeMdcKeyName>userId</includeMdcKeyName>
-      <includeMdcKeyName>sessionId</includeMdcKeyName>
-      <includeMdcKeyName>correlationId</includeMdcKeyName>
-      <includeMdcKeyName>requestId</includeMdcKeyName>
-      <includeMdcKeyName>operation</includeMdcKeyName>
-      <fieldNames>
-        <timestamp>timestamp</timestamp>
-        <message>message</message>
-        <logger>logger</logger>
-        <thread>thread</thread>
-        <level>level</level>
-        <stackTrace>stack_trace</stackTrace>
-      </fieldNames>
+<encoder>
+      <Pattern>| %d{yyyy-MM-dd HH:mm:ss.SSS} | %X{serverId} | %X{userId} | %X{sessionId} | %X{correlationId} | %X{requestId} | %X{operation} | %thread | %-5level | %logger{40} |- %msg | %rEx |%n</Pattern>
     </encoder>
   </appender>
   <condition class="ch.qos.logback.core.boolex.ExpressionPropertyCondition">


### PR DESCRIPTION
Switched the STDOUT and PerServer appenders in logback.xml over to the logstash-logback-encoder so the server writes structured JSON instead, and added that dependency to proxyserver/pom.xml. [ #422 ]

All the existing MDC fields (serverId, userId, sessionId, correlationId, requestId, etc) are still there, just as real JSON fields now instead of bracketed text, and exceptions come through as a single `stack_trace` field instead of getting split across multiple lines. 

Tested and confirmed JSON lines print to stdout with INFO/WARN levels and a full stack trace in one field, rather than everything showing as "info" like it does today. Left the Papertrail appender as plain text since that's a separate working pipeline and out of scope here. This should be a drop-in change for the log-shipper side to start parsing real fields once it's deployed.

