### PR TITLE
Bump local dev Postgres from 14 to 15

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -17,7 +17,7 @@ services:
         limits:
           memory: 4G
   db:
-    image: "postgres:14"
+    image: "postgres:15"
     shm_size: 256m
     env_file: .env
     volumes:

--- a/proxyserver/README.md
+++ b/proxyserver/README.md
@@ -13,7 +13,7 @@ This server can also be run directly with java, for remote debugging or speed of
     * Edit your `.env` file, particularly `POSTGRES_URL` and `POSTGRES_PORT`, to match how you will be running the db
       (`POSTGRES_URL` can be `localhost` if just running it locally / through a docker container).
     * If you still want to use docker for this, run
-      `docker run -p 5432:5432 --env-file .env --volume efileproxyserver_data-volume:/var/lib/postgresql/data postgres:14`.
+      `docker run -p 5432:5432 --env-file .env --volume efileproxyserver_data-volume:/var/lib/postgresql/data postgres:15`.
 * `mvn package` to build the output JAR artifact.
 * `cd proxyserver` (if not already there), and then `./run_server.sh`
 

--- a/proxyserver/src/test/java/edu/suffolk/litlab/efsp/db/DatabaseVersionTest.java
+++ b/proxyserver/src/test/java/edu/suffolk/litlab/efsp/db/DatabaseVersionTest.java
@@ -48,7 +48,7 @@ import org.testcontainers.utility.MountableFile;
 @Tag("Docker")
 public class DatabaseVersionTest {
 
-  public static final String POSTGRES_DOCKER_NAME = "postgres:14";
+  public static final String POSTGRES_DOCKER_NAME = "postgres:15";
 
   private static final Logger log = LoggerFactory.getLogger(DatabaseVersionTest.class);
 


### PR DESCRIPTION
Matches the Postgres 15 version already used in Supabase prod. Local dev data is disposable, so no migration needed.

Closes #437