### PR TITLE
Adds MDC context for the interview

### DIFF
--- a/proxyserver/src/main/java/edu/suffolk/litlab/efsp/server/logging/MDCWrappers.java
+++ b/proxyserver/src/main/java/edu/suffolk/litlab/efsp/server/logging/MDCWrappers.java
@@ -12,6 +12,7 @@ public class MDCWrappers {
   public static final String USER_ID = "userId";
   public static final String SESSION_ID = "sessionId";
   public static final String CORRELATION_ID = "correlationId";
+  public static final String INTERVIEW_ID = "interviewId";
   public static final String REQUEST_ID = "requestId";
   public static final String OPERATION = "operation";
 
@@ -21,6 +22,7 @@ public class MDCWrappers {
     MDC.remove(USER_ID);
     MDC.remove(SESSION_ID);
     MDC.remove(CORRELATION_ID);
+    MDC.remove(INTERVIEW_ID);
     MDC.remove(REQUEST_ID);
     MDC.remove(OPERATION);
   }

--- a/proxyserver/src/main/java/edu/suffolk/litlab/efsp/server/utils/ObservabilityHeadersInterceptor.java
+++ b/proxyserver/src/main/java/edu/suffolk/litlab/efsp/server/utils/ObservabilityHeadersInterceptor.java
@@ -53,7 +53,7 @@ public class ObservabilityHeadersInterceptor implements ContainerRequestFilter {
     }
   }
 
-  private static final Pattern safeRegex = Pattern.compile("^[A-Za-z0-9\\-]{0,36}$");
+  private static final Pattern safeRegex = Pattern.compile("^[A-Za-z0-9\\-]{0,72}$");
 
   private String handleHeaderString(Map<String, List<String>> headers, String headerKey) {
     var headerList = headers.get(headerKey);

--- a/proxyserver/src/main/java/edu/suffolk/litlab/efsp/server/utils/ObservabilityHeadersInterceptor.java
+++ b/proxyserver/src/main/java/edu/suffolk/litlab/efsp/server/utils/ObservabilityHeadersInterceptor.java
@@ -23,6 +23,7 @@ public class ObservabilityHeadersInterceptor implements ContainerRequestFilter {
 
   private static final String SESSION_ID = "efsp-session-id";
   private static final String CORRELATION_ID = "efsp-correlation-id";
+  private static final String INTERVIEW_ID = "efsp-interview-id";
   private static final String REQUEST_ID = "efsp-request-id";
 
   @Override
@@ -36,6 +37,10 @@ public class ObservabilityHeadersInterceptor implements ContainerRequestFilter {
       String correlationId = handleHeaderString(headers, CORRELATION_ID);
       if (correlationId != null) {
         MDC.put(MDCWrappers.CORRELATION_ID, correlationId);
+      }
+      String interviewId = handleHeaderString(headers, INTERVIEW_ID);
+      if (interviewId != null) {
+        MDC.put(MDCWrappers.INTERVIEW_ID, interviewId);
       }
       String requestId = handleHeaderString(headers, REQUEST_ID);
       if (requestId == null) {

--- a/proxyserver/src/main/resources/logback.xml
+++ b/proxyserver/src/main/resources/logback.xml
@@ -6,6 +6,7 @@
       <includeMdcKeyName>serverId</includeMdcKeyName>
       <includeMdcKeyName>serverName</includeMdcKeyName>
       <includeMdcKeyName>userId</includeMdcKeyName>
+      <includeMdcKeyName>interviewId</includeMdcKeyName>
       <includeMdcKeyName>sessionId</includeMdcKeyName>
       <includeMdcKeyName>correlationId</includeMdcKeyName>
       <includeMdcKeyName>requestId</includeMdcKeyName>
@@ -21,7 +22,7 @@
     </encoder>
   </appender>
   <appender name="PerServer" class="edu.suffolk.litlab.efsp.server.logging.ServerSpecificAppender">
-<encoder>
+    <encoder>
       <Pattern>| %d{yyyy-MM-dd HH:mm:ss.SSS} | %X{serverId} | %X{userId} | %X{sessionId} | %X{correlationId} | %X{requestId} | %X{operation} | %thread | %-5level | %logger{40} |- %msg | %rEx |%n</Pattern>
     </encoder>
   </appender>

--- a/proxyserver/src/test/java/edu/suffolk/litlab/efsp/server/utils/ObservabilityHeadersInterceptorTest.java
+++ b/proxyserver/src/test/java/edu/suffolk/litlab/efsp/server/utils/ObservabilityHeadersInterceptorTest.java
@@ -17,12 +17,17 @@ public class ObservabilityHeadersInterceptorTest {
 
   @Property
   boolean interceptorHandlesAllHeaders(
-      @ForAll String sessionId, @ForAll String corrId, @ForAll String reqId) throws IOException {
+      @ForAll String sessionId,
+      @ForAll String corrId,
+      @ForAll String reqId,
+      @ForAll String interviewId)
+      throws IOException {
     ContainerRequestContext ctx = mock(ContainerRequestContext.class);
     var headers = new MultivaluedHashMap<String, String>();
     headers.add("efsp-session-id", sessionId);
     headers.add("efsp-correlation-id", corrId);
     headers.add("efsp-request-id", reqId);
+    headers.add("efsp-interview-id", interviewId);
     when(ctx.getHeaders()).thenReturn(headers);
 
     interceptor.filter(ctx);


### PR DESCRIPTION
`ObservabilityHeadersInterceptor` now reads a new efsp-interview-id header and sets it as `interviewId` in MDC, same pattern as sessionId/correlationId (skipped if the header's missing or unsafe). 

Extended the existing property-based test (`ObservabilityHeadersInterceptorTest`) to send the new header through too.

Not included yet: the `logback.xml` piece from #416 (adding interviewId to the log output). Holding that until #422/#429 merges. Once #429's in, interviewId just needs one more includeMdcKeyName entry there.